### PR TITLE
Feat/improve test time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,29 @@
-# name: CI
+name: CI
 
-# on:
-#   push:
-#     branches:
-#       - main
-#       - dev
-#   pull_request:
+on:
+  pull_request:
 
-# jobs:
-#   build:
-#     runs-on: ubuntu-latest
+jobs:
+  build:
+    runs-on: ubuntu-latest
 
-#     steps:
-#       - name: Check out repository
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-#       - name: Set up .NET SDK
-#         uses: actions/setup-dotnet@v4
-#         with:
-#           dotnet-version: 8.0.x
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
 
-#       - name: Restore
-#         run: dotnet restore LiteDB.sln
+      - name: Restore
+        run: dotnet restore LiteDB.sln
 
-#       - name: Build
-#         run: dotnet build LiteDB.sln --configuration Release --no-restore
+      - name: Build
+        run: dotnet build LiteDB.sln --configuration Release --no-restore
 
-#       - name: Test
-#         timeout-minutes: 5
-#         run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed"
+      - name: Test
+        timeout-minutes: 5
+        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed"

--- a/LiteDB.Tests/Engine/Rebuild_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using LiteDB.Engine;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -18,7 +19,7 @@ namespace LiteDB.Tests.Engine
             {
                 var col = db.GetCollection<Zip>("zip");
 
-                col.Insert(DataGen.Zip());
+                col.Insert(CreateSyntheticZipData(200, SurvivorId));
 
                 db.DropCollection("zip");
 
@@ -54,25 +55,27 @@ namespace LiteDB.Tests.Engine
 
                     col.EnsureIndex("city", false);
 
-                    var inserted = col.Insert(DataGen.Zip()); // 29.353 docs
-                    var deleted = col.DeleteMany(x => x.Id != "01001"); // delete 29.352 docs
+                    const int documentCount = 200;
 
-                    Assert.Equal(29353, inserted);
-                    Assert.Equal(29352, deleted);
+                    var inserted = col.Insert(CreateSyntheticZipData(documentCount, SurvivorId));
+                    var deleted = col.DeleteMany(x => x.Id != SurvivorId);
+
+                    Assert.Equal(documentCount, inserted);
+                    Assert.Equal(documentCount - 1, deleted);
 
                     Assert.Equal(1, col.Count());
 
                     // must checkpoint
                     db.Checkpoint();
 
-                    // file still large than 5mb (even with only 1 document)
-                    Assert.True(file.Size > 5 * 1024 * 1024);
+                    // file still larger than 1 MB (even with only 1 document)
+                    Assert.True(file.Size > 1 * 1024 * 1024);
 
                     // reduce datafile
                     var reduced = db.Rebuild();
 
-                    // now file are small than 50kb
-                    Assert.True(file.Size < 50 * 1024);
+                    // now file should be small again
+                    Assert.True(file.Size < 256 * 1024);
 
                     DoTest(db, col);
                 }
@@ -88,6 +91,40 @@ namespace LiteDB.Tests.Engine
 
                     DoTest(db, col);
                 }
+            }
+        }
+
+        private const string SurvivorId = "01001";
+
+        private static IEnumerable<Zip> CreateSyntheticZipData(int totalCount, string survivingId)
+        {
+            if (totalCount < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(totalCount));
+            }
+
+            const int payloadLength = 32 * 1024; // 32 KB payload to force file growth
+
+            for (var i = 0; i < totalCount; i++)
+            {
+                var id = (20000 + i).ToString("00000");
+
+                if (!string.IsNullOrEmpty(survivingId) && i == 0)
+                {
+                    id = survivingId;
+                }
+
+                var payload = new byte[payloadLength];
+                Array.Fill(payload, (byte)(i % 256));
+
+                yield return new Zip
+                {
+                    Id = id,
+                    City = $"City {i:D4}",
+                    Loc = new[] { (double)i, (double)i + 0.5 },
+                    State = "ST",
+                    Payload = payload
+                };
             }
         }
 

--- a/LiteDB.Tests/Internals/Sort_Tests.cs
+++ b/LiteDB.Tests/Internals/Sort_Tests.cs
@@ -43,25 +43,24 @@ namespace LiteDB.Internals
         [Fact]
         public void Sort_Int_Desc()
         {
-            var rnd = new Random();
-            var source = Enumerable.Range(0, 20000)
-                .Select(x => new KeyValuePair<BsonValue, PageAddress>(rnd.Next(1, 30000), PageAddress.Empty))
+            var source = Enumerable.Range(0, 900)
+                .Select(x => (x * 37) % 1000)
+                .Select(x => new KeyValuePair<BsonValue, PageAddress>(x, PageAddress.Empty))
                 .ToArray();
 
             var pragmas = new EnginePragmas(null);
             pragmas.Set(Pragmas.COLLATION, Collation.Binary.ToString(), false);
 
-            using (var tempDisk = new SortDisk(_factory, 10 * 8192, pragmas))
+            using (var tempDisk = new SortDisk(_factory, 8192, pragmas))
             using (var s = new SortService(tempDisk, Query.Descending, pragmas))
             {
                 s.Insert(source);
 
-                s.Count.Should().Be(20000);
-                s.Containers.Count.Should().Be(3);
+                s.Count.Should().Be(900);
+                s.Containers.Count.Should().Be(2);
 
-                s.Containers.ElementAt(0).Count.Should().Be(8192);
-                s.Containers.ElementAt(1).Count.Should().Be(8192);
-                s.Containers.ElementAt(2).Count.Should().Be(3616);
+                s.Containers.ElementAt(0).Count.Should().Be(819);
+                s.Containers.ElementAt(1).Count.Should().Be(81);
 
                 var output = s.Sort().ToArray();
 

--- a/LiteDB.Tests/Utils/Models/Zip.cs
+++ b/LiteDB.Tests/Utils/Models/Zip.cs
@@ -16,6 +16,7 @@ namespace LiteDB.Tests
         public string City { get; set; }
         public double[] Loc { get; set; }
         public string State { get; set; }
+        public byte[] Payload { get; set; }
 
         public int CompareTo(Zip other)
         {


### PR DESCRIPTION
This pull request updates several test files to improve reliability and performance of the LiteDB test suite. The main changes include generating synthetic test data with predictable payloads, adjusting file size assertions for more realistic thresholds, and introducing a utility to set engine timeouts directly for more precise transaction tests. Additionally, some test parameters have been tuned to reduce resource usage and improve determinism.

### Engine rebuild and synthetic data improvements

* Added a `Payload` field to the `Zip` model and introduced the `CreateSyntheticZipData` helper to generate a controlled number of large documents for more predictable file growth and shrinkage in rebuild tests. File size assertions were updated to use more realistic thresholds and to reduce test flakiness. (`LiteDB.Tests/Engine/Rebuild_Tests.cs`, `LiteDB.Tests/Utils/Models/Zip.cs`) [[1]](diffhunk://#diff-ce4f3df4cbc0c6fb42105199eb1e09fe8ad55450c3a6b115a2cc99259250b06cL21-R22) [[2]](diffhunk://#diff-ce4f3df4cbc0c6fb42105199eb1e09fe8ad55450c3a6b115a2cc99259250b06cL57-R78) [[3]](diffhunk://#diff-ce4f3df4cbc0c6fb42105199eb1e09fe8ad55450c3a6b115a2cc99259250b06cR97-R130) [[4]](diffhunk://#diff-0223368578630b327eecb5fb0050e03a3db1e72f760196ee3fe7618449d5bf31R19)

### Transaction timeout testing enhancements

* Added the `SetEngineTimeout` reflection utility to allow direct setting of engine timeouts in tests, improving precision and reliability of transaction timeout scenarios. Updated transaction tests to use shorter timeouts and adjusted wait periods for better determinism. (`LiteDB.Tests/Engine/Transactions_Tests.cs`) [[1]](diffhunk://#diff-f4d045d34dc3e19aaac948aa31e91bf47f502157c9daf0625942ff84a5643066L27-R30) [[2]](diffhunk://#diff-f4d045d34dc3e19aaac948aa31e91bf47f502157c9daf0625942ff84a5643066L254-R257) [[3]](diffhunk://#diff-f4d045d34dc3e19aaac948aa31e91bf47f502157c9daf0625942ff84a5643066L266-R269) [[4]](diffhunk://#diff-f4d045d34dc3e19aaac948aa31e91bf47f502157c9daf0625942ff84a5643066R279-R298)
* Improved comments and logic in transaction tests to clarify the sequence and expected behavior regarding lock timeouts. (`LiteDB.Tests/Engine/Transactions_Tests.cs`) [[1]](diffhunk://#diff-f4d045d34dc3e19aaac948aa31e91bf47f502157c9daf0625942ff84a5643066L39-R41) [[2]](diffhunk://#diff-f4d045d34dc3e19aaac948aa31e91bf47f502157c9daf0625942ff84a5643066L56-R58)

### Sorting test resource optimization

* Reduced the number of items and buffer size in sorting tests to decrease resource usage and improve test speed. Updated expected container counts and sizes to match the new parameters. (`LiteDB.Tests/Internals/Sort_Tests.cs`)