### PR TITLE
Fix vector index mapping for enumerable expressions

### DIFF
--- a/LiteDB.Demo.Tools.VectorSearch/Commands/SearchCommand.cs
+++ b/LiteDB.Demo.Tools.VectorSearch/Commands/SearchCommand.cs
@@ -70,13 +70,15 @@ namespace LiteDB.Demo.Tools.VectorSearch.Commands
                 {
                     preview = preview[..settings.PreviewLength] + "\u2026";
                 }
-
-                table.AddRow(
-                    rank.ToString(),
-                    hit.Similarity.ToString("F3"),
-                    hit.Document.Title,
-                    preview,
-                    settings.HidePath ? string.Empty : hit.Document.Path);
+                
+                table.AddRow
+                (
+                    Markup.Escape(rank.ToString()),
+                    Markup.Escape(hit.Similarity.ToString("F3")),
+                    Markup.Escape(hit.Document.Title),
+                    Markup.Escape(preview),
+                    settings.HidePath ? string.Empty : Markup.Escape(hit.Document.Path)
+                );
 
                 rank++;
             }

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -15,6 +15,9 @@
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\ingest-20250922-234735.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 	
   <ItemGroup Condition="'$(Configuration)' == 'Release'">

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -3,8 +3,10 @@ using LiteDB;
 using LiteDB.Engine;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using Xunit;
 
 namespace LiteDB.Tests.QueryTest
@@ -101,6 +103,46 @@ namespace LiteDB.Tests.QueryTest
             Action conflicting = () => collection.EnsureIndex("embedding_idx", expression, new VectorIndexOptions(2, VectorDistanceMetric.Euclidean));
 
             conflicting.Should().Throw<LiteException>();
+        }
+
+        [Fact]
+        public void EnsureVectorIndex_PreservesEnumerableExpressionsForVectorIndexes()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var collection = db.GetCollection<VectorDocument>("documents");
+
+            var resourcePath = Path.Combine(AppContext.BaseDirectory, "Resources", "ingest-20250922-234735.json");
+            var json = File.ReadAllText(resourcePath);
+
+            using var parsed = JsonDocument.Parse(json);
+            // Use a subset of the embedding to stay under the index entry size limit while
+            // preserving the serialized structure that triggered the regression.
+            var embedding = parsed.RootElement
+                .GetProperty("Embedding")
+                .EnumerateArray()
+                .Select(static value => value.GetSingle())
+                .Take(128)
+                .ToArray();
+
+            var options = new VectorIndexOptions((ushort)embedding.Length, VectorDistanceMetric.Cosine);
+
+            collection.EnsureIndex(x => x.Embedding, options);
+
+            var document = new VectorDocument
+            {
+                Id = 1,
+                Embedding = embedding,
+                Flag = false
+            };
+
+            Action act = () => collection.Upsert(document);
+
+            act.Should().NotThrow();
+
+            var stored = collection.FindById(1);
+
+            stored.Should().NotBeNull();
+            stored.Embedding.Should().Equal(embedding);
         }
 
         [Fact]

--- a/LiteDB/Client/Database/Collections/Index.cs
+++ b/LiteDB/Client/Database/Collections/Index.cs
@@ -72,7 +72,7 @@ namespace LiteDB
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
-            var expression = this.GetIndexExpression(keySelector);
+            var expression = this.GetIndexExpression(keySelector, convertEnumerableToMultiKey: false);
 
             return this.EnsureIndex(expression, options);
         }
@@ -94,7 +94,7 @@ namespace LiteDB
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
-            var expression = this.GetIndexExpression(keySelector);
+            var expression = this.GetIndexExpression(keySelector, convertEnumerableToMultiKey: false);
 
             return this.EnsureIndex(name, expression, options);
         }
@@ -102,11 +102,11 @@ namespace LiteDB
         /// <summary>
         /// Get index expression based on LINQ expression. Convert IEnumerable in MultiKey indexes
         /// </summary>
-        private BsonExpression GetIndexExpression<K>(Expression<Func<T, K>> keySelector)
+        private BsonExpression GetIndexExpression<K>(Expression<Func<T, K>> keySelector, bool convertEnumerableToMultiKey = true)
         {
             var expression = _mapper.GetIndexExpression(keySelector);
 
-            if (typeof(K).IsEnumerable() && expression.IsScalar == true)
+            if (convertEnumerableToMultiKey && typeof(K).IsEnumerable() && expression.IsScalar == true)
             {
                 if (expression.Type == BsonExpressionType.Path)
                 {

--- a/LiteDB/Engine/Pages/VectorIndexPage.cs
+++ b/LiteDB/Engine/Pages/VectorIndexPage.cs
@@ -25,11 +25,11 @@ namespace LiteDB.Engine
             return new VectorIndexNode(this, index, segment);
         }
 
-        public VectorIndexNode InsertNode(PageAddress dataBlock, float[] vector, int bytesLength, byte levelCount)
+        public VectorIndexNode InsertNode(PageAddress dataBlock, float[] vector, int bytesLength, byte levelCount, PageAddress externalVector)
         {
             var segment = base.Insert((ushort)bytesLength, out var index);
 
-            return new VectorIndexNode(this, index, segment, dataBlock, vector, levelCount);
+            return new VectorIndexNode(this, index, segment, dataBlock, vector, levelCount, externalVector);
         }
 
         public void DeleteNode(byte index)


### PR DESCRIPTION
## Summary
- avoid converting enumerable LINQ selectors to multi-key expressions when creating vector indexes so the raw array is indexed
- add a regression test that loads the sample ingestion document and confirms vector inserts succeed
- copy the serialized ingestion sample to the test output so it can be consumed during the run

## Testing
- dotnet test LiteDB.Tests -f net8.0 --filter FullyQualifiedName~VectorIndex

------
https://chatgpt.com/codex/tasks/task_e_68d1c72a3304832ab63bb2d8f774a759