### PR TITLE
Use max sentinel for invalid vector similarity results

### DIFF
--- a/LiteDB/Document/Expression/Methods/Vector.cs
+++ b/LiteDB/Document/Expression/Methods/Vector.cs
@@ -8,7 +8,7 @@ internal partial class BsonExpressionMethods
     public static BsonValue VECTOR_SIM(BsonValue left, BsonValue right)
     {
         if (!(left.IsArray || left.Type == BsonType.Vector) || !(right.IsArray || right.Type == BsonType.Vector))
-            return BsonValue.Null;
+            return BsonValue.MaxValue;
 
         var query = left.IsArray
             ? left.AsArray
@@ -22,7 +22,7 @@ internal partial class BsonExpressionMethods
                 catch { return float.NaN; }
             }).ToArray();
 
-        if (query.Count != candidate.Length) return BsonValue.Null;
+        if (query.Count != candidate.Length) return BsonValue.MaxValue;
 
         double dot = 0, magQ = 0, magC = 0;
 
@@ -35,21 +35,21 @@ internal partial class BsonExpressionMethods
             }
             catch
             {
-                return BsonValue.Null;
+                return BsonValue.MaxValue;
             }
 
             var c = (double)candidate[i];
 
-            if (double.IsNaN(c)) return BsonValue.Null;
+            if (double.IsNaN(c)) return BsonValue.MaxValue;
 
             dot += q * c;
             magQ += q * q;
             magC += c * c;
         }
 
-        if (magQ == 0 || magC == 0) return BsonValue.Null;
+        if (magQ == 0 || magC == 0) return BsonValue.MaxValue;
 
         var cosine = 1.0 - (dot / (Math.Sqrt(magQ) * Math.Sqrt(magC)));
-        return double.IsNaN(cosine) ? BsonValue.Null : cosine;
+        return double.IsNaN(cosine) ? BsonValue.MaxValue : cosine;
     }
 }


### PR DESCRIPTION
## Summary
- return `BsonValue.MaxValue` from `VECTOR_SIM` when inputs are missing, malformed, or zero-length so invalid distances sort last
- update vector similarity tests to expect the sentinel and cover `.WhereNear`/`.TopKNear` ignoring null or malformed embeddings

## Testing
- dotnet test LiteDB.Tests -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68cf498a7a9083269c03091d3ee64799