### PR TITLE
Add test database factory

### DIFF
--- a/LiteDB.Tests/Database/AutoId_Tests.cs
+++ b/LiteDB.Tests/Database/AutoId_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using LiteDB;
+using LiteDB.Tests.Utils;
 using FluentAssertions;
 using Xunit;
 
@@ -268,7 +269,7 @@ namespace LiteDB.Tests.Database
         [Fact]
         public void AutoId_Zero_Int()
         {
-            using (var db = new LiteDatabase(":memory:"))
+            using (var db = DatabaseFactory.Create())
             {
                 var test = db.GetCollection("Test", BsonAutoId.Int32);
                 var doc = new BsonDocument() { ["_id"] = 0, ["p1"] = 1 };

--- a/LiteDB.Tests/Database/Create_Database_Tests.cs
+++ b/LiteDB.Tests/Database/Create_Database_Tests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using FluentAssertions;
 using LiteDB.Engine;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -17,7 +18,7 @@ namespace LiteDB.Tests.Database
 
             using (var file = new TempFile())
             {
-                using (var db = new LiteDatabase("filename=" + file.Filename + ";initial size=" + initial))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, "filename=" + file.Filename + ";initial size=" + initial))
                 {
                     var col = db.GetCollection("col");
 

--- a/LiteDB.Tests/Database/Database_Pragmas_Tests.cs
+++ b/LiteDB.Tests/Database/Database_Pragmas_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using LiteDB;
+using LiteDB.Tests.Utils;
 using FluentAssertions;
 using Xunit;
 using System.Globalization;
@@ -13,7 +14,7 @@ namespace LiteDB.Tests.Database
         [Fact]
         public void Database_Pragmas_Get_Set()
         {
-            using (var db = new LiteDatabase(":memory:"))
+            using (var db = DatabaseFactory.Create())
             {
                 db.Timeout.TotalSeconds.Should().Be(60.0);
                 db.UtcDate.Should().Be(false);

--- a/LiteDB.Tests/Database/DeleteMany_Tests.cs
+++ b/LiteDB.Tests/Database/DeleteMany_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using LiteDB;
+using LiteDB.Tests.Utils;
 using FluentAssertions;
 using Xunit;
 
@@ -12,7 +13,7 @@ namespace LiteDB.Tests.Database
         [Fact]
         public void DeleteMany_With_Arguments()
         {
-            using (var db = new LiteDatabase(":memory:"))
+            using (var db = DatabaseFactory.Create())
             {
                 var c1 = db.GetCollection("Test");
 

--- a/LiteDB.Tests/Database/Delete_By_Name_Tests.cs
+++ b/LiteDB.Tests/Database/Delete_By_Name_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -22,7 +23,7 @@ namespace LiteDB.Tests.Database
         public void Delete_By_Name()
         {
             using (var f = new TempFile())
-            using (var db = new LiteDatabase(f.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
             {
                 var col = db.GetCollection<Person>("Person");
 

--- a/LiteDB.Tests/Database/Document_Size_Tests.cs
+++ b/LiteDB.Tests/Database/Document_Size_Tests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using FluentAssertions;
 using LiteDB.Engine;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -16,7 +17,7 @@ namespace LiteDB.Tests.Database
         public void Very_Large_Single_Document_Support_With_Partial_Load_Memory_Usage()
         {
             using (var file = new TempFile())
-            using (var db = new LiteDatabase(file.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
             {
                 var col = db.GetCollection("col");
 

--- a/LiteDB.Tests/Database/FindAll_Tests.cs
+++ b/LiteDB.Tests/Database/FindAll_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -23,7 +24,7 @@ namespace LiteDB.Tests.Database
         {
             using (var f = new TempFile())
             {
-                using (var db = new LiteDatabase(f.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
                 {
                     var col = db.GetCollection<Person>("Person");
 
@@ -34,7 +35,7 @@ namespace LiteDB.Tests.Database
                 }
                 // close datafile
 
-                using (var db = new LiteDatabase(f.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
                 {
                     var p = db.GetCollection<Person>("Person").Find(Query.All("Fullname", Query.Ascending));
 

--- a/LiteDB.Tests/Database/IndexSortAndFilter_Tests.cs
+++ b/LiteDB.Tests/Database/IndexSortAndFilter_Tests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -25,7 +26,7 @@ namespace LiteDB.Tests.Database
         public IndexSortAndFilterTest()
         {
             _tempFile = new TempFile();
-            _database = new LiteDatabase(_tempFile.Filename);
+            _database = DatabaseFactory.Create(TestDatabaseType.Disk, _tempFile.Filename);
             _collection = _database.GetCollection<Item>("items");
 
             _collection.Upsert(new Item() { Id = "C", Value = "Value 1" });

--- a/LiteDB.Tests/Database/MultiKey_Mapper_Tests.cs
+++ b/LiteDB.Tests/Database/MultiKey_Mapper_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -28,7 +29,7 @@ namespace LiteDB.Tests.Database
         [Fact]
         public void MultiKey_Mapper()
         {
-            using (var db = new LiteDatabase(":memory:"))
+            using (var db = DatabaseFactory.Create())
             {
                 var col = db.GetCollection<MultiKeyDoc>("col");
 

--- a/LiteDB.Tests/Database/NonIdPoco_Tests.cs
+++ b/LiteDB.Tests/Database/NonIdPoco_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -22,7 +23,7 @@ namespace LiteDB.Tests.Database
         public void MissingIdDoc_Test()
         {
             using (var file = new TempFile())
-            using (var db = new LiteDatabase(file.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
             {
                 var col = db.GetCollection<MissingIdDoc>("col");
 

--- a/LiteDB.Tests/Database/Query_Min_Max_Tests.cs
+++ b/LiteDB.Tests/Database/Query_Min_Max_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -25,7 +26,7 @@ namespace LiteDB.Tests.Database
         public void Query_Min_Max()
         {
             using (var f = new TempFile())
-            using (var db = new LiteDatabase(f.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
             {
                 var c = db.GetCollection<EntityMinMax>("col");
 

--- a/LiteDB.Tests/Database/Site_Tests.cs
+++ b/LiteDB.Tests/Database/Site_Tests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -13,7 +14,7 @@ namespace LiteDB.Tests.Database
         public void Home_Example()
         {
             using (var f = new TempFile())
-            using (var db = new LiteDatabase(f.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
             {
                 // Get customer collection
                 var customers = db.GetCollection<Customer>("customers");

--- a/LiteDB.Tests/Database/Snapshot_Upgrade_Tests.cs
+++ b/LiteDB.Tests/Database/Snapshot_Upgrade_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -11,7 +12,7 @@ namespace LiteDB.Tests.Database
         [Fact]
         public void Transaction_Update_Upsert()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
             var col = db.GetCollection("test");
 
             bool transactionCreated = db.BeginTrans();

--- a/LiteDB.Tests/Database/Storage_Tests.cs
+++ b/LiteDB.Tests/Database/Storage_Tests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database
@@ -31,7 +32,7 @@ namespace LiteDB.Tests.Database
         public void Storage_Upload_Download()
         {
             using (var f = new TempFile())
-            using (var db = new LiteDatabase(f.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
                 //using (var db = new LiteDatabase(@"c:\temp\file.db"))
             {
                 var fs = db.GetStorage<int>("_files", "_chunks");

--- a/LiteDB.Tests/Database/Upgrade_Tests.cs
+++ b/LiteDB.Tests/Database/Upgrade_Tests.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using LiteDB;
+using LiteDB.Tests.Utils;
 using FluentAssertions;
 using Xunit;
 using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities.ObjectModel;
@@ -16,7 +17,7 @@ namespace LiteDB.Tests.Database
             // v5 upgrades only from v4!
             using(var tempFile = new TempFile("../../../Resources/v4.db"))
             {
-                using (var db = new LiteDatabase($"filename={tempFile};upgrade=true"))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, $"filename={tempFile};upgrade=true"))
                 {
                     // convert and open database
                     var col1 = db.GetCollection("col1");
@@ -24,7 +25,7 @@ namespace LiteDB.Tests.Database
                     col1.Count().Should().Be(3);
                 }
 
-                using (var db = new LiteDatabase($"filename={tempFile};upgrade=true"))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, $"filename={tempFile};upgrade=true"))
                 {
                     // database already converted
                     var col1 = db.GetCollection("col1");
@@ -40,7 +41,7 @@ namespace LiteDB.Tests.Database
             // v5 upgrades only from v4!
             using (var tempFile = new TempFile("../../../Resources/v4.db"))
             {
-                using (var db = new LiteDatabase($"filename={tempFile};upgrade=true"))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, $"filename={tempFile};upgrade=true"))
                 {
                     // convert and open database
                     var col1 = db.GetCollection("col1");
@@ -48,7 +49,7 @@ namespace LiteDB.Tests.Database
                     col1.Count().Should().Be(3);
                 }
 
-                using (var db = new LiteDatabase($"filename={tempFile};upgrade=true"))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, $"filename={tempFile};upgrade=true"))
                 {
                     // database already converted
                     var col1 = db.GetCollection("col1");

--- a/LiteDB.Tests/Database/Writing_While_Reading_Test.cs
+++ b/LiteDB.Tests/Database/Writing_While_Reading_Test.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Database;
@@ -9,7 +10,7 @@ public class Writing_While_Reading_Test
     public void Test()
     {
         using var f = new TempFile();
-        using (var db = new LiteDatabase(f.Filename))
+        using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
         {
             var col = db.GetCollection<MyClass>("col");
             col.Insert(new MyClass { Name = "John", Description = "Doe" });
@@ -18,7 +19,7 @@ public class Writing_While_Reading_Test
         }
 
 
-        using (var db = new LiteDatabase(f.Filename))
+        using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
         {
             var col = db.GetCollection<MyClass>("col");
             foreach (var item in col.FindAll())
@@ -31,7 +32,7 @@ public class Writing_While_Reading_Test
         }
 
 
-        using (var db = new LiteDatabase(f.Filename))
+        using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, f.Filename))
         {
             var col = db.GetCollection<MyClass>("col");
             foreach (var item in col.FindAll())

--- a/LiteDB.Tests/Engine/DropCollection_Tests.cs
+++ b/LiteDB.Tests/Engine/DropCollection_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Engine
@@ -10,7 +11,7 @@ namespace LiteDB.Tests.Engine
         public void DropCollection()
         {
             using (var file = new TempFile())
-            using (var db = new LiteDatabase(file.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
             {
                 db.GetCollectionNames().Should().NotContain("col");
 
@@ -31,7 +32,7 @@ namespace LiteDB.Tests.Engine
         {
             using (var file = new TempFile())
             {
-                using (var db = new LiteDatabase(file.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
                 {
                     var col = db.GetCollection("test");
                     col.Insert(new BsonDocument { ["_id"] = 1 });
@@ -39,7 +40,7 @@ namespace LiteDB.Tests.Engine
                     db.Rebuild();
                 }
 
-                using (var db = new LiteDatabase(file.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
                 {
                     var col = db.GetCollection("test");
                     col.Insert(new BsonDocument { ["_id"] = 1 });

--- a/LiteDB.Tests/Engine/Index_Tests.cs
+++ b/LiteDB.Tests/Engine/Index_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Engine
@@ -10,7 +11,7 @@ namespace LiteDB.Tests.Engine
         [Fact]
         public void Index_With_No_Name()
         {
-            using (var db = new LiteDatabase("filename=:memory:"))
+            using (var db = DatabaseFactory.Create(connectionString: "filename=:memory:"))
             {
                 var users = db.GetCollection("users");
                 var indexes = db.GetCollection("$indexes");
@@ -31,7 +32,7 @@ namespace LiteDB.Tests.Engine
         [Fact]
         public void Index_Order()
         {
-            using (var db = new LiteDatabase("filename=:memory:"))
+            using (var db = DatabaseFactory.Create(connectionString: "filename=:memory:"))
             {
                 var col = db.GetCollection("col");
                 var indexes = db.GetCollection("$indexes");
@@ -68,7 +69,7 @@ namespace LiteDB.Tests.Engine
         [Fact]
         public void Index_With_Like()
         {
-            using (var db = new LiteDatabase("filename=:memory:"))
+            using (var db = DatabaseFactory.Create(connectionString: "filename=:memory:"))
             {
                 var col = db.GetCollection("names", BsonAutoId.Int32);
 
@@ -118,7 +119,7 @@ namespace LiteDB.Tests.Engine
         [Fact]
         public void EnsureIndex_Invalid_Arguments()
         {
-            using var db = new LiteDatabase("filename=:memory:");
+            using var db = DatabaseFactory.Create(connectionString: "filename=:memory:");
             var test = db.GetCollection("test");
 
             // null name
@@ -143,7 +144,7 @@ namespace LiteDB.Tests.Engine
         [Fact]
         public void MultiKey_Index_Test()
         {
-            using var db = new LiteDatabase("filename=:memory:");
+            using var db = DatabaseFactory.Create(connectionString: "filename=:memory:");
             var col = db.GetCollection("customers", BsonAutoId.Int32);
             col.EnsureIndex("$.Phones[*].Type");
 

--- a/LiteDB.Tests/Engine/Rebuild_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using LiteDB.Engine;
+using LiteDB.Tests.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,7 +16,7 @@ namespace LiteDB.Tests.Engine
         public void Rebuild_After_DropCollection()
         {
             using (var file = new TempFile())
-            using (var db = new LiteDatabase(file.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
             {
                 var col = db.GetCollection<Zip>("zip");
 
@@ -47,7 +48,7 @@ namespace LiteDB.Tests.Engine
 
             using (var file = new TempFile())
             {
-                using (var db = new LiteDatabase(file.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
                 {
                     var col = db.GetCollection<Zip>();
 
@@ -81,7 +82,7 @@ namespace LiteDB.Tests.Engine
                 }
 
                 // re-open and rebuild again
-                using (var db = new LiteDatabase(file.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
                 {
                     var col = db.GetCollection<Zip>();
 
@@ -132,7 +133,7 @@ namespace LiteDB.Tests.Engine
         public void Rebuild_Change_Culture_Error()
         {
             using (var file = new TempFile())
-            using (var db = new LiteDatabase(file.Filename))
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
             {
                 // remove string comparer ignore case
                 db.Rebuild(new RebuildOptions { Collation = new Collation("en-US/None") });

--- a/LiteDB.Tests/Engine/Transactions_Tests.cs
+++ b/LiteDB.Tests/Engine/Transactions_Tests.cs
@@ -23,7 +23,7 @@ namespace LiteDB.Tests.Engine
             var data1 = DataGen.Person(1, 100).ToArray();
             var data2 = DataGen.Person(101, 200).ToArray();
 
-            using (var db = new LiteDatabase("filename=:memory:"))
+            using (var db = DatabaseFactory.Create(connectionString: "filename=:memory:"))
             {
                 // configure the minimal pragma timeout and then override the engine to a few milliseconds
                 db.Pragma(Pragmas.TIMEOUT, 1);

--- a/LiteDB.Tests/Engine/UserVersion_Tests.cs
+++ b/LiteDB.Tests/Engine/UserVersion_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Engine
@@ -10,14 +11,14 @@ namespace LiteDB.Tests.Engine
         {
             using (var file = new TempFile())
             {
-                using (var db = new LiteDatabase(file.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
                 {
                     db.UserVersion.Should().Be(0);
                     db.UserVersion = 5;
                     db.Checkpoint();
                 }
 
-                using (var db = new LiteDatabase(file.Filename))
+                using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
                 {
                     db.UserVersion.Should().Be(5);
                 }

--- a/LiteDB.Tests/Internals/ExtendedLength_Tests.cs
+++ b/LiteDB.Tests/Internals/ExtendedLength_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Internals
@@ -22,7 +23,7 @@ namespace LiteDB.Internals
         [Fact]
         public void IndexExtendedLength_Tests()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
             var col = db.GetCollection("customers", BsonAutoId.Int32);
             col.EnsureIndex("$.Name");
             col.Insert(new BsonDocument { ["Name"] = new string('A', 1010) });

--- a/LiteDB.Tests/Issues/Issue1651_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1651_Tests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Xunit;
 using System.Linq;
+using LiteDB.Tests.Utils;
 
 namespace LiteDB.Tests.Issues
 {
@@ -28,7 +29,7 @@ namespace LiteDB.Tests.Issues
         {
             BsonMapper.Global.Entity<Order>().DbRef(order => order.Customer);
 
-            using var _database = new LiteDatabase(":memory:");
+            using var _database = DatabaseFactory.Create();
             var _orderCollection = _database.GetCollection<Order>("Order");
             var _customerCollection = _database.GetCollection<Customer>("Customer");
 

--- a/LiteDB.Tests/Issues/Issue1695_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1695_Tests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using FluentAssertions;
 using LiteDB.Engine;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues
@@ -19,7 +20,7 @@ namespace LiteDB.Tests.Issues
         [Fact]
         public void ICollection_Parameter_Test()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
             var col = db.GetCollection<StateModel>("col");
 
             ICollection<ObjectId> ids = new List<ObjectId>();

--- a/LiteDB.Tests/Issues/Issue1701_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1701_Tests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Xunit;
 using System.Linq;
+using LiteDB.Tests.Utils;
 
 namespace LiteDB.Tests.Issues
 {
@@ -10,7 +11,7 @@ namespace LiteDB.Tests.Issues
         [Fact]
         public void Deleted_Index_Slot_Test()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
             var col = db.GetCollection("col", BsonAutoId.Int32);
             var id = col.Insert(new BsonDocument { ["attr1"] = "attr", ["attr2"] = "attr", ["attr3"] = "attr" });
 

--- a/LiteDB.Tests/Issues/Issue1838_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1838_Tests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Xunit;
 using System.Linq;
+using LiteDB.Tests.Utils;
 
 namespace LiteDB.Tests.Issues
 {
@@ -10,7 +11,7 @@ namespace LiteDB.Tests.Issues
         [Fact]
         public void Find_ByDatetime_Offset()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
             var collection = db.GetCollection<TestType>(nameof(TestType));
 
             // sample data

--- a/LiteDB.Tests/Issues/Issue1860_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1860_Tests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Xunit;
 using System.Linq;
+using LiteDB.Tests.Utils;
 
 namespace LiteDB.Tests.Issues
 {
@@ -10,7 +11,7 @@ namespace LiteDB.Tests.Issues
         [Fact]
         public void Constructor_has_enum_bsonctor()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
 
             // Get a collection (or create, if doesn't exist)
             var col1 = db.GetCollection<C1>("c1");
@@ -44,7 +45,7 @@ namespace LiteDB.Tests.Issues
         [Fact]
         public void Constructor_has_enum()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
 
             // Get a collection (or create, if doesn't exist)
             var col1 = db.GetCollection<C1>("c1");
@@ -78,7 +79,7 @@ namespace LiteDB.Tests.Issues
         [Fact]
         public void Constructor_has_enum_asint()
         {
-            using var db = new LiteDatabase(":memory:", new BsonMapper { EnumAsInteger = true });
+            using var db = DatabaseFactory.Create(mapper: new BsonMapper { EnumAsInteger = true });
 
             // Get a collection (or create, if doesn't exist)
             var col1 = db.GetCollection<C1>("c1");

--- a/LiteDB.Tests/Issues/Issue1865_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue1865_Tests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Xunit;
 using System.Linq;
 using System.Security.Cryptography;
+using LiteDB.Tests.Utils;
 
 namespace LiteDB.Tests.Issues
 {
@@ -37,7 +38,7 @@ namespace LiteDB.Tests.Issues
 
             //BsonMapper.Global.ResolveCollectionName = (s) => "activity";
 
-            using var _database = new LiteDatabase(":memory:");
+            using var _database = DatabaseFactory.Create();
             var projectsCol = _database.GetCollection<Project>("activity");
             var pointsCol = _database.GetCollection<Point>("activity");
 

--- a/LiteDB.Tests/Issues/Issue2127_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2127_Tests.cs
@@ -3,6 +3,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading;
+using LiteDB.Tests.Utils;
 
 namespace LiteDB.Tests.Issues
 {
@@ -81,7 +82,7 @@ namespace LiteDB.Tests.Issues
                     Connection = ConnectionType.Direct
                 };
 
-                _liteDb = new LiteDatabase(connectionString);
+                _liteDb = DatabaseFactory.Create(TestDatabaseType.Disk, connectionString.ToString());
             }
 
             public void Insert(ExampleItem item)

--- a/LiteDB.Tests/Issues/Issue2129_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2129_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues
@@ -10,7 +11,7 @@ namespace LiteDB.Tests.Issues
         [Fact]
         public void TestInsertAfterDeleteAll()
         {
-            var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
             var col = db.GetCollection<SwapChance>(nameof(SwapChance));
             col.EnsureIndex(x => x.Accounts1to2);
             col.EnsureIndex(x => x.Accounts2to1);

--- a/LiteDB.Tests/Issues/Issue2265_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2265_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues;
@@ -31,7 +32,7 @@ public class Issue2265_Tests
     [Fact]
     public void Test()
     {
-        using (var db = new LiteDatabase(":memory:"))
+        using (var db = DatabaseFactory.Create())
         {
             var c = db.GetCollection<Weights>("weights");
             Weights? w = c.FindOne(x => true);

--- a/LiteDB.Tests/Issues/Issue2298_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2298_Tests.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues;
@@ -45,23 +46,23 @@ public class Issue2298_Tests
     }
 
     [Fact]
-    public void We_Dont_Need_Ctor()
-    {
-        BsonMapper.Global.RegisterType<QuantityRange<Mass>>(
-            serialize: (range) => new BsonDocument
-            {
-                { nameof(QuantityRange<Mass>.Min), range.Min },
-                { nameof(QuantityRange<Mass>.Max), range.Max },
-                { nameof(QuantityRange<Mass>.Unit), range.Unit.ToString() }
-            },
-            deserialize: (document) => MassRangeBuilder(document as BsonDocument)
-        );
+        public void We_Dont_Need_Ctor()
+        {
+            BsonMapper.Global.RegisterType<QuantityRange<Mass>>(
+                serialize: (range) => new BsonDocument
+                {
+                    { nameof(QuantityRange<Mass>.Min), range.Min },
+                    { nameof(QuantityRange<Mass>.Max), range.Max },
+                    { nameof(QuantityRange<Mass>.Unit), range.Unit.ToString() }
+                },
+                deserialize: (document) => MassRangeBuilder(document as BsonDocument)
+            );
 
-        var range = new QuantityRange<Mass>(100, 500, Mass.Units.Pound);
-        var filename = "Demo.DB";
-        var DB = new LiteDatabase(filename);
-        var collection = DB.GetCollection<QuantityRange<Mass>>("DEMO");
-        collection.Insert(range);
-        var restored = collection.FindAll().First();
-    }
+            var range = new QuantityRange<Mass>(100, 500, Mass.Units.Pound);
+            using var filename = new TempFile();
+            using var db = DatabaseFactory.Create(TestDatabaseType.Disk, filename.Filename);
+            var collection = db.GetCollection<QuantityRange<Mass>>("DEMO");
+            collection.Insert(range);
+            var restored = collection.FindAll().First();
+        }
 }

--- a/LiteDB.Tests/Issues/Issue2458_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2458_Tests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues;
@@ -9,7 +10,7 @@ public class Issue2458_Tests
     [Fact]
     public void NegativeSeekFails()
     {
-        using var db = new LiteDatabase(":memory:");
+        using var db = DatabaseFactory.Create();
         var fs = db.FileStorage;
         AddTestFile("test", 1, fs);
         using Stream stream = fs.OpenRead("test");
@@ -21,7 +22,7 @@ public class Issue2458_Tests
     [Fact]
     public void SeekPastFileSucceds()
     {
-        using var db = new LiteDatabase(":memory:");
+        using var db = DatabaseFactory.Create();
         var fs = db.FileStorage;
         AddTestFile("test", 1, fs);
         using Stream stream = fs.OpenRead("test");
@@ -31,7 +32,7 @@ public class Issue2458_Tests
     [Fact]
     public void SeekShortChunks()
     {
-        using var db = new LiteDatabase(":memory:");
+        using var db = DatabaseFactory.Create();
         var fs = db.FileStorage;
         using(Stream writeStream = fs.OpenWrite("test", "test"))
         {

--- a/LiteDB.Tests/Issues/Issue2471_Test.cs
+++ b/LiteDB.Tests/Issues/Issue2471_Test.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues;
@@ -17,7 +18,7 @@ public class Issue2471_Test
     [Fact]
     public void TestFragmentDB_FindByIDException()
     {
-        using var db = new LiteDatabase(":memory:");
+        using var db = DatabaseFactory.Create();
         var collection = db.GetCollection<object>("fragtest");
 
         var fragment = new object { };
@@ -36,7 +37,7 @@ public class Issue2471_Test
     [Fact]
     public void MultipleReadCleansUpTransaction()
     {
-        using var database = new LiteDatabase(":memory:");
+        using var database = DatabaseFactory.Create();
 
         var collection = database.GetCollection("test");
         collection.Insert(new BsonDocument { ["_id"] = 1 });

--- a/LiteDB.Tests/Issues/Issue2494_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2494_Tests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues;
@@ -23,7 +24,7 @@ public class Issue2494_Tests
             Upgrade = true,
         };
 
-        using (var db = new LiteDatabase(connectionString)) // <= throws as of version 5.0.18
+        using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, connectionString.ToString())) // <= throws as of version 5.0.18
         {
             var col = db.GetCollection<PlayerDto>();
             col.FindAll();

--- a/LiteDB.Tests/Issues/Issue2570_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2570_Tests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Issues;
@@ -15,7 +16,7 @@ public class Issue2570_Tests
     [Fact]
     public void Issue2570_Tuples()
     {
-        using (var db = new LiteDatabase(":memory:"))
+        using (var db = DatabaseFactory.Create())
         {
             var col = db.GetCollection<Person>("Person");
 
@@ -46,7 +47,7 @@ public class Issue2570_Tests
     [Fact]
     public void Issue2570_Structs()
     {
-        using (var db = new LiteDatabase(":memory:"))
+        using (var db = DatabaseFactory.Create())
         {
             var col = db.GetCollection<PersonWithStruct>("Person");
 

--- a/LiteDB.Tests/Issues/Pull2468_Tests.cs
+++ b/LiteDB.Tests/Issues/Pull2468_Tests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using LiteDB.Tests.Utils;
 using Xunit;
 
 using static LiteDB.Tests.Issues.Issue1838_Tests;
@@ -18,7 +19,7 @@ public class Pull2468_Tests
     [Fact]
     public void Supports_LowerInvariant()
     {
-        using var db = new LiteDatabase(":memory:");
+        using var db = DatabaseFactory.Create();
         var collection = db.GetCollection<TestType>(nameof(TestType));
 
         collection.Insert(new TestType()
@@ -45,7 +46,7 @@ public class Pull2468_Tests
     [Fact]
     public void Supports_UpperInvariant()
     {
-        using var db = new LiteDatabase(":memory:");
+        using var db = DatabaseFactory.Create();
         var collection = db.GetCollection<TestType>(nameof(TestType));
 
         collection.Insert(new TestType()

--- a/LiteDB.Tests/Mapper/Mapper_Tests.cs
+++ b/LiteDB.Tests/Mapper/Mapper_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using System;
 using System.Reflection;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.Mapper
@@ -23,7 +24,7 @@ namespace LiteDB.Tests.Mapper
         [Fact]
         public void Class_Not_Assignable()
         {
-            using (var db = new LiteDatabase(":memory:"))
+            using (var db = DatabaseFactory.Create())
             {
                 var col = db.GetCollection<MyClass>("Test");
                 col.Insert(new MyClass { Id = 1, Member = null });

--- a/LiteDB.Tests/Query/Data/PersonQueryData.cs
+++ b/LiteDB.Tests/Query/Data/PersonQueryData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using LiteDB.Tests.Utils;
 
 namespace LiteDB.Tests.QueryTest
 {
@@ -13,7 +14,7 @@ namespace LiteDB.Tests.QueryTest
         {
             _local = DataGen.Person().ToArray();
 
-            _db = new LiteDatabase(":memory:");
+            _db = DatabaseFactory.Create();
             _collection = _db.GetCollection<Person>("person");
             _collection.Insert(this._local);
         }

--- a/LiteDB.Tests/Query/Select_Tests.cs
+++ b/LiteDB.Tests/Query/Select_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.QueryTest
@@ -78,7 +79,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void Query_With_No_Collection()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = DatabaseFactory.Create();
 
             using (var r = db.Execute("SELECT DAY(NOW()) as DIA"))
             {

--- a/LiteDB.Tests/Utils/DatabaseFactory.cs
+++ b/LiteDB.Tests/Utils/DatabaseFactory.cs
@@ -1,0 +1,40 @@
+using System;
+using LiteDB;
+
+namespace LiteDB.Tests.Utils
+{
+    public enum TestDatabaseType
+    {
+        Default,
+        InMemory,
+        Disk
+    }
+
+    public static class DatabaseFactory
+    {
+        public static LiteDatabase Create(TestDatabaseType type = TestDatabaseType.Default, string connectionString = null, BsonMapper mapper = null)
+        {
+            switch (type)
+            {
+                case TestDatabaseType.Default:
+                case TestDatabaseType.InMemory:
+                    return mapper is null
+                        ? new LiteDatabase(connectionString ?? ":memory:")
+                        : new LiteDatabase(connectionString ?? ":memory:", mapper);
+
+                case TestDatabaseType.Disk:
+                    if (string.IsNullOrWhiteSpace(connectionString))
+                    {
+                        throw new ArgumentException("Disk databases require a connection string.", nameof(connectionString));
+                    }
+
+                    return mapper is null
+                        ? new LiteDatabase(connectionString)
+                        : new LiteDatabase(connectionString, mapper);
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), type, null);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a `DatabaseFactory` helper and `TestDatabaseType` enum so tests can consistently request in-memory or disk-backed databases
- refactor in-memory tests to call the factory by default and require an explicit disk flag where persisted files are needed
- propagate factory usage to disk-specific scenarios and mapper-customized setups to centralize LiteDatabase creation

## Testing
- dotnet test -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68cf39a0d5c48326b2f1d38d873ea8fa