### PR TITLE
Use deterministic sample for descending sort test

### DIFF
--- a/LiteDB.Tests/Internals/Sort_Tests.cs
+++ b/LiteDB.Tests/Internals/Sort_Tests.cs
@@ -43,25 +43,24 @@ namespace LiteDB.Internals
         [Fact]
         public void Sort_Int_Desc()
         {
-            var rnd = new Random();
-            var source = Enumerable.Range(0, 20000)
-                .Select(x => new KeyValuePair<BsonValue, PageAddress>(rnd.Next(1, 30000), PageAddress.Empty))
+            var source = Enumerable.Range(0, 900)
+                .Select(x => (x * 37) % 1000)
+                .Select(x => new KeyValuePair<BsonValue, PageAddress>(x, PageAddress.Empty))
                 .ToArray();
 
             var pragmas = new EnginePragmas(null);
             pragmas.Set(Pragmas.COLLATION, Collation.Binary.ToString(), false);
 
-            using (var tempDisk = new SortDisk(_factory, 10 * 8192, pragmas))
+            using (var tempDisk = new SortDisk(_factory, 8192, pragmas))
             using (var s = new SortService(tempDisk, Query.Descending, pragmas))
             {
                 s.Insert(source);
 
-                s.Count.Should().Be(20000);
-                s.Containers.Count.Should().Be(3);
+                s.Count.Should().Be(900);
+                s.Containers.Count.Should().Be(2);
 
-                s.Containers.ElementAt(0).Count.Should().Be(8192);
-                s.Containers.ElementAt(1).Count.Should().Be(8192);
-                s.Containers.ElementAt(2).Count.Should().Be(3616);
+                s.Containers.ElementAt(0).Count.Should().Be(819);
+                s.Containers.ElementAt(1).Count.Should().Be(81);
 
                 var output = s.Sort().ToArray();
 


### PR DESCRIPTION
## Summary
- replace the large random Sort_Int_Desc data set with a deterministic 900-item sample
- shrink the SortDisk container size so the test still spans multiple containers
- update container count assertions while keeping the ordering check intact

## Testing
- dotnet test LiteDB.Tests -f net8.0 --filter Sort_Int_Desc

------
https://chatgpt.com/codex/tasks/task_e_68cf34c7a898832690bbb43e1ec1596a