### PR TITLE
Handle BsonVector in JSON writer

### DIFF
--- a/LiteDB.Tests/Document/Json_Tests.cs
+++ b/LiteDB.Tests/Document/Json_Tests.cs
@@ -94,5 +94,18 @@ namespace LiteDB.Tests.Document
             Assert.False(double.IsNegativeInfinity(bson["doubleNegativeInfinity"].AsDouble));
             Assert.False(double.IsPositiveInfinity(bson["doublePositiveInfinity"].AsDouble));
         }
+
+        [Fact]
+        public void Json_Writes_BsonVector_As_Array()
+        {
+            var document = new BsonDocument
+            {
+                ["Embedding"] = new BsonVector(new float[] { 1.0f, 2.5f, -3.75f })
+            };
+
+            var json = JsonSerializer.Serialize(document);
+
+            json.Should().Contain("\"Embedding\":[1.0,2.5,-3.75]");
+        }
     }
 }

--- a/LiteDB/Document/Json/JsonWriter.cs
+++ b/LiteDB/Document/Json/JsonWriter.cs
@@ -116,6 +116,12 @@ namespace LiteDB
                 case BsonType.MaxValue:
                     this.WriteExtendDataType("$maxValue", "1");
                     break;
+
+                case BsonType.Vector:
+                    var vector = value.AsVector;
+                    var array = new BsonArray(vector.Select(x => (BsonValue)x));
+                    this.WriteArray(array);
+                    break;
             }
         }
 


### PR DESCRIPTION
## Summary
- serialize `BsonVector` values as JSON arrays by reusing the array writer
- add regression coverage that verifies vectors are emitted as numeric arrays

## Testing
- dotnet test LiteDB.Tests -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68cf49899bd88326917a458011177ab0