### PR TITLE
Add synthetic zip payloads for rebuild tests

### DIFF
--- a/LiteDB.Tests/Engine/Rebuild_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using LiteDB.Engine;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -18,7 +19,7 @@ namespace LiteDB.Tests.Engine
             {
                 var col = db.GetCollection<Zip>("zip");
 
-                col.Insert(DataGen.Zip());
+                col.Insert(CreateSyntheticZipData(200, SurvivorId));
 
                 db.DropCollection("zip");
 
@@ -54,25 +55,27 @@ namespace LiteDB.Tests.Engine
 
                     col.EnsureIndex("city", false);
 
-                    var inserted = col.Insert(DataGen.Zip()); // 29.353 docs
-                    var deleted = col.DeleteMany(x => x.Id != "01001"); // delete 29.352 docs
+                    const int documentCount = 200;
 
-                    Assert.Equal(29353, inserted);
-                    Assert.Equal(29352, deleted);
+                    var inserted = col.Insert(CreateSyntheticZipData(documentCount, SurvivorId));
+                    var deleted = col.DeleteMany(x => x.Id != SurvivorId);
+
+                    Assert.Equal(documentCount, inserted);
+                    Assert.Equal(documentCount - 1, deleted);
 
                     Assert.Equal(1, col.Count());
 
                     // must checkpoint
                     db.Checkpoint();
 
-                    // file still large than 5mb (even with only 1 document)
-                    Assert.True(file.Size > 5 * 1024 * 1024);
+                    // file still larger than 1 MB (even with only 1 document)
+                    Assert.True(file.Size > 1 * 1024 * 1024);
 
                     // reduce datafile
                     var reduced = db.Rebuild();
 
-                    // now file are small than 50kb
-                    Assert.True(file.Size < 50 * 1024);
+                    // now file should be small again
+                    Assert.True(file.Size < 256 * 1024);
 
                     DoTest(db, col);
                 }
@@ -88,6 +91,40 @@ namespace LiteDB.Tests.Engine
 
                     DoTest(db, col);
                 }
+            }
+        }
+
+        private const string SurvivorId = "01001";
+
+        private static IEnumerable<Zip> CreateSyntheticZipData(int totalCount, string survivingId)
+        {
+            if (totalCount < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(totalCount));
+            }
+
+            const int payloadLength = 32 * 1024; // 32 KB payload to force file growth
+
+            for (var i = 0; i < totalCount; i++)
+            {
+                var id = (20000 + i).ToString("00000");
+
+                if (!string.IsNullOrEmpty(survivingId) && i == 0)
+                {
+                    id = survivingId;
+                }
+
+                var payload = new byte[payloadLength];
+                Array.Fill(payload, (byte)(i % 256));
+
+                yield return new Zip
+                {
+                    Id = id,
+                    City = $"City {i:D4}",
+                    Loc = new[] { (double)i, (double)i + 0.5 },
+                    State = "ST",
+                    Payload = payload
+                };
             }
         }
 

--- a/LiteDB.Tests/Utils/Models/Zip.cs
+++ b/LiteDB.Tests/Utils/Models/Zip.cs
@@ -16,6 +16,7 @@ namespace LiteDB.Tests
         public string City { get; set; }
         public double[] Loc { get; set; }
         public string State { get; set; }
+        public byte[] Payload { get; set; }
 
         public int CompareTo(Zip other)
         {


### PR DESCRIPTION
## Summary
- replace the large resource-based zip data in the rebuild tests with a synthetic generator that pads each document with payload bytes while keeping one survivor document
- relax the rebuild size assertions so they validate that the file shrinks below a small threshold after rebuild
- extend the Zip test model with a payload field consumed by the new generator

## Testing
- dotnet test LiteDB.Tests -f net8.0 --filter Rebuild_Tests

------
https://chatgpt.com/codex/tasks/task_e_68cf34c9c23083268d67705ba740d871