### PR TITLE
Introduce chunk-based vector search indexing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Check out repository
@@ -22,18 +25,40 @@ jobs:
         run: dotnet restore LiteDB.sln
 
       - name: Build
-        run: dotnet build LiteDB.sln --configuration Release --no-restore
+        run: dotnet build LiteDB.sln --configuration Release --no-restore /p:DefineConstants=TESTING
 
-      - name: Test
-        timeout-minutes: 5
-        continue-on-error: true
-        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed"
+      - name: Test (with hang diagnostics)
+        timeout-minutes: 8
+        env:
+          VSTEST_TESTHOST_HANG_DUMP_TYPE: full
+          VSTEST_TESTHOST_HANG_DUMP_FOLDER: ${{ github.workspace }}/hangdumps
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+          DOTNET_NOLOGO: 1
+        run: >-
+          dotnet test LiteDB.sln
+          --configuration Release
+          --no-build
+          --verbosity normal
+          --settings tests.ci.runsettings
+          --logger "trx;LogFileName=TestResults.trx"
+          --logger "console;verbosity=detailed"
+          --blame-hang --blame-hang-timeout 00:02:00
+          --diag "TestHost.diag.log;tracelevel=verbose"
+          /p:DefineConstants=TESTING
 
       - name: Upload test results
-        if: always()
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test-results
+          path: "**/*TestResults*.trx"
+
+      - name: Upload hang dumps (if any)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hangdumps
           path: |
-            **/TestResults.trx
-            **/TestResults/**/*
+            hangdumps
+            **/TestResults/**/*.dmp
+          if-no-files-found: ignore

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Check out repository
@@ -22,30 +25,74 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Set prerelease version
+        id: version
+        run: |
+          # Use SemVer-compliant prerelease without leading zeros
+          echo "package_version=6.0.0-prerelease.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          echo "Version set to 6.0.0-prerelease.${{ github.run_number }}"
+
       - name: Restore
         run: dotnet restore LiteDB.sln
 
-      - name: Build
-        run: dotnet build LiteDB.sln --configuration Release --no-restore
+      - name: Test (with hang diagnostics)
+        timeout-minutes: 8
+        env:
+          VSTEST_TESTHOST_HANG_DUMP_TYPE: full
+          VSTEST_TESTHOST_HANG_DUMP_FOLDER: ${{ github.workspace }}/hangdumps
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+          DOTNET_NOLOGO: 1
+        run: >-
+          dotnet test LiteDB.sln
+          --configuration Release
+          --verbosity normal
+          --settings tests.ci.runsettings
+          --logger "trx;LogFileName=TestResults.trx"
+          --logger "console;verbosity=detailed"
+          --blame-hang --blame-hang-timeout 00:02:00
+          --diag "TestHost.diag.log;tracelevel=verbose"
+          /p:DefineConstants=TESTING
 
-      - name: Test
-        timeout-minutes: 5
-        run: dotnet test LiteDB.sln --configuration Release --no-build --verbosity normal --settings tests.runsettings --logger "trx;LogFileName=TestResults.trx" --logger "console;verbosity=detailed"
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: "**/*TestResults*.trx"
+      
+      - name: Upload hang dumps (if any)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: hangdumps
+          path: |
+            hangdumps
+            **/TestResults/**/*.dmp
+          if-no-files-found: ignore
+
+      - name: Build
+        if: success()
+        run: dotnet build LiteDB/LiteDB.csproj --configuration Release --no-restore -p:Version=${{ steps.version.outputs.package_version }} -p:PackageVersion=${{ steps.version.outputs.package_version }} -p:MinVerSkip=true
 
       - name: Pack
-        run: |
-          dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts
+        if: success()
+        run: dotnet pack LiteDB/LiteDB.csproj --configuration Release --no-build -o artifacts -p:PackageVersion=${{ steps.version.outputs.package_version }} -p:Version=${{ steps.version.outputs.package_version }} -p:MinVerSkip=true
 
-      - name: Capture package version
-        id: version
-        run: |
-          PACKAGE_PATH=$(ls artifacts/LiteDB.*.nupkg | head -n 1)
-          PACKAGE_FILENAME=$(basename "$PACKAGE_PATH")
-          PACKAGE_VERSION=${PACKAGE_FILENAME#LiteDB.}
-          PACKAGE_VERSION=${PACKAGE_VERSION%.nupkg}
-          echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Publish GitHub prerelease
+        if: success()
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.package_version }}
+          name: LiteDB ${{ steps.version.outputs.package_version }}
+          generate_release_notes: true
+          prerelease: true
+          files: artifacts/*.nupkg
+          target_commitish: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Retrieve secrets from Bitwarden
+        if: success()
         uses: bitwarden/sm-action@v2
         with:
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
@@ -54,16 +101,7 @@ jobs:
             265b2fb6-2cf0-4859-9bc8-b24c00ab4378 > NUGET_API_KEY
 
       - name: Push package to NuGet
+        if: success()
         run: |
           dotnet nuget push "artifacts/*.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
-      - name: Publish GitHub prerelease
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.version.outputs.package_version }}
-          name: LiteDB ${{ steps.version.outputs.package_version }}
-          generate_release_notes: true
-          prerelease: true
-          files: artifacts/*.nupkg
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ConsoleApp1/Program.cs
+++ b/ConsoleApp1/Program.cs
@@ -27,7 +27,7 @@ try
 {
     using (var db = new LiteEngine(settings))
     {
-#if DEBUG
+#if DEBUG || TESTING
         db.SimulateDiskWriteFail = (page) =>
         {
             var p = new BasePage(page);

--- a/LiteDB.Demo.Tools.VectorSearch/Models/IndexedDocumentChunk.cs
+++ b/LiteDB.Demo.Tools.VectorSearch/Models/IndexedDocumentChunk.cs
@@ -1,0 +1,19 @@
+using System;
+using LiteDB;
+
+namespace LiteDB.Demo.Tools.VectorSearch.Models
+{
+    public sealed class IndexedDocumentChunk
+    {
+        public ObjectId Id { get; set; } = ObjectId.Empty;
+
+        public string Path { get; set; } = string.Empty;
+
+        public int ChunkIndex { get; set; }
+
+        public string Snippet { get; set; } = string.Empty;
+
+        public float[] Embedding { get; set; } = Array.Empty<float>();
+    }
+}
+

--- a/LiteDB.RollbackRepro/LiteDB.RollbackRepro.csproj
+++ b/LiteDB.RollbackRepro/LiteDB.RollbackRepro.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+  
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.RollbackRepro/Program.cs
+++ b/LiteDB.RollbackRepro/Program.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using LiteDB;
+
+namespace LiteDB.RollbackRepro;
+
+/// <summary>
+/// Repro of #2586
+/// To repro after the patch, set ``<PackageReference Include="LiteDB" Version="5.0.20" />``
+/// </summary>
+internal static class Program
+{
+    private const int HolderTransactionCount = 99;
+    private const int DocumentWriteCount = 10_000;
+
+    private static void Main()
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var databasePath = Path.Combine(AppContext.BaseDirectory, "rollback-crash.db");
+        Console.WriteLine($"Database path: {databasePath}");
+
+        if (File.Exists(databasePath))
+        {
+            Console.WriteLine("Deleting previous database file.");
+            File.Delete(databasePath);
+        }
+
+        var connectionString = new ConnectionString
+        {
+            Filename = databasePath,
+            Connection = ConnectionType.Direct
+        };
+
+        using var db = new LiteDatabase(connectionString);
+        var collection = db.GetCollection<LargeDocument>("documents");
+
+        using var releaseHolders = new ManualResetEventSlim(false);
+        using var holdersReady = new CountdownEvent(HolderTransactionCount);
+
+        var holderThreads = StartGuardTransactions(db, holdersReady, releaseHolders);
+
+        holdersReady.Wait();
+        Console.WriteLine($"Spawned {HolderTransactionCount} background transactions to exhaust the shared transaction memory pool.");
+
+        try
+        {
+            RunFailingTransaction(db, collection);
+        }
+        catch (LiteException liteException)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Captured expected LiteDB.LiteException:");
+            Console.WriteLine(liteException);
+        }
+        finally
+        {
+            releaseHolders.Set();
+
+            foreach (var thread in holderThreads)
+            {
+                thread.Join();
+            }
+
+            stopwatch.Stop();
+            Console.WriteLine($"Total elapsed time: {stopwatch.Elapsed}.");
+        }
+    }
+
+    private static IReadOnlyList<Thread> StartGuardTransactions(LiteDatabase db, CountdownEvent ready, ManualResetEventSlim release)
+    {
+        var threads = new List<Thread>(HolderTransactionCount);
+
+        for (var i = 0; i < HolderTransactionCount; i++)
+        {
+            var thread = new Thread(() => HoldTransaction(db, ready, release))
+            {
+                IsBackground = true,
+                Name = $"Holder-{i:D2}"
+            };
+
+            thread.Start();
+            threads.Add(thread);
+        }
+
+        return threads;
+    }
+
+    private static void HoldTransaction(LiteDatabase db, CountdownEvent ready, ManualResetEventSlim release)
+    {
+        var threadId = Thread.CurrentThread.ManagedThreadId;
+        var began = false;
+
+        try
+        {
+            began = db.BeginTrans();
+            if (!began)
+            {
+                Console.WriteLine($"[{threadId}] BeginTrans returned false for holder transaction.");
+            }
+        }
+        catch (LiteException ex)
+        {
+            Console.WriteLine($"[{threadId}] Failed to start holder transaction: {ex.Message}");
+        }
+        finally
+        {
+            ready.Signal();
+        }
+
+        if (!began)
+        {
+            return;
+        }
+
+        try
+        {
+            release.Wait();
+        }
+        finally
+        {
+            try
+            {
+                db.Rollback();
+            }
+            catch (LiteException ex)
+            {
+                Console.WriteLine($"[{threadId}] Holder rollback threw: {ex.Message}");
+            }
+        }
+    }
+
+    private static void RunFailingTransaction(LiteDatabase db, ILiteCollection<LargeDocument> collection)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Starting write transaction on thread {Thread.CurrentThread.ManagedThreadId}.");
+
+        if (!db.BeginTrans())
+        {
+            throw new InvalidOperationException("Failed to begin primary transaction for reproduction.");
+        }
+
+        TransactionInspector? inspector = null;
+        var maxSize = 0;
+        var safepointTriggered = false;
+        var shouldTriggerSafepoint = false;
+
+        var payloadA = new string('A', 4_096);
+        var payloadB = new string('B', 4_096);
+        var payloadC = new string('C', 2_048);
+        var largeBinary = new byte[128 * 1024];
+
+        var commitRequested = false;
+
+        try
+        {
+            for (var i = 0; i < DocumentWriteCount; i++)
+            {
+                if (shouldTriggerSafepoint && !safepointTriggered)
+                {
+                    inspector ??= TransactionInspector.Attach(db);
+
+                    Console.WriteLine();
+                    Console.WriteLine($"Manually invoking safepoint before processing document #{i:N0}.");
+
+                    inspector.InvokeSafepoint();
+                    // Safepoint transitions all dirty buffers into the readable cache. Manually
+                    // mark the collection page as readable to mirror the race condition described
+                    // in the bug investigation before triggering the rollback path.
+                    inspector.ForceCollectionPageShareCounter(1);
+
+                    safepointTriggered = true;
+
+                    throw new InvalidOperationException("Simulating transaction failure after safepoint flush.");
+                }
+
+                var document = new LargeDocument
+                {
+                    Id = i,
+                    BatchId = Guid.NewGuid(),
+                    CreatedUtc = DateTime.UtcNow,
+                    Description = $"Large document #{i:N0}",
+                    Payload1 = payloadA,
+                    Payload2 = payloadB,
+                    Payload3 = payloadC,
+                    LargePayload = largeBinary
+                };
+
+                collection.Upsert(document);
+
+                if (i % 100 == 0)
+                {
+                    Console.WriteLine($"Upserted {i:N0} documents...");
+                }
+
+                inspector ??= TransactionInspector.Attach(db);
+
+                var currentSize = inspector.CurrentSize;
+                maxSize = Math.Max(maxSize, inspector.MaxSize);
+
+                if (!shouldTriggerSafepoint && currentSize >= maxSize)
+                {
+                    shouldTriggerSafepoint = true;
+                    Console.WriteLine($"Queued safepoint after reaching transaction size {currentSize} at document #{i + 1:N0}.");
+                }
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Simulating failure after safepoint flush.");
+            throw new InvalidOperationException("Simulating transaction failure after safepoint flush.");
+        }
+        catch (Exception ex) when (ex is not LiteException)
+        {
+            Console.WriteLine($"Caught application exception: {ex.Message}");
+            Console.WriteLine("Requesting rollback — this should trigger 'discarded page must be writable'.");
+
+            var shareCounter = inspector?.GetCollectionShareCounter();
+            if (shareCounter.HasValue)
+            {
+                Console.WriteLine($"Collection page share counter before rollback: {shareCounter.Value}.");
+            }
+
+            if (inspector is not null)
+            {
+                foreach (var (pageId, pageType, counter) in inspector.EnumerateWritablePages())
+                {
+                    Console.WriteLine($"Writable page {pageId} ({pageType}) share counter: {counter}.");
+                }
+            }
+
+            db.Rollback();
+  
+            var color = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Green;
+            Console.WriteLine("Rollback returned without throwing — the bug did not reproduce.");
+            Console.ForegroundColor = color;
+            // throw;
+            return;
+        }
+        finally
+        {
+            if (commitRequested)
+            {
+                db.Commit();
+            }
+        }
+        
+        var colorFg = Console.ForegroundColor;
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine("Rollback threw LiteException — the bug reproduced.");
+        Console.ForegroundColor = colorFg;
+    }
+
+    private sealed class LargeDocument
+    {
+        public int Id { get; set; }
+        public Guid BatchId { get; set; }
+        public DateTime CreatedUtc { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public string Payload1 { get; set; } = string.Empty;
+        public string Payload2 { get; set; } = string.Empty;
+        public string Payload3 { get; set; } = string.Empty;
+        public byte[] LargePayload { get; set; } = Array.Empty<byte>();
+    }
+
+    private sealed class TransactionInspector
+    {
+        private readonly object _transaction;
+        private readonly object _transactionPages;
+        private readonly object _snapshot;
+        private readonly PropertyInfo _transactionSizeProperty;
+        private readonly PropertyInfo _maxTransactionSizeProperty;
+        private readonly PropertyInfo _collectionPageProperty;
+        private readonly PropertyInfo _bufferProperty;
+        private readonly FieldInfo _shareCounterField;
+        private readonly MethodInfo _safepointMethod;
+
+        private TransactionInspector(
+            object transaction,
+            object transactionPages,
+            object snapshot,
+            PropertyInfo transactionSizeProperty,
+            PropertyInfo maxTransactionSizeProperty,
+            PropertyInfo collectionPageProperty,
+            PropertyInfo bufferProperty,
+            FieldInfo shareCounterField,
+            MethodInfo safepointMethod)
+        {
+            _transaction = transaction;
+            _transactionPages = transactionPages;
+            _snapshot = snapshot;
+            _transactionSizeProperty = transactionSizeProperty;
+            _maxTransactionSizeProperty = maxTransactionSizeProperty;
+            _collectionPageProperty = collectionPageProperty;
+            _bufferProperty = bufferProperty;
+            _shareCounterField = shareCounterField;
+            _safepointMethod = safepointMethod;
+        }
+
+        public int CurrentSize => (int)_transactionSizeProperty.GetValue(_transactionPages)!;
+
+        public int MaxSize => (int)_maxTransactionSizeProperty.GetValue(_transaction)!;
+
+        public int? GetCollectionShareCounter()
+        {
+            var collectionPage = _collectionPageProperty.GetValue(_snapshot);
+
+            if (collectionPage is null)
+            {
+                return null;
+            }
+
+            var buffer = _bufferProperty.GetValue(collectionPage);
+
+            return buffer is null ? null : (int?)_shareCounterField.GetValue(buffer);
+        }
+
+        public void InvokeSafepoint()
+        {
+            _safepointMethod.Invoke(_transaction, Array.Empty<object>());
+        }
+
+        public void ForceCollectionPageShareCounter(int shareCounter)
+        {
+            var collectionPage = _collectionPageProperty.GetValue(_snapshot);
+
+            if (collectionPage is null)
+            {
+                return;
+            }
+
+            var buffer = _bufferProperty.GetValue(collectionPage);
+
+            if (buffer is null)
+            {
+                return;
+            }
+
+            _shareCounterField.SetValue(buffer, shareCounter);
+        }
+
+        public IEnumerable<(uint PageId, string PageType, int ShareCounter)> EnumerateWritablePages()
+        {
+            var getPagesMethod = _snapshot.GetType().GetMethod(
+                "GetWritablePages",
+                BindingFlags.Public | BindingFlags.Instance,
+                binder: null,
+                new[] { typeof(bool), typeof(bool) },
+                modifiers: null)
+                ?? throw new InvalidOperationException("GetWritablePages method not found on snapshot.");
+
+            if (getPagesMethod.Invoke(_snapshot, new object[] { true, true }) is not IEnumerable<object> pages)
+            {
+                yield break;
+            }
+
+            foreach (var page in pages)
+            {
+                var pageIdProperty = page.GetType().GetProperty("PageID", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("PageID property not found on page.");
+
+                var pageTypeProperty = page.GetType().GetProperty("PageType", BindingFlags.Public | BindingFlags.Instance)
+                                       ?? throw new InvalidOperationException("PageType property not found on page.");
+
+                var bufferProperty = page.GetType().GetProperty("Buffer", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("Buffer property not found on page.");
+
+                var buffer = bufferProperty.GetValue(page);
+
+                if (buffer is null)
+                {
+                    continue;
+                }
+
+                var pageId = (uint)pageIdProperty.GetValue(page)!;
+                var pageTypeName = pageTypeProperty.GetValue(page)?.ToString() ?? "<unknown>";
+                var shareCounter = (int)_shareCounterField.GetValue(buffer)!;
+
+                yield return (pageId, pageTypeName, shareCounter);
+            }
+        }
+
+        public static TransactionInspector Attach(LiteDatabase db)
+        {
+            var engineField = typeof(LiteDatabase).GetField("_engine", BindingFlags.NonPublic | BindingFlags.Instance)
+                              ?? throw new InvalidOperationException("Unable to locate LiteDatabase engine field.");
+
+            var engine = engineField.GetValue(db) ?? throw new InvalidOperationException("LiteDatabase engine is not initialized.");
+
+            var monitorField = engine.GetType().GetField("_monitor", BindingFlags.NonPublic | BindingFlags.Instance)
+                               ?? throw new InvalidOperationException("Unable to locate TransactionMonitor field.");
+
+            var monitor = monitorField.GetValue(engine) ?? throw new InvalidOperationException("TransactionMonitor is unavailable.");
+
+            var getThreadTransaction = monitor.GetType().GetMethod("GetThreadTransaction", BindingFlags.Public | BindingFlags.Instance)
+                                       ?? throw new InvalidOperationException("GetThreadTransaction method not found.");
+
+            var transaction = getThreadTransaction.Invoke(monitor, Array.Empty<object>())
+                ?? throw new InvalidOperationException("Current thread transaction is not available.");
+
+            var pagesProperty = transaction.GetType().GetProperty("Pages", BindingFlags.Public | BindingFlags.Instance)
+                                 ?? throw new InvalidOperationException("Transaction.Pages property not found.");
+
+            var transactionPages = pagesProperty.GetValue(transaction)
+                ?? throw new InvalidOperationException("Transaction pages are not available.");
+
+            var transactionSizeProperty = transactionPages.GetType().GetProperty("TransactionSize", BindingFlags.Public | BindingFlags.Instance)
+                                          ?? throw new InvalidOperationException("TransactionSize property not found.");
+
+            var maxTransactionSizeProperty = transaction.GetType().GetProperty("MaxTransactionSize", BindingFlags.Public | BindingFlags.Instance)
+                                             ?? throw new InvalidOperationException("MaxTransactionSize property not found.");
+
+            var snapshotsProperty = transaction.GetType().GetProperty("Snapshots", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("Snapshots property not found.");
+
+            if (snapshotsProperty.GetValue(transaction) is not IEnumerable<object> snapshots)
+            {
+                throw new InvalidOperationException("Snapshots collection not available.");
+            }
+
+            var snapshot = snapshots.Cast<object>().FirstOrDefault()
+                ?? throw new InvalidOperationException("No snapshots available for the current transaction.");
+
+            var collectionPageProperty = snapshot.GetType().GetProperty("CollectionPage", BindingFlags.Public | BindingFlags.Instance)
+                                         ?? throw new InvalidOperationException("CollectionPage property not found.");
+
+            var collectionPageType = collectionPageProperty.PropertyType;
+
+            var bufferProperty = collectionPageType.GetProperty("Buffer", BindingFlags.Public | BindingFlags.Instance)
+                                   ?? throw new InvalidOperationException("Buffer property not found on collection page.");
+
+            var shareCounterField = bufferProperty.PropertyType.GetField("ShareCounter", BindingFlags.Public | BindingFlags.Instance)
+                                     ?? throw new InvalidOperationException("ShareCounter field not found on page buffer.");
+
+            var safepointMethod = transaction.GetType().GetMethod("Safepoint", BindingFlags.Public | BindingFlags.Instance)
+                                   ?? throw new InvalidOperationException("Safepoint method not found on transaction service.");
+
+            return new TransactionInspector(
+                transaction,
+                transactionPages,
+                snapshot,
+                transactionSizeProperty,
+                maxTransactionSizeProperty,
+                collectionPageProperty,
+                bufferProperty,
+                shareCounterField,
+                safepointMethod);
+        }
+    }
+}

--- a/LiteDB.Stress/Test/TestExecution.cs
+++ b/LiteDB.Stress/Test/TestExecution.cs
@@ -47,7 +47,10 @@ namespace LiteDB.Stress
             this.CreateThreads();
 
             // start report thread
-            var t = new Thread(() => this.ReportThread());
+            var t = new Thread(() => this.ReportThread())
+            {
+                IsBackground = true
+            };
             t.Name = "REPORT";
             t.Start();
         }
@@ -100,7 +103,10 @@ namespace LiteDB.Stress
                             info.Counter++;
                             info.LastRun = DateTime.Now;
                         }
-                    });
+                    })
+                    {
+                        IsBackground = true
+                    };
 
                     _threads[thread.ManagedThreadId] = new ThreadInfo
                     {

--- a/LiteDB.Tests/Engine/Collation_Tests.cs
+++ b/LiteDB.Tests/Engine/Collation_Tests.cs
@@ -33,7 +33,10 @@ namespace LiteDB.Tests.Engine
                 e.Insert("col1", names.Select(x => new BsonDocument { ["name"] = x }), BsonAutoId.Int32);
 
                 // sort by merge sort
-                var sortByOrderByName = e.Query("col1", new Query { OrderBy = "name" })
+                var orderQuery = new Query();
+                orderQuery.OrderBy.Add(new QueryOrder("name", Query.Ascending));
+
+                var sortByOrderByName = e.Query("col1", orderQuery)
                     .ToEnumerable()
                     .Select(x => x["name"].AsString)
                     .ToArray();
@@ -53,8 +56,11 @@ namespace LiteDB.Tests.Engine
                 // index test
                 e.EnsureIndex("col1", "idx_name", "name", false);
 
+                var indexOrderQuery = new Query();
+                indexOrderQuery.OrderBy.Add(new QueryOrder("name", Query.Ascending));
+
                 // sort by index
-                var sortByIndexName = e.Query("col1", new Query { OrderBy = "name" })
+                var sortByIndexName = e.Query("col1", indexOrderQuery)
                     .ToEnumerable()
                     .Select(x => x["name"].AsString)
                     .ToArray();

--- a/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
+++ b/LiteDB.Tests/Engine/Rebuild_Crash_Tests.cs
@@ -1,91 +1,121 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using LiteDB.Engine;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Xunit;
+using Xunit.Abstractions;
 
 #if DEBUG
 namespace LiteDB.Tests.Engine
 {
     public class Rebuild_Crash_Tests
     {
+        private readonly ITestOutputHelper _output;
+
+        public Rebuild_Crash_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         [Fact]
         public void Rebuild_Crash_IO_Write_Error()
         {
-            var N = 1_000;
-
-            using (var file = new TempFile())
+            _output.WriteLine("Running Rebuild_Crash_IO_Write_Error");
+            try
             {
-                var settings = new EngineSettings
-                {
-                    AutoRebuild = true,
-                    Filename = file.Filename,
-                    Password = "46jLz5QWd5fI3m4LiL2r"
-                };
+                var N = 1_000;
 
-                var data = Enumerable.Range(1, N).Select(i => new BsonDocument
+                using (var file = new TempFile())
                 {
-                    ["_id"] = i,
-                    ["name"] = Faker.Fullname(),
-                    ["age"] = Faker.Age(),
-                    ["created"] = Faker.Birthday(),
-                    ["lorem"] = Faker.Lorem(5, 25)
-                }).ToArray();
+                    var settings = new EngineSettings
+                    {
+                        AutoRebuild = true,
+                        Filename = file.Filename,
+                        Password = "46jLz5QWd5fI3m4LiL2r"
+                    };
 
-                try
-                {
+                    var data = Enumerable.Range(1, N).Select(i => new BsonDocument
+                    {
+                        ["_id"] = i,
+                        ["name"] = Faker.Fullname(),
+                        ["age"] = Faker.Age(),
+                        ["created"] = Faker.Birthday(),
+                        ["lorem"] = Faker.Lorem(5, 25)
+                    }).ToArray();
+
+                    var faultInjected = 0;
+
+                    try
+                    {
+                        using (var db = new LiteEngine(settings))
+                        {
+                            var writeHits = 0;
+
+                            db.SimulateDiskWriteFail = (page) =>
+                            {
+                                var p = new BasePage(page);
+
+                                if (p.PageType == PageType.Data && p.ColID == 1)
+                                {
+                                    var hit = Interlocked.Increment(ref writeHits);
+
+                                    if (hit == 10)
+                                    {
+                                        p.PageType.Should().Be(PageType.Data);
+                                        p.ColID.Should().Be(1);
+
+                                        page.Write((uint)123123123, 8192 - 4);
+
+                                        Interlocked.Exchange(ref faultInjected, 1);
+                                    }
+                                }
+                            };
+
+                            db.Pragma("USER_VERSION", 123);
+
+                            db.EnsureIndex("col1", "idx_age", "$.age", false);
+
+                            db.Insert("col1", data, BsonAutoId.Int32);
+                            db.Insert("col2", data, BsonAutoId.Int32);
+
+                            db.Checkpoint();
+
+                            // will fail
+                            var col1 = db.Query("col1", Query.All()).ToList().Count;
+
+                            // never run here
+                            Assert.Fail("should get error in query");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        faultInjected.Should().Be(1, "the simulated disk write fault should have triggered");
+
+                        Assert.True(ex is LiteException lex && lex.ErrorCode == 999);
+                    }
+
+                    //Console.WriteLine("Recovering database...");
+
                     using (var db = new LiteEngine(settings))
                     {
-                        db.SimulateDiskWriteFail = (page) =>
-                        {
-                            var p = new BasePage(page);
-
-                            if (p.PageID == 28)
-                            {
-                                p.ColID.Should().Be(1);
-                                p.PageType.Should().Be(PageType.Data);
-
-                                page.Write((uint)123123123, 8192 - 4);
-                            }
-                        };
-
-                        db.Pragma("USER_VERSION", 123);
-
-                        db.EnsureIndex("col1", "idx_age", "$.age", false);
-
-                        db.Insert("col1", data, BsonAutoId.Int32);
-                        db.Insert("col2", data, BsonAutoId.Int32);
-
-                        db.Checkpoint();
-
-                        // will fail
                         var col1 = db.Query("col1", Query.All()).ToList().Count;
+                        var col2 = db.Query("col2", Query.All()).ToList().Count;
+                        var errors = db.Query("_rebuild_errors", Query.All()).ToList().Count;
 
-                        // never run here
-                        Assert.Fail("should get error in query");
+                        col1.Should().Be(N - 1);
+                        col2.Should().Be(N);
+                        errors.Should().Be(1);
+
                     }
                 }
-                catch (Exception ex)
-                {
-                    Assert.True(ex is LiteException lex && lex.ErrorCode == 999);
-                }
-
-                //Console.WriteLine("Recovering database...");
-
-                using (var db = new LiteEngine(settings))
-                {
-                    var col1 = db.Query("col1", Query.All()).ToList().Count;
-                    var col2 = db.Query("col2", Query.All()).ToList().Count;
-                    var errors = db.Query("_rebuild_errors", Query.All()).ToList().Count;
-
-                    col1.Should().Be(N - 1);
-                    col2.Should().Be(N);
-                    errors.Should().Be(1);
-
-                }
+            }
+            finally
+            {
+                _output.WriteLine("Finished running Rebuild_Crash_IO_Write_Error");
             }
         }
     }

--- a/LiteDB.Tests/Engine/Recursion_Tests.cs
+++ b/LiteDB.Tests/Engine/Recursion_Tests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace LiteDB.Tests.Engine;
 
+[Collection("SharedDemoDatabase")]
 public class Recursion_Tests
 {
     [Fact]

--- a/LiteDB.Tests/Internals/Sort_Tests.cs
+++ b/LiteDB.Tests/Internals/Sort_Tests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;
@@ -24,7 +24,7 @@ namespace LiteDB.Internals
             pragmas.Set(Pragmas.COLLATION, Collation.Binary.ToString(), false);
 
             using (var tempDisk = new SortDisk(_factory, 10 * 8192, pragmas))
-            using (var s = new SortService(tempDisk, Query.Ascending, pragmas))
+            using (var s = new SortService(tempDisk, new[] { Query.Ascending }, pragmas))
             {
                 s.Insert(source);
 
@@ -52,7 +52,7 @@ namespace LiteDB.Internals
             pragmas.Set(Pragmas.COLLATION, Collation.Binary.ToString(), false);
 
             using (var tempDisk = new SortDisk(_factory, 8192, pragmas))
-            using (var s = new SortService(tempDisk, Query.Descending, pragmas))
+            using (var s = new SortService(tempDisk, [Query.Descending], pragmas))
             {
                 s.Insert(source);
 

--- a/LiteDB.Tests/Issues/Issue2534_Tests.cs
+++ b/LiteDB.Tests/Issues/Issue2534_Tests.cs
@@ -2,6 +2,7 @@
 
 namespace LiteDB.Tests.Issues;
 
+[Collection("SharedDemoDatabase")]
 public class Issue2534_Tests
 {
     [Fact]

--- a/LiteDB.Tests/Issues/IssueCheckpointFlush_Tests.cs
+++ b/LiteDB.Tests/Issues/IssueCheckpointFlush_Tests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO;
+using FluentAssertions;
+using LiteDB;
+using LiteDB.Tests;
+using Xunit;
+
+namespace LiteDB.Tests.Issues
+{
+    public class IssueCheckpointFlush_Tests
+    {
+        private class Entity
+        {
+            public int Id { get; set; }
+
+            public string Value { get; set; } = string.Empty;
+        }
+
+        [Fact]
+        public void CommittedChangesAreLostWhenClosingExternalStreamWithoutCheckpoint()
+        {
+            using var tempFile = new TempFile();
+
+            using (var createStream = new FileStream(tempFile.Filename, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite))
+            {
+                using var createDb = new LiteDatabase(createStream);
+                var collection = createDb.GetCollection<Entity>("entities");
+
+                collection.Upsert(new Entity { Id = 1, Value = "initial" });
+
+                createDb.Commit();
+                createStream.Flush(true);
+            }
+
+            var updateStream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            var updateDb = new LiteDatabase(updateStream);
+            var updateCollection = updateDb.GetCollection<Entity>("entities");
+
+            updateCollection.Upsert(new Entity { Id = 1, Value = "updated" });
+
+            updateDb.Commit();
+            updateStream.Flush(true);
+            updateStream.Dispose();
+            updateDb = null;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            using (var verifyStream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var verifyDb = new LiteDatabase(verifyStream))
+            {
+                var document = verifyDb.GetCollection<Entity>("entities").FindById(1);
+
+                document.Should().NotBeNull();
+                document!.Value.Should().Be("updated");
+            }
+        }
+
+        [Fact]
+        public void StreamConstructorRestoresCheckpointSizeAfterDisposal()
+        {
+            using var tempFile = new TempFile();
+
+            using (var fileDb = new LiteDatabase(tempFile.Filename))
+            {
+                fileDb.CheckpointSize.Should().Be(1000);
+            }
+
+            using (var stream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite))
+            using (var streamDb = new LiteDatabase(stream))
+            {
+                streamDb.CheckpointSize.Should().Be(1);
+            }
+
+            using (var reopened = new LiteDatabase(tempFile.Filename))
+            {
+                reopened.CheckpointSize.Should().Be(1000);
+            }
+        }
+
+        [Fact]
+        public void StreamConstructorAllowsReadOnlyStreams()
+        {
+            using var tempFile = new TempFile();
+
+            using (var setup = new LiteDatabase(tempFile.Filename))
+            {
+                var collection = setup.GetCollection<Entity>("entities");
+
+                collection.Insert(new Entity { Id = 1, Value = "initial" });
+
+                setup.Checkpoint();
+            }
+
+            using var readOnlyStream = new FileStream(tempFile.Filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var readOnlyDb = new LiteDatabase(readOnlyStream);
+
+            var document = readOnlyDb.GetCollection<Entity>("entities").FindById(1);
+
+            document.Should().NotBeNull();
+            document!.Value.Should().Be("initial");
+        }
+    }
+}

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">

--- a/LiteDB.Tests/Query/OrderBy_Tests.cs
+++ b/LiteDB.Tests/Query/OrderBy_Tests.cs
@@ -1,5 +1,9 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
+using LiteDB.Engine;
+using LiteDB.Tests.Utils;
 using Xunit;
 
 namespace LiteDB.Tests.QueryTest
@@ -16,12 +20,12 @@ namespace LiteDB.Tests.QueryTest
 
             var r0 = local
                 .OrderBy(x => x.Name)
-                .Select(x => new {x.Name})
+                .Select(x => new { x.Name })
                 .ToArray();
 
             var r1 = collection.Query()
                 .OrderBy(x => x.Name)
-                .Select(x => new {x.Name})
+                .Select(x => new { x.Name })
                 .ToArray();
 
             r0.Should().Equal(r1);
@@ -37,12 +41,12 @@ namespace LiteDB.Tests.QueryTest
 
             var r0 = local
                 .OrderByDescending(x => x.Name)
-                .Select(x => new {x.Name})
+                .Select(x => new { x.Name })
                 .ToArray();
 
             var r1 = collection.Query()
                 .OrderByDescending(x => x.Name)
-                .Select(x => new {x.Name})
+                .Select(x => new { x.Name })
                 .ToArray();
 
             r0.Should().Equal(r1);
@@ -58,12 +62,12 @@ namespace LiteDB.Tests.QueryTest
 
             var r0 = local
                 .OrderBy(x => x.Date.Day)
-                .Select(x => new {d = x.Date.Day})
+                .Select(x => new { d = x.Date.Day })
                 .ToArray();
 
             var r1 = collection.Query()
                 .OrderBy(x => x.Date.Day)
-                .Select(x => new {d = x.Date.Day})
+                .Select(x => new { d = x.Date.Day })
                 .ToArray();
 
             r0.Should().Equal(r1);
@@ -105,6 +109,487 @@ namespace LiteDB.Tests.QueryTest
 
             asc[0].Id.Should().Be(1);
             desc[0].Id.Should().Be(1000);
+        }
+
+        [Fact]
+        public void Query_OrderBy_ThenBy_Multiple_Keys()
+        {
+            using var db = new PersonQueryData();
+            var (collection, local) = db.GetData();
+
+            collection.EnsureIndex(x => x.Age);
+
+            var expected = local
+                .OrderBy(x => x.Age)
+                .ThenByDescending(x => x.Name)
+                .Select
+                (
+                    x => new
+                    {
+                        x.Age,
+                        x.Name
+                    }
+                )
+                .ToArray();
+
+            var actual = collection.Query()
+                .OrderBy(x => x.Age)
+                .ThenByDescending(x => x.Name)
+                .Select
+                (
+                    x => new
+                    {
+                        x.Age,
+                        x.Name
+                    }
+                )
+                .ToArray();
+
+            actual.Should().Equal(expected);
+
+            var plan = collection.Query()
+                .OrderBy(x => x.Age)
+                .ThenByDescending(x => x.Name)
+                .GetPlan();
+
+            plan["index"]["order"].AsInt32.Should().Be(Query.Ascending);
+
+            var orderBy = plan["orderBy"].AsArray;
+
+            orderBy.Count.Should().Be(2);
+            orderBy[0]["expr"].AsString.Should().Be("$.Age");
+            orderBy[0]["order"].AsInt32.Should().Be(Query.Ascending);
+            orderBy[1]["expr"].AsString.Should().Be("$.Name");
+            orderBy[1]["order"].AsInt32.Should().Be(Query.Descending);
+        }
+
+        [Fact]
+        public void Query_OrderByDescending_ThenBy_Index_Order_Applied()
+        {
+            using var db = new PersonQueryData();
+            var (collection, local) = db.GetData();
+
+            collection.EnsureIndex(x => x.Name);
+            collection.EnsureIndex(x => x.Age);
+
+            var expected = local
+                .OrderByDescending(x => x.Age)
+                .ThenBy(x => x.Name)
+                .Select
+                (
+                    x => new
+                    {
+                        x.Name,
+                        x.Age
+                    }
+                )
+                .ToArray();
+
+            var actual = collection.Query()
+                .OrderByDescending(x => x.Age)
+                .ThenBy(x => x.Name)
+                .Select
+                (
+                    x => new
+                    {
+                        x.Name,
+                        x.Age
+                    }
+                )
+                .ToArray();
+
+            actual.Should().Equal(expected);
+
+            var plan = collection.Query()
+                .OrderByDescending(x => x.Name)
+                .ThenBy(x => x.Age)
+                .GetPlan();
+
+            plan["index"]["order"].AsInt32.Should().Be(Query.Descending);
+
+            var orderBy = plan["orderBy"].AsArray;
+
+            orderBy.Count.Should().Be(2);
+            orderBy[0]["order"].AsInt32.Should().Be(Query.Descending);
+            orderBy[1]["order"].AsInt32.Should().Be(Query.Ascending);
+        }
+
+        public record Data(int Id, int Value);
+
+        [Fact]
+        public void Query_OrderByDescending_ThenBy_Index_Order_Applied_Data2()
+        {
+            var data = Enumerable
+                .Range(1, 1000)
+                .Select(x => new Data(x, new Random(x).Next())) // pseudo random
+                .ToArray();
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<Data>("data");
+            col.EnsureIndex(x => x.Value);
+            col.EnsureIndex(x => x.Id);
+            col.Insert(data);
+
+            var expected = data
+                .OrderByDescending(x => x.Value)
+                .ThenBy(x => x.Id)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderByDescending(x => x.Value)
+                .ThenBy(x => x.Id)
+                .ToArray();
+
+            expected.Should().Equal(actual);
+        }
+
+        [Fact]
+        public void Query_OrderByAscending_ThenByDescending_Index_Order_Applied_Data2()
+        {
+            var data = Enumerable
+                .Range(1, 1000)
+                .Select(x => new Data(x, new Random(x).Next())) // pseudo random
+                .ToArray();
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<Data>("data");
+            col.EnsureIndex(x => x.Value);
+            col.EnsureIndex(x => x.Id);
+            col.Insert(data);
+
+            var expected = data
+                .OrderBy(x => x.Value)
+                .ThenByDescending(x => x.Id)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderBy(x => x.Value)
+                .ThenByDescending(x => x.Id)
+                .ToArray();
+
+            expected.Should().Equal(actual);
+        }
+
+        [Fact]
+        public void Query_OrderByAscending_ThenByAscending_Index_Order_Applied_Data2()
+        {
+            var data = Enumerable
+                .Range(1, 1000)
+                .Select(x => new Data(x, new Random(x).Next())) // pseudo random
+                .ToArray();
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<Data>("data");
+            col.EnsureIndex(x => x.Value);
+            col.EnsureIndex(x => x.Id);
+            col.Insert(data);
+
+            var expected = data
+                .OrderBy(x => x.Value)
+                .ThenBy(x => x.Id)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderBy(x => x.Value)
+                .ThenBy(x => x.Id)
+                .ToArray();
+
+            expected.Should().Equal(actual);
+        }
+
+        [Fact]
+        public void Query_OrderByDescending_ThenByDescending_Index_Order_Applied_Data2()
+        {
+            var data = Enumerable
+                .Range(1, 1000)
+                .Select(x => new Data(x, new Random(x).Next())) // pseudo random
+                .ToArray();
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<Data>("data");
+            col.EnsureIndex(x => x.Value);
+            col.EnsureIndex(x => x.Id);
+            col.Insert(data);
+
+            var expected = data
+                .OrderByDescending(x => x.Value)
+                .ThenByDescending(x => x.Id)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderByDescending(x => x.Value)
+                .ThenByDescending(x => x.Id)
+                .ToArray();
+
+            expected.Should().Equal(actual);
+        }
+
+        [Fact]
+        public void Query_Missmatch_Order()
+        {
+            var data = Enumerable
+                .Range(1, 1000)
+                .Select(x => new Data(x, new Random(x).Next())) // pseudo random
+                .ToArray();
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<Data>("data");
+            col.EnsureIndex(x => x.Value);
+            col.EnsureIndex(x => x.Id);
+            col.Insert(data);
+
+            var expected = data
+                .OrderBy(x => x.Value)
+                .ThenByDescending(x => x.Id)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderByDescending(x => x.Value)
+                .ThenBy(x => x.Id)
+                .ToArray();
+
+            expected.Should().NotEqual(actual);
+        }
+
+        public record ThreeLayerData(int Id, int Category, string Name, int Priority);
+
+        [Fact]
+        public void Query_ThreeLayer_Ascending_Ascending_Ascending()
+        {
+            var data = new[]
+            {
+                new ThreeLayerData(1, 1, "C", 3),
+                new ThreeLayerData(2, 1, "A", 2),
+                new ThreeLayerData(3, 1, "A", 1),
+                new ThreeLayerData(4, 2, "B", 2),
+                new ThreeLayerData(5, 2, "B", 1),
+                new ThreeLayerData(6, 1, "B", 1)
+            };
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<ThreeLayerData>("data");
+            col.EnsureIndex(x => x.Category);
+            col.EnsureIndex(x => x.Name);
+            col.EnsureIndex(x => x.Priority);
+            col.Insert(data);
+
+            var expected = data
+                .OrderBy(x => x.Category)
+                .ThenBy(x => x.Name)
+                .ThenBy(x => x.Priority)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderBy(x => x.Category)
+                .ThenBy(x => x.Name)
+                .ThenBy(x => x.Priority)
+                .ToArray();
+
+            actual.Should().Equal(expected);
+        }
+
+        [Fact]
+        public void Query_ThreeLayer_Descending_Ascending_Descending()
+        {
+            var data = new[]
+            {
+                new ThreeLayerData(1, 1, "C", 3),
+                new ThreeLayerData(2, 1, "A", 2),
+                new ThreeLayerData(3, 1, "A", 1),
+                new ThreeLayerData(4, 2, "B", 2),
+                new ThreeLayerData(5, 2, "B", 1),
+                new ThreeLayerData(6, 1, "B", 1),
+                new ThreeLayerData(7, 3, "A", 2),
+                new ThreeLayerData(8, 3, "A", 3)
+            };
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<ThreeLayerData>("data");
+            col.EnsureIndex(x => x.Category);
+            col.EnsureIndex(x => x.Name);
+            col.EnsureIndex(x => x.Priority);
+            col.Insert(data);
+
+            var expected = data
+                .OrderByDescending(x => x.Category)
+                .ThenBy(x => x.Name)
+                .ThenByDescending(x => x.Priority)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderByDescending(x => x.Category)
+                .ThenBy(x => x.Name)
+                .ThenByDescending(x => x.Priority)
+                .ToArray();
+
+            actual.Should().Equal(expected);
+        }
+
+        [Fact]
+        public void Query_ThreeLayer_Ascending_Descending_Ascending()
+        {
+            var data = new[]
+            {
+                new ThreeLayerData(1, 1, "C", 3),
+                new ThreeLayerData(2, 1, "A", 2),
+                new ThreeLayerData(3, 1, "A", 1),
+                new ThreeLayerData(4, 2, "B", 2),
+                new ThreeLayerData(5, 2, "B", 1),
+                new ThreeLayerData(6, 1, "B", 1),
+                new ThreeLayerData(7, 2, "A", 3),
+                new ThreeLayerData(8, 2, "C", 1)
+            };
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<ThreeLayerData>("data");
+            col.EnsureIndex(x => x.Category);
+            col.EnsureIndex(x => x.Name);
+            col.EnsureIndex(x => x.Priority);
+            col.Insert(data);
+
+            var expected = data
+                .OrderBy(x => x.Category)
+                .ThenByDescending(x => x.Name)
+                .ThenBy(x => x.Priority)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderBy(x => x.Category)
+                .ThenByDescending(x => x.Name)
+                .ThenBy(x => x.Priority)
+                .ToArray();
+
+            actual.Should().Equal(expected);
+        }
+
+        [Fact]
+        public void Query_ThreeLayer_Descending_Descending_Descending()
+        {
+            var data = new[]
+            {
+                new ThreeLayerData(1, 1, "C", 3),
+                new ThreeLayerData(2, 1, "A", 2),
+                new ThreeLayerData(3, 1, "A", 1),
+                new ThreeLayerData(4, 2, "B", 2),
+                new ThreeLayerData(5, 2, "B", 1),
+                new ThreeLayerData(6, 1, "B", 1),
+                new ThreeLayerData(7, 3, "A", 2),
+                new ThreeLayerData(8, 3, "D", 4)
+            };
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<ThreeLayerData>("data");
+            col.EnsureIndex(x => x.Category);
+            col.EnsureIndex(x => x.Name);
+            col.EnsureIndex(x => x.Priority);
+            col.Insert(data);
+
+            var expected = data
+                .OrderByDescending(x => x.Category)
+                .ThenByDescending(x => x.Name)
+                .ThenByDescending(x => x.Priority)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderByDescending(x => x.Category)
+                .ThenByDescending(x => x.Name)
+                .ThenByDescending(x => x.Priority)
+                .ToArray();
+
+            actual.Should().Equal(expected);
+        }
+
+        [Fact]
+        public void Query_ThreeLayer_With_Large_Dataset()
+        {
+            var random = new Random(42); // Fixed seed for reproducible results
+            var data = Enumerable
+                .Range(1, 1000)
+                .Select(x => new ThreeLayerData(
+                    0,
+                    random.Next(1, 5), // Category 1-4
+                    ((char)('A' + random.Next(0, 5))).ToString(), // Name A-E
+                    random.Next(1, 4) // Priority 1-3
+                ))
+                .ToArray();
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<ThreeLayerData>("data");
+            col.EnsureIndex(x => x.Category);
+            col.EnsureIndex(x => x.Name);
+            col.EnsureIndex(x => x.Priority);
+            col.Insert(data);
+            
+            data = col.FindAll().ToArray();
+
+            var expected = data
+                .OrderByDescending(x => x.Category)
+                .ThenBy(x => x.Name)
+                .ThenByDescending(x => x.Priority)
+                .ThenByDescending(x => x.Id)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderByDescending(x => x.Category)
+                .ThenBy(x => x.Name)
+                .ThenByDescending(x => x.Priority)
+                .ThenByDescending(x => x.Id)
+                .ToArray();
+
+            actual.Should().Equal(expected);
+
+            // Verify the query plan shows all three ordering segments
+            var plan = col.Query()
+                .OrderByDescending(x => x.Category)
+                .ThenBy(x => x.Name)
+                .ThenByDescending(x => x.Priority)
+                .GetPlan();
+
+            var orderBy = plan["orderBy"].AsArray;
+            orderBy.Count.Should().Be(3);
+            orderBy[0]["expr"].AsString.Should().Be("$.Category");
+            orderBy[0]["order"].AsInt32.Should().Be(Query.Descending);
+            orderBy[1]["expr"].AsString.Should().Be("$.Name");
+            orderBy[1]["order"].AsInt32.Should().Be(Query.Ascending);
+            orderBy[2]["expr"].AsString.Should().Be("$.Priority");
+            orderBy[2]["order"].AsInt32.Should().Be(Query.Descending);
+        }
+
+        [Fact]
+        public void Query_ThreeLayer_Edge_Case_With_Nulls_And_Duplicates()
+        {
+            var data = new[]
+            {
+                new ThreeLayerData(1, 1, "A", 1),
+                new ThreeLayerData(2, 1, "A", 1), // Duplicate
+                new ThreeLayerData(3, 1, "A", 2),
+                new ThreeLayerData(4, 2, "A", 1),
+                new ThreeLayerData(5, 2, "B", 1),
+                new ThreeLayerData(6, 1, "B", 1),
+                new ThreeLayerData(7, 1, "B", 2),
+                new ThreeLayerData(8, 2, "A", 1) // Another duplicate of Id 4
+            };
+
+            using var db = DatabaseFactory.Create();
+            var col = db.GetCollection<ThreeLayerData>("data");
+            col.EnsureIndex(x => x.Category);
+            col.EnsureIndex(x => x.Name);
+            col.EnsureIndex(x => x.Priority);
+            col.Insert(data);
+
+            var expected = data
+                .OrderBy(x => x.Category)
+                .ThenByDescending(x => x.Name)
+                .ThenBy(x => x.Priority)
+                .ToArray();
+
+            var actual = col.Query()
+                .OrderBy(x => x.Category)
+                .ThenByDescending(x => x.Name)
+                .ThenBy(x => x.Priority)
+                .ToArray();
+
+            actual.Should().Equal(expected);
         }
     }
 }

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using LiteDB;
 using LiteDB.Engine;
+using MathNet.Numerics.LinearAlgebra;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -80,6 +81,89 @@ namespace LiteDB.Tests.QueryTest
             }
 
             return count;
+        }
+
+        private static float[] CreateVector(Random random, int dimensions)
+        {
+            var vector = new float[dimensions];
+            var hasNonZero = false;
+
+            for (var i = 0; i < dimensions; i++)
+            {
+                var value = (float)(random.NextDouble() * 2d - 1d);
+                vector[i] = value;
+
+                if (!hasNonZero && Math.Abs(value) > 1e-6f)
+                {
+                    hasNonZero = true;
+                }
+            }
+
+            if (!hasNonZero)
+            {
+                vector[random.Next(dimensions)] = 1f;
+            }
+
+            return vector;
+        }
+
+        private static (double Distance, double Similarity) ComputeReferenceMetrics(float[] candidate, float[] target, VectorDistanceMetric metric)
+        {
+            var builder = Vector<double>.Build;
+            var candidateVector = builder.DenseOfEnumerable(candidate.Select(v => (double)v));
+            var targetVector = builder.DenseOfEnumerable(target.Select(v => (double)v));
+
+            switch (metric)
+            {
+                case VectorDistanceMetric.Cosine:
+                    var candidateNorm = candidateVector.L2Norm();
+                    var targetNorm = targetVector.L2Norm();
+
+                    if (candidateNorm == 0d || targetNorm == 0d)
+                    {
+                        return (double.NaN, double.NaN);
+                    }
+
+                    var cosineSimilarity = candidateVector.DotProduct(targetVector) / (candidateNorm * targetNorm);
+                    return (1d - cosineSimilarity, double.NaN);
+
+                case VectorDistanceMetric.Euclidean:
+                    return ((candidateVector - targetVector).L2Norm(), double.NaN);
+
+                case VectorDistanceMetric.DotProduct:
+                    var dot = candidateVector.DotProduct(targetVector);
+                    return (-dot, dot);
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(metric), metric, null);
+            }
+        }
+
+        private static List<(int Id, double Distance, double Similarity)> ComputeExpectedRanking(
+            IEnumerable<VectorDocument> documents,
+            float[] target,
+            VectorDistanceMetric metric,
+            int? limit = null)
+        {
+            var ordered = documents
+                .Select(doc =>
+                {
+                    var (distance, similarity) = ComputeReferenceMetrics(doc.Embedding, target, metric);
+                    return (doc.Id, Distance: distance, Similarity: similarity);
+                })
+                .Where(result => metric == VectorDistanceMetric.DotProduct
+                    ? !double.IsNaN(result.Similarity)
+                    : !double.IsNaN(result.Distance))
+                .OrderBy(result => metric == VectorDistanceMetric.DotProduct ? -result.Similarity : result.Distance)
+                .ThenBy(result => result.Id)
+                .ToList();
+
+            if (limit.HasValue)
+            {
+                ordered = ordered.Take(limit.Value).ToList();
+            }
+
+            return ordered;
         }
 
         [Fact]
@@ -347,9 +431,12 @@ namespace LiteDB.Tests.QueryTest
             using var db = new LiteDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
+            const int nearClusterSize = 64;
+            const int farClusterSize = 64;
+
             var documents = new List<VectorDocument>();
 
-            for (var i = 0; i < 32; i++)
+            for (var i = 0; i < nearClusterSize; i++)
             {
                 documents.Add(new VectorDocument
                 {
@@ -359,17 +446,18 @@ namespace LiteDB.Tests.QueryTest
                 });
             }
 
-            for (var i = 0; i < 32; i++)
+            for (var i = 0; i < farClusterSize; i++)
             {
                 documents.Add(new VectorDocument
                 {
-                    Id = i + 33,
+                    Id = i + nearClusterSize + 1,
                     Embedding = new[] { -1f, 2f + i / 100f },
                     Flag = false
                 });
             }
 
             collection.Insert(documents);
+            collection.Count().Should().Be(documents.Count);
 
             collection.EnsureIndex(
                 "embedding_idx",
@@ -389,7 +477,8 @@ namespace LiteDB.Tests.QueryTest
                 });
 
             stats.Total.Should().BeGreaterThan(stats.Visited);
-            stats.Matches.Should().OnlyContain(id => id < 32);
+            stats.Total.Should().BeGreaterOrEqualTo(nearClusterSize);
+            stats.Matches.Should().OnlyContain(id => id <= nearClusterSize);
         }
 
         [Fact]
@@ -466,6 +555,210 @@ namespace LiteDB.Tests.QueryTest
 
                 return 0;
             });
+        }
+
+        [Theory]
+        [InlineData(VectorDistanceMetric.Cosine)]
+        [InlineData(VectorDistanceMetric.Euclidean)]
+        [InlineData(VectorDistanceMetric.DotProduct)]
+        public void VectorDistance_Computation_MatchesMathNet(VectorDistanceMetric metric)
+        {
+            var random = new Random(1789);
+            const int dimensions = 6;
+
+            for (var i = 0; i < 20; i++)
+            {
+                var candidate = CreateVector(random, dimensions);
+                var target = CreateVector(random, dimensions);
+
+                var distance = VectorIndexService.ComputeDistance(candidate, target, metric, out var similarity);
+                var (expectedDistance, expectedSimilarity) = ComputeReferenceMetrics(candidate, target, metric);
+
+                if (double.IsNaN(expectedDistance))
+                {
+                    double.IsNaN(distance).Should().BeTrue();
+                }
+                else
+                {
+                    distance.Should().BeApproximately(expectedDistance, 1e-6);
+                }
+
+                if (double.IsNaN(expectedSimilarity))
+                {
+                    double.IsNaN(similarity).Should().BeTrue();
+                }
+                else
+                {
+                    similarity.Should().BeApproximately(expectedSimilarity, 1e-6);
+                }
+            }
+
+            if (metric == VectorDistanceMetric.Cosine)
+            {
+                var zero = new float[dimensions];
+                var other = CreateVector(random, dimensions);
+
+                var distance = VectorIndexService.ComputeDistance(zero, other, metric, out var similarity);
+
+                double.IsNaN(distance).Should().BeTrue();
+                double.IsNaN(similarity).Should().BeTrue();
+            }
+        }
+
+        [Theory]
+        [InlineData(VectorDistanceMetric.Cosine)]
+        [InlineData(VectorDistanceMetric.Euclidean)]
+        [InlineData(VectorDistanceMetric.DotProduct)]
+        public void VectorIndex_Search_MatchesReferenceRanking(VectorDistanceMetric metric)
+        {
+            using var db = new LiteDatabase(":memory:");
+            var collection = db.GetCollection<VectorDocument>("vectors");
+
+            var random = new Random(4242);
+            const int dimensions = 6;
+
+            var documents = Enumerable.Range(1, 32)
+                .Select(i => new VectorDocument
+                {
+                    Id = i,
+                    Embedding = CreateVector(random, dimensions),
+                    Flag = i % 2 == 0
+                })
+                .ToList();
+
+            collection.Insert(documents);
+
+            collection.EnsureIndex(
+                "embedding_idx",
+                BsonExpression.Create("$.Embedding"),
+                new VectorIndexOptions((ushort)dimensions, metric));
+
+            var target = CreateVector(random, dimensions);
+            foreach (var limit in new[] { 5, 12 })
+            {
+                var expectedTop = ComputeExpectedRanking(documents, target, metric, limit);
+
+                var actual = InspectVectorIndex(db, "vectors", (snapshot, collation, metadata) =>
+                {
+                    var service = new VectorIndexService(snapshot, collation);
+                    return service.Search(metadata, target, double.MaxValue, limit)
+                        .Select(result =>
+                        {
+                            var mapped = BsonMapper.Global.ToObject<VectorDocument>(result.Document);
+                            return (Id: mapped.Id, Score: result.Distance);
+                        })
+                        .ToList();
+                });
+
+                actual.Should().HaveCount(expectedTop.Count);
+
+                for (var i = 0; i < expectedTop.Count; i++)
+                {
+                    actual[i].Id.Should().Be(expectedTop[i].Id);
+
+                    if (metric == VectorDistanceMetric.DotProduct)
+                    {
+                        actual[i].Score.Should().BeApproximately(expectedTop[i].Similarity, 1e-6);
+                    }
+                    else
+                    {
+                        actual[i].Score.Should().BeApproximately(expectedTop[i].Distance, 1e-6);
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(VectorDistanceMetric.Cosine)]
+        [InlineData(VectorDistanceMetric.Euclidean)]
+        [InlineData(VectorDistanceMetric.DotProduct)]
+        public void WhereNear_MatchesReferenceOrdering(VectorDistanceMetric metric)
+        {
+            using var db = new LiteDatabase(":memory:");
+            var collection = db.GetCollection<VectorDocument>("vectors");
+
+            var random = new Random(9182);
+            const int dimensions = 6;
+
+            var documents = Enumerable.Range(1, 40)
+                .Select(i => new VectorDocument
+                {
+                    Id = i,
+                    Embedding = CreateVector(random, dimensions),
+                    Flag = i % 3 == 0
+                })
+                .ToList();
+
+            collection.Insert(documents);
+
+            collection.EnsureIndex(
+                "embedding_idx",
+                BsonExpression.Create("$.Embedding"),
+                new VectorIndexOptions((ushort)dimensions, metric));
+
+            var target = CreateVector(random, dimensions);
+            const int limit = 12;
+
+            var query = collection.Query()
+                .WhereNear(x => x.Embedding, target, double.MaxValue)
+                .Limit(limit);
+
+            var plan = query.GetPlan();
+            plan["index"]["mode"].AsString.Should().Be("VECTOR INDEX SEARCH");
+
+            var results = query.ToArray();
+
+            results.Should().HaveCount(limit);
+
+            var searchIds = InspectVectorIndex(db, "vectors", (snapshot, collation, metadata) =>
+            {
+                var service = new VectorIndexService(snapshot, collation);
+                return service.Search(metadata, target, double.MaxValue, limit)
+                    .Select(result => BsonMapper.Global.ToObject<VectorDocument>(result.Document).Id)
+                    .ToArray();
+            });
+
+            results.Select(x => x.Id).Should().Equal(searchIds);
+        }
+
+        [Theory]
+        [InlineData(VectorDistanceMetric.Cosine)]
+        [InlineData(VectorDistanceMetric.Euclidean)]
+        [InlineData(VectorDistanceMetric.DotProduct)]
+        public void TopKNear_MatchesReferenceOrdering(VectorDistanceMetric metric)
+        {
+            using var db = new LiteDatabase(":memory:");
+            var collection = db.GetCollection<VectorDocument>("vectors");
+
+            var random = new Random(5461);
+            const int dimensions = 6;
+
+            var documents = Enumerable.Range(1, 48)
+                .Select(i => new VectorDocument
+                {
+                    Id = i,
+                    Embedding = CreateVector(random, dimensions),
+                    Flag = i % 4 == 0
+                })
+                .ToList();
+
+            collection.Insert(documents);
+
+            collection.EnsureIndex(
+                "embedding_idx",
+                BsonExpression.Create("$.Embedding"),
+                new VectorIndexOptions((ushort)dimensions, metric));
+
+            var target = CreateVector(random, dimensions);
+            const int limit = 7;
+            var expected = ComputeExpectedRanking(documents, target, metric, limit);
+
+            var results = collection.Query()
+                .TopKNear(x => x.Embedding, target, limit)
+                .ToArray();
+
+            results.Should().HaveCount(expected.Count);
+            results.Select(x => x.Id).Should().Equal(expected.Select(x => x.Id));
         }
     }
 }

--- a/LiteDB.Tests/Query/Where_Tests.cs
+++ b/LiteDB.Tests/Query/Where_Tests.cs
@@ -1,109 +1,182 @@
-﻿using FluentAssertions;
-using System.Linq;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace LiteDB.Tests.QueryTest
 {
     public class Where_Tests : PersonQueryData
     {
+        private readonly ITestOutputHelper _output;
+
+        public Where_Tests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         class Entity
         {
             public string Name { get; set; }
             public int Size { get; set; }
         }
 
-        [Fact]
-        public void Query_Where_With_Parameter()
+        [Fact(Timeout = 30000)]
+        public async Task Query_Where_With_Parameter()
         {
-            using var db = new PersonQueryData();
-            var (collection, local) = db.GetData();
+            var testName = nameof(Query_Where_With_Parameter);
 
-            var r0 = local
-                .Where(x => x.Address.State == "FL")
-                .ToArray();
+            _output.WriteLine($"starting {testName}");
 
-            var r1 = collection.Query()
-                .Where(x => x.Address.State == "FL")
-                .ToArray();
+            try
+            {
+                using var db = new PersonQueryData();
+                var (collection, local) = db.GetData();
 
-            AssertEx.ArrayEqual(r0, r1, true);
+                var r0 = local
+                    .Where(x => x.Address.State == "FL")
+                    .ToArray();
+
+                var r1 = collection.Query()
+                    .Where(x => x.Address.State == "FL")
+                    .ToArray();
+
+                AssertEx.ArrayEqual(r0, r1, true);
+            }
+            finally
+            {
+                _output.WriteLine($"{testName} completed");
+            }
+
+            await Task.CompletedTask;
         }
 
-        [Fact]
-        public void Query_Multi_Where_With_Like()
+        [Fact(Timeout = 30000)]
+        public async Task Query_Multi_Where_With_Like()
         {
-            using var db = new PersonQueryData();
-            var (collection, local) = db.GetData();
+            var testName = nameof(Query_Multi_Where_With_Like);
 
-            var r0 = local
-                .Where(x => x.Age >= 10 && x.Age <= 40)
-                .Where(x => x.Name.StartsWith("Ge"))
-                .ToArray();
+            _output.WriteLine($"starting {testName}");
 
-            var r1 = collection.Query()
-                .Where(x => x.Age >= 10 && x.Age <= 40)
-                .Where(x => x.Name.StartsWith("Ge"))
-                .ToArray();
+            try
+            {
+                using var db = new PersonQueryData();
+                var (collection, local) = db.GetData();
 
-            AssertEx.ArrayEqual(r0, r1, true);
+                var r0 = local
+                    .Where(x => x.Age >= 10 && x.Age <= 40)
+                    .Where(x => x.Name.StartsWith("Ge"))
+                    .ToArray();
+
+                var r1 = collection.Query()
+                    .Where(x => x.Age >= 10 && x.Age <= 40)
+                    .Where(x => x.Name.StartsWith("Ge"))
+                    .ToArray();
+
+                AssertEx.ArrayEqual(r0, r1, true);
+            }
+            finally
+            {
+                _output.WriteLine($"{testName} completed");
+            }
+
+            await Task.CompletedTask;
         }
 
-        [Fact]
-        public void Query_Single_Where_With_And()
+        [Fact(Timeout = 30000)]
+        public async Task Query_Single_Where_With_And()
         {
-            using var db = new PersonQueryData();
-            var (collection, local) = db.GetData();
+            var testName = nameof(Query_Single_Where_With_And);
 
-            var r0 = local
-                .Where(x => x.Age == 25 && x.Active)
-                .ToArray();
+            _output.WriteLine($"starting {testName}");
 
-            var r1 = collection.Query()
-                .Where("age = 25 AND active = true")
-                .ToArray();
+            try
+            {
+                using var db = new PersonQueryData();
+                var (collection, local) = db.GetData();
 
-            AssertEx.ArrayEqual(r0, r1, true);
+                var r0 = local
+                    .Where(x => x.Age == 25 && x.Active)
+                    .ToArray();
+
+                var r1 = collection.Query()
+                    .Where("age = 25 AND active = true")
+                    .ToArray();
+
+                AssertEx.ArrayEqual(r0, r1, true);
+            }
+            finally
+            {
+                _output.WriteLine($"{testName} completed");
+            }
+
+            await Task.CompletedTask;
         }
 
-        [Fact]
-        public void Query_Single_Where_With_Or_And_In()
+        [Fact(Timeout = 30000)]
+        public async Task Query_Single_Where_With_Or_And_In()
         {
-            using var db = new PersonQueryData();
-            var (collection, local) = db.GetData();
+            var testName = nameof(Query_Single_Where_With_Or_And_In);
 
-            var r0 = local
-                .Where(x => x.Age == 25 || x.Age == 26 || x.Age == 27)
-                .ToArray();
+            _output.WriteLine($"starting {testName}");
 
-            var r1 = collection.Query()
-                .Where("age = 25 OR age = 26 OR age = 27")
-                .ToArray();
+            try
+            {
+                using var db = new PersonQueryData();
+                var (collection, local) = db.GetData();
 
-            var r2 = collection.Query()
-                .Where("age IN [25, 26, 27]")
-                .ToArray();
+                var r0 = local
+                    .Where(x => x.Age == 25 || x.Age == 26 || x.Age == 27)
+                    .ToArray();
 
-            AssertEx.ArrayEqual(r0, r1, true);
-            AssertEx.ArrayEqual(r1, r2, true);
+                var r1 = collection.Query()
+                    .Where("age = 25 OR age = 26 OR age = 27")
+                    .ToArray();
+
+                var r2 = collection.Query()
+                    .Where("age IN [25, 26, 27]")
+                    .ToArray();
+
+                AssertEx.ArrayEqual(r0, r1, true);
+                AssertEx.ArrayEqual(r1, r2, true);
+            }
+            finally
+            {
+                _output.WriteLine($"{testName} completed");
+            }
+
+            await Task.CompletedTask;
         }
 
-        [Fact]
-        public void Query_With_Array_Ids()
+        [Fact(Timeout = 30000)]
+        public async Task Query_With_Array_Ids()
         {
-            using var db = new PersonQueryData();
-            var (collection, local) = db.GetData();
+            var testName = nameof(Query_With_Array_Ids);
 
-            var ids = new int[] { 1, 2, 3 };
+            _output.WriteLine($"starting {testName}");
 
-            var r0 = local
-                .Where(x => ids.Contains(x.Id))
-                .ToArray();
+            try
+            {
+                using var db = new PersonQueryData();
+                var (collection, local) = db.GetData();
 
-            var r1 = collection.Query()
-                .Where(x => ids.Contains(x.Id))
-                .ToArray();
+                var ids = new int[] { 1, 2, 3 };
 
-            AssertEx.ArrayEqual(r0, r1, true);
+                var r0 = local
+                    .Where(x => ids.Contains(x.Id))
+                    .ToArray();
+
+                var r1 = collection.Query()
+                    .Where(x => ids.Contains(x.Id))
+                    .ToArray();
+
+                AssertEx.ArrayEqual(r0, r1, true);
+            }
+            finally
+            {
+                _output.WriteLine($"{testName} completed");
+            }
+
+            await Task.CompletedTask;
         }
     }
 }

--- a/LiteDB.Tests/Shared/SharedDemoDatabaseCollection.cs
+++ b/LiteDB.Tests/Shared/SharedDemoDatabaseCollection.cs
@@ -1,0 +1,43 @@
+namespace LiteDB.Tests;
+
+using System;
+using System.IO;
+using Xunit;
+
+[CollectionDefinition("SharedDemoDatabase", DisableParallelization = true)]
+public sealed class SharedDemoDatabaseCollection : ICollectionFixture<SharedDemoDatabaseFixture>
+{
+}
+
+public sealed class SharedDemoDatabaseFixture : IDisposable
+{
+    private readonly string _filename;
+
+    public SharedDemoDatabaseFixture()
+    {
+        _filename = Path.GetFullPath("Demo.db");
+        TryDeleteFile();
+    }
+
+    public void Dispose()
+    {
+        TryDeleteFile();
+    }
+
+    private void TryDeleteFile()
+    {
+        try
+        {
+            if (File.Exists(_filename))
+            {
+                File.Delete(_filename);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32328.378
@@ -14,6 +14,12 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LiteDB.Stress", "LiteDB.Stress\LiteDB.Stress.csproj", "{FFBC5669-DA32-4907-8793-7B414279DA3B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Demo.Tools.VectorSearch", "LiteDB.Demo.Tools.VectorSearch\LiteDB.Demo.Tools.VectorSearch.csproj", "{64EEF08C-CE83-4929-B5E4-583BBC332941}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApp1", "ConsoleApp1\ConsoleApp1.csproj", "{E8763934-E46A-4AAF-A2B5-E812016DAF84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.RollbackRepro", "LiteDB.RollbackRepro\LiteDB.RollbackRepro.csproj", "{BE1D6CA2-134A-404A-8F1A-C48E4E240159}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{D455AC29-7847-4DF4-AD06-69042F8B8885}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -97,6 +103,14 @@ Global
 		{64EEF08C-CE83-4929-B5E4-583BBC332941}.Release|x64.Build.0 = Release|Any CPU
 		{64EEF08C-CE83-4929-B5E4-583BBC332941}.Release|x86.ActiveCfg = Release|Any CPU
 		{64EEF08C-CE83-4929-B5E4-583BBC332941}.Release|x86.Build.0 = Release|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -106,5 +120,9 @@ Global
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E8763934-E46A-4AAF-A2B5-E812016DAF84} = {D455AC29-7847-4DF4-AD06-69042F8B8885}
+		{BE1D6CA2-134A-404A-8F1A-C48E4E240159} = {D455AC29-7847-4DF4-AD06-69042F8B8885}
 	EndGlobalSection
 EndGlobal

--- a/LiteDB/Client/Database/ILiteQueryable.cs
+++ b/LiteDB/Client/Database/ILiteQueryable.cs
@@ -20,6 +20,10 @@ namespace LiteDB
         ILiteQueryable<T> OrderBy<K>(Expression<Func<T, K>> keySelector, int order = 1);
         ILiteQueryable<T> OrderByDescending(BsonExpression keySelector);
         ILiteQueryable<T> OrderByDescending<K>(Expression<Func<T, K>> keySelector);
+        ILiteQueryable<T> ThenBy(BsonExpression keySelector);
+        ILiteQueryable<T> ThenBy<K>(Expression<Func<T, K>> keySelector);
+        ILiteQueryable<T> ThenByDescending(BsonExpression keySelector);
+        ILiteQueryable<T> ThenByDescending<K>(Expression<Func<T, K>> keySelector);
 
         ILiteQueryable<T> GroupBy(BsonExpression keySelector);
         ILiteQueryable<T> Having(BsonExpression predicate);

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -19,6 +19,7 @@ namespace LiteDB
         private readonly ILiteEngine _engine;
         private readonly BsonMapper _mapper;
         private readonly bool _disposeOnClose;
+        private readonly int? _checkpointOverride;
 
         /// <summary>
         /// Get current instance of BsonMapper used in this database instance (can be BsonMapper.Global)
@@ -66,6 +67,27 @@ namespace LiteDB
             _engine = new LiteEngine(settings);
             _mapper = mapper ?? BsonMapper.Global;
             _disposeOnClose = true;
+
+            if (logStream == null && stream is not MemoryStream)
+            {
+                if (!stream.CanWrite)
+                {
+                    // Read-only streams cannot participate in eager checkpointing because the process
+                    // writes pages back to the underlying data stream immediately.
+                }
+                else
+                {
+                    // Without a dedicated log stream the WAL lives purely in memory; force
+                    // checkpointing to ensure commits reach the underlying data stream.
+                    var originalCheckpointSize = _engine.Pragma(Pragmas.CHECKPOINT);
+
+                    if (originalCheckpointSize != 1)
+                    {
+                        _engine.Pragma(Pragmas.CHECKPOINT, 1);
+                        _checkpointOverride = originalCheckpointSize;
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -373,6 +395,11 @@ namespace LiteDB
         {
             if (disposing && _disposeOnClose)
             {
+                if (_checkpointOverride.HasValue)
+                {
+                    _engine.Pragma(Pragmas.CHECKPOINT, _checkpointOverride.Value);
+                }
+
                 _engine.Dispose();
             }
         }

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -103,14 +103,13 @@ namespace LiteDB
         #region OrderBy
 
         /// <summary>
-        /// Sort the documents of resultset in ascending (or descending) order according to a key (support only one OrderBy)
+        /// Sort the documents of resultset in ascending (or descending) order according to a key.
         /// </summary>
         public ILiteQueryable<T> OrderBy(BsonExpression keySelector, int order = Query.Ascending)
         {
-            if (_query.OrderBy != null) throw new ArgumentException("ORDER BY already defined in this query builder");
+            if (_query.OrderBy.Count > 0) throw new ArgumentException("Multiple OrderBy calls are not supported. Use ThenBy for additional sort keys.");
 
-            _query.OrderBy = keySelector;
-            _query.Order = order;
+            _query.OrderBy.Add(new QueryOrder(keySelector, order));
             return this;
         }
 
@@ -123,14 +122,52 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Sort the documents of resultset in descending order according to a key (support only one OrderBy)
+        /// Sort the documents of resultset in descending order according to a key.
         /// </summary>
         public ILiteQueryable<T> OrderByDescending(BsonExpression keySelector) => this.OrderBy(keySelector, Query.Descending);
 
         /// <summary>
-        /// Sort the documents of resultset in descending order according to a key (support only one OrderBy)
+        /// Sort the documents of resultset in descending order according to a key.
         /// </summary>
         public ILiteQueryable<T> OrderByDescending<K>(Expression<Func<T, K>> keySelector) => this.OrderBy(keySelector, Query.Descending);
+
+        /// <summary>
+        /// Appends an ascending sort expression that is applied when previous keys are equal.
+        /// </summary>
+        public ILiteQueryable<T> ThenBy(BsonExpression keySelector)
+        {
+            if (_query.OrderBy.Count == 0) return this.OrderBy(keySelector, Query.Ascending);
+
+            _query.OrderBy.Add(new QueryOrder(keySelector, Query.Ascending));
+            return this;
+        }
+
+        /// <summary>
+        /// Appends an ascending sort expression that is applied when previous keys are equal.
+        /// </summary>
+        public ILiteQueryable<T> ThenBy<K>(Expression<Func<T, K>> keySelector)
+        {
+            return this.ThenBy(_mapper.GetExpression(keySelector));
+        }
+
+        /// <summary>
+        /// Appends a descending sort expression that is applied when previous keys are equal.
+        /// </summary>
+        public ILiteQueryable<T> ThenByDescending(BsonExpression keySelector)
+        {
+            if (_query.OrderBy.Count == 0) return this.OrderBy(keySelector, Query.Descending);
+
+            _query.OrderBy.Add(new QueryOrder(keySelector, Query.Descending));
+            return this;
+        }
+
+        /// <summary>
+        /// Appends a descending sort expression that is applied when previous keys are equal.
+        /// </summary>
+        public ILiteQueryable<T> ThenByDescending<K>(Expression<Func<T, K>> keySelector)
+        {
+            return this.ThenByDescending(_mapper.GetExpression(keySelector));
+        }
 
         #endregion
 

--- a/LiteDB/Client/SqlParser/Commands/Select.cs
+++ b/LiteDB/Client/SqlParser/Commands/Select.cs
@@ -126,18 +126,30 @@ namespace LiteDB
                 _tokenizer.ReadToken();
                 _tokenizer.ReadToken().Expect("BY");
 
-                var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
-
-                var orderByOrder = Query.Ascending;
-                var orderByToken = _tokenizer.LookAhead();
-
-                if (orderByToken.Is("ASC") || orderByToken.Is("DESC"))
+                while (true)
                 {
-                    orderByOrder = _tokenizer.ReadToken().Is("ASC") ? Query.Ascending : Query.Descending;
-                }
+                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
 
-                query.OrderBy = orderBy;
-                query.Order = orderByOrder;
+                    var orderByOrder = Query.Ascending;
+                    var orderByToken = _tokenizer.LookAhead();
+
+                    if (orderByToken.Is("ASC") || orderByToken.Is("DESC"))
+                    {
+                        orderByOrder = _tokenizer.ReadToken().Is("ASC") ? Query.Ascending : Query.Descending;
+                    }
+
+                    query.OrderBy.Add(new QueryOrder(orderBy, orderByOrder));
+
+                    var next = _tokenizer.LookAhead();
+
+                    if (next.Type == TokenType.Comma)
+                    {
+                        _tokenizer.ReadToken();
+                        continue;
+                    }
+
+                    break;
+                }
             }
 
             ahead = _tokenizer.LookAhead().Expect(TokenType.Word, TokenType.EOF, TokenType.SemiColon);

--- a/LiteDB/Client/Structures/Query.cs
+++ b/LiteDB/Client/Structures/Query.cs
@@ -36,7 +36,9 @@ namespace LiteDB
         /// </summary>
         public static Query All(int order = Ascending)
         {
-            return new Query { OrderBy = "_id", Order = order };
+            var query = new Query();
+            query.OrderBy.Add(new QueryOrder(BsonExpression.Create("_id"), order));
+            return query;
         }
 
         /// <summary>
@@ -44,7 +46,9 @@ namespace LiteDB
         /// </summary>
         public static Query All(string field, int order = Ascending)
         {
-            return new Query { OrderBy = field, Order = order };
+            var query = new Query();
+            query.OrderBy.Add(new QueryOrder(BsonExpression.Create(field), order));
+            return query;
         }
 
         /// <summary>

--- a/LiteDB/Document/BsonArray.cs
+++ b/LiteDB/Document/BsonArray.cs
@@ -36,6 +36,14 @@ namespace LiteDB
 
             this.AddRange(items);
         }
+        
+        public BsonArray(BsonArray items)
+            : this()
+        {
+            if (items == null) throw new ArgumentNullException(nameof(items));
+
+            this.AddRange(items);
+        }
 
         public new IList<BsonValue> RawValue => (IList<BsonValue>)base.RawValue;
 
@@ -73,9 +81,8 @@ namespace LiteDB
 
             foreach (var bsonValue in collection)
             {
-                list.Add(bsonValue ?? Null);    
+                list.Add(bsonValue ?? Null);
             }
-            
         }
         
         public void AddRange(IEnumerable<BsonValue> items)

--- a/LiteDB/Engine/Disk/DiskReader.cs
+++ b/LiteDB/Engine/Disk/DiskReader.cs
@@ -50,7 +50,7 @@ namespace LiteDB.Engine
                 _cache.GetWritablePage(position, origin, (pos, buf) => this.ReadStream(stream, pos, buf)) :
                 _cache.GetReadablePage(position, origin, (pos, buf) => this.ReadStream(stream, pos, buf));
 
-#if DEBUG
+#if DEBUG || TESTING
             _state.SimulateDiskReadFail?.Invoke(page);
 #endif
 

--- a/LiteDB/Engine/Disk/DiskService.cs
+++ b/LiteDB/Engine/Disk/DiskService.cs
@@ -190,7 +190,7 @@ namespace LiteDB.Engine
                     // set log stream position to page
                     stream.Position = page.Position;
 
-#if DEBUG
+#if DEBUG || TESTING
                     _state.SimulateDiskWriteFail?.Invoke(page);
 #endif
 

--- a/LiteDB/Engine/Engine/Transaction.cs
+++ b/LiteDB/Engine/Engine/Transaction.cs
@@ -112,8 +112,8 @@ namespace LiteDB.Engine
             _monitor.ReleaseTransaction(transaction);
 
             // try checkpoint when finish transaction and log file are bigger than checkpoint pragma value (in pages)
-            if (_header.Pragmas.Checkpoint > 0 && 
-                _disk.GetFileLength(FileOrigin.Log) > (_header.Pragmas.Checkpoint * PAGE_SIZE))
+            if (_header.Pragmas.Checkpoint > 0 &&
+                _disk.GetFileLength(FileOrigin.Log) >= (_header.Pragmas.Checkpoint * PAGE_SIZE))
             {
                 _walIndex.TryCheckpoint();
             }

--- a/LiteDB/Engine/EngineState.cs
+++ b/LiteDB/Engine/EngineState.cs
@@ -18,7 +18,7 @@ namespace LiteDB.Engine
         private readonly LiteEngine _engine; // can be null for unit tests
         private readonly EngineSettings _settings;
 
-#if DEBUG
+#if DEBUG || TESTING
         public Action<PageBuffer> SimulateDiskReadFail = null;
         public Action<PageBuffer> SimulateDiskWriteFail = null;
 #endif

--- a/LiteDB/Engine/LiteEngine.cs
+++ b/LiteDB/Engine/LiteEngine.cs
@@ -243,7 +243,7 @@ namespace LiteDB.Engine
 
         #endregion
 
-#if DEBUG
+#if DEBUG || TESTING
         // exposes for unit tests
         internal TransactionMonitor GetMonitor() => _monitor;
         internal Action<PageBuffer> SimulateDiskReadFail { set => _state.SimulateDiskReadFail = value; }

--- a/LiteDB/Engine/Query/Pipeline/GroupByPipe.cs
+++ b/LiteDB/Engine/Query/Pipeline/GroupByPipe.cs
@@ -39,7 +39,7 @@ namespace LiteDB.Engine
             // run orderBy used in GroupBy (if not already ordered by index)
             if (query.OrderBy != null)
             {
-                source = this.OrderBy(source, query.OrderBy.Expression, query.OrderBy.Order, 0, int.MaxValue);
+                source = this.OrderBy(source, query.OrderBy, 0, int.MaxValue);
             }
 
             // apply groupby

--- a/LiteDB/Engine/Query/Pipeline/QueryPipe.cs
+++ b/LiteDB/Engine/Query/Pipeline/QueryPipe.cs
@@ -46,7 +46,7 @@ namespace LiteDB.Engine
             if (query.OrderBy != null)
             {
                 // pipe: orderby with offset+limit
-                source = this.OrderBy(source, query.OrderBy.Expression, query.OrderBy.Order, query.Offset, query.Limit);
+                source = this.OrderBy(source, query.OrderBy, query.Offset, query.Limit);
             }
             else
             {

--- a/LiteDB/Engine/Query/Query.cs
+++ b/LiteDB/Engine/Query/Query.cs
@@ -17,8 +17,7 @@ namespace LiteDB
         public List<BsonExpression> Includes { get; } = new List<BsonExpression>();
         public List<BsonExpression> Where { get; } = new List<BsonExpression>();
 
-        public BsonExpression OrderBy { get; set; } = null;
-        public int Order { get; set; } = Query.Ascending;
+        public List<QueryOrder> OrderBy { get; } = new List<QueryOrder>();
 
         public BsonExpression GroupBy { get; set; } = null;
         public BsonExpression Having { get; set; } = null;
@@ -86,9 +85,12 @@ namespace LiteDB
                 sb.AppendLine($"HAVING {this.Having.Source}");
             }
 
-            if (this.OrderBy != null)
+            if (this.OrderBy.Count > 0)
             {
-                sb.AppendLine($"ORDER BY {this.OrderBy.Source} {(this.Order == Query.Ascending ? "ASC" : "DESC")}");
+                var orderBy = this.OrderBy
+                    .Select(x => $"{x.Expression.Source} {(x.Order == Query.Ascending ? "ASC" : "DESC")}");
+
+                sb.AppendLine($"ORDER BY {string.Join(", ", orderBy)}");
             }
 
             if (this.Limit != int.MaxValue)

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -326,12 +326,16 @@ namespace LiteDB.Engine
                 }
             }
 
-            if (expression == null && _query.OrderBy != null)
+            if (expression == null && _query.OrderBy.Count > 0)
             {
-                if (this.TryParseVectorExpression(_query.OrderBy, out expression, out target))
+                foreach (var order in _query.OrderBy)
                 {
-                    matchedFromOrderBy = true;
-                    maxDistance = double.MaxValue;
+                    if (this.TryParseVectorExpression(order.Expression, out expression, out target))
+                    {
+                        matchedFromOrderBy = true;
+                        maxDistance = double.MaxValue;
+                        break;
+                    }
                 }
             }
 
@@ -340,7 +344,7 @@ namespace LiteDB.Engine
                 expression = NormalizeVectorField(_query.VectorField);
                 target = _query.VectorTarget?.ToArray();
                 maxDistance = _query.VectorMaxDistance;
-                matchedFromOrderBy = matchedFromOrderBy || (_query.OrderBy != null && _query.OrderBy.Type == BsonExpressionType.VectorSim);
+                matchedFromOrderBy = matchedFromOrderBy || (_query.OrderBy.Any(order => order.Expression?.Type == BsonExpressionType.VectorSim));
             }
 
             if (expression == null || target == null)

--- a/LiteDB/Engine/Query/Structures/OrderBy.cs
+++ b/LiteDB/Engine/Query/Structures/OrderBy.cs
@@ -12,14 +12,39 @@ namespace LiteDB.Engine
     /// </summary>
     internal class OrderBy
     {
-        public BsonExpression Expression { get; }
+        private readonly List<OrderByItem> _segments;
 
-        public int Order { get; set; }
-
-        public OrderBy(BsonExpression expression, int order)
+        public OrderBy(IEnumerable<OrderByItem> segments)
         {
-            this.Expression = expression;
+            if (segments == null) throw new ArgumentNullException(nameof(segments));
+
+            _segments = segments.ToList();
+
+            if (_segments.Count == 0)
+            {
+                throw new ArgumentException("OrderBy requires at least one segment", nameof(segments));
+            }
+        }
+
+        public IReadOnlyList<OrderByItem> Segments => _segments;
+
+        public BsonExpression PrimaryExpression => _segments[0].Expression;
+
+        public int PrimaryOrder => _segments[0].Order;
+
+        public bool ContainsField(string field) => _segments.Any(x => x.Expression.Fields.Contains(field));
+    }
+
+    internal class OrderByItem
+    {
+        public OrderByItem(BsonExpression expression, int order)
+        {
+            this.Expression = expression ?? throw new ArgumentNullException(nameof(expression));
             this.Order = order;
         }
+
+        public BsonExpression Expression { get; }
+
+        public int Order { get; }
     }
 }

--- a/LiteDB/Engine/Query/Structures/QueryOrder.cs
+++ b/LiteDB/Engine/Query/Structures/QueryOrder.cs
@@ -1,0 +1,18 @@
+namespace LiteDB
+{
+    /// <summary>
+    /// Represents a single ORDER BY segment containing the expression and direction.
+    /// </summary>
+    public class QueryOrder
+    {
+        public QueryOrder(BsonExpression expression, int order)
+        {
+            this.Expression = expression;
+            this.Order = order;
+        }
+
+        public BsonExpression Expression { get; }
+
+        public int Order { get; }
+    }
+}

--- a/LiteDB/Engine/Query/Structures/QueryPlan.cs
+++ b/LiteDB/Engine/Query/Structures/QueryPlan.cs
@@ -179,11 +179,11 @@ namespace LiteDB.Engine
 
             if (this.OrderBy != null)
             {
-                doc["orderBy"] = new BsonDocument
+                doc["orderBy"] = new BsonArray(this.OrderBy.Segments.Select(x => new BsonDocument
                 {
-                    ["expr"] = this.OrderBy.Expression.Source,
-                    ["order"] = this.OrderBy.Order,
-                };
+                    ["expr"] = x.Expression.Source,
+                    ["order"] = x.Order,
+                }));
             }
 
             if (this.Limit != int.MaxValue)

--- a/LiteDB/Engine/Services/TransactionService.cs
+++ b/LiteDB/Engine/Services/TransactionService.cs
@@ -296,11 +296,17 @@ namespace LiteDB.Engine
                 // but first, if writable, discard changes
                 if (snapshot.Mode == LockMode.Write)
                 {
-                    // discard all dirty pages
-                    _disk.DiscardDirtyPages(snapshot.GetWritablePages(true, true).Select(x => x.Buffer));
+                    // discard all dirty pages (only buffers still writable)
+                    _disk.DiscardDirtyPages(snapshot
+                        .GetWritablePages(true, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
 
-                    // discard all clean pages
-                    _disk.DiscardCleanPages(snapshot.GetWritablePages(false, true).Select(x => x.Buffer));
+                    // discard all clean pages (only buffers still writable)
+                    _disk.DiscardCleanPages(snapshot
+                        .GetWritablePages(false, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
                 }
 
                 // now, release pages
@@ -406,11 +412,17 @@ namespace LiteDB.Engine
                 // release writable snapshots
                 foreach (var snapshot in _snapshots.Values.Where(x => x.Mode == LockMode.Write))
                 {
-                    // discard all dirty pages
-                    _disk.DiscardDirtyPages(snapshot.GetWritablePages(true, true).Select(x => x.Buffer));
+                    // discard all dirty pages (only buffers still writable)
+                    _disk.DiscardDirtyPages(snapshot
+                        .GetWritablePages(true, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
 
-                    // discard all clean pages
-                    _disk.DiscardCleanPages(snapshot.GetWritablePages(false, true).Select(x => x.Buffer));
+                    // discard all clean pages (only buffers still writable)
+                    _disk.DiscardCleanPages(snapshot
+                        .GetWritablePages(false, true)
+                        .Select(x => x.Buffer)
+                        .Where(x => x.ShareCounter == BUFFER_WRITABLE));
                 }
 
                 // release buffers in read-only snaphosts

--- a/LiteDB/Engine/Sort/SortContainer.cs
+++ b/LiteDB/Engine/Sort/SortContainer.cs
@@ -18,6 +18,7 @@ namespace LiteDB.Engine
     {
         private readonly Collation _collation;
         private readonly int _size;
+        private readonly int[] _orders;
 
         private int _remaining = 0;
         private int _count = 0;
@@ -49,10 +50,11 @@ namespace LiteDB.Engine
         /// </summary>
         public int Count => _count;
 
-        public SortContainer(Collation collation, int size)
+        public SortContainer(Collation collation, int size, IReadOnlyList<int> orders)
         {
             _collation = collation;
             _size = size;
+            _orders = orders as int[] ?? orders.ToArray();
         }
 
         public void Insert(IEnumerable<KeyValuePair<BsonValue, PageAddress>> items, int order, BufferSlice buffer)
@@ -108,6 +110,11 @@ namespace LiteDB.Engine
             }
 
             var key = _reader.ReadIndexKey();
+
+            if (_orders.Length > 1)
+            {
+                key = SortKey.FromBsonValue(key, _orders);
+            }
             var value = _reader.ReadPageAddress();
 
             this.Current = new KeyValuePair<BsonValue, PageAddress>(key, value);

--- a/LiteDB/Engine/Sort/SortKey.cs
+++ b/LiteDB/Engine/Sort/SortKey.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB;
+
+namespace LiteDB.Engine
+{
+    internal class SortKey : BsonArray
+    {
+        private readonly int[] _orders;
+
+        private SortKey(IEnumerable<BsonValue> values, IEnumerable<int> orders)
+            : base(values?.Select(x => x ?? BsonValue.Null) ?? throw new ArgumentNullException(nameof(values)))
+        {
+            if (orders == null) throw new ArgumentNullException(nameof(orders));
+
+            _orders = orders as int[] ?? orders.ToArray();
+
+            if (_orders.Length != this.Count)
+            {
+                throw new ArgumentException("Orders length must match values length", nameof(orders));
+            }
+        }
+        
+        private SortKey(BsonArray array, IEnumerable<int> orders)
+            : base(array)
+        {
+            if (orders == null) throw new ArgumentNullException(nameof(orders));
+
+            _orders = orders as int[] ?? orders.ToArray();
+
+            if (_orders.Length != this.Count)
+            {
+                throw new ArgumentException("Orders length must match values length", nameof(orders));
+            }
+        }
+
+        public override int CompareTo(BsonValue other)
+        {
+            return this.CompareTo(other, Collation.Binary);
+        }
+
+        public override int CompareTo(BsonValue other, Collation collation)
+        {
+            if (other is SortKey sortKey)
+            {
+                var length = Math.Min(this.Count, sortKey.Count);
+
+                for (var i = 0; i < length; i++)
+                {
+                    var result = this[i].CompareTo(sortKey[i], collation);
+
+                    if (result == 0) continue;
+
+                    return _orders[i] == Query.Descending ? -result : result;
+                }
+
+                if (this.Count == sortKey.Count) return 0;
+
+                return this.Count < sortKey.Count ? -1 : 1;
+            }
+
+            if (other is BsonArray array)
+            {
+                return this.CompareTo(new SortKey(array, Enumerable.Repeat(Query.Ascending, array.Count)), collation);
+            }
+
+            return base.CompareTo(other, collation);
+        }
+
+        public static SortKey FromValues(IReadOnlyList<BsonValue> values, IReadOnlyList<int> orders)
+        {
+            if (values == null) throw new ArgumentNullException(nameof(values));
+            if (orders == null) throw new ArgumentNullException(nameof(orders));
+
+            return new SortKey(values, orders);
+        }
+
+        public static SortKey FromBsonValue(BsonValue value, IReadOnlyList<int> orders)
+        {
+            if (value is SortKey sortKey) return sortKey;
+
+            if (value is BsonArray array)
+            {
+                return new SortKey(array.ToArray(), orders);
+            }
+
+            return new SortKey(new[] { value }, orders);
+        }
+    }
+}

--- a/LiteDB/Engine/Structures/PageBuffer.cs
+++ b/LiteDB/Engine/Structures/PageBuffer.cs
@@ -62,7 +62,7 @@ namespace LiteDB.Engine
             Interlocked.Decrement(ref this.ShareCounter);
         }
 
-#if DEBUG
+#if DEBUG || TESTING
         ~PageBuffer()
         {
             ENSURE(this.ShareCounter == 0, $"share count must be 0 in destroy PageBuffer (current: {this.ShareCounter})");

--- a/LiteDB/Utils/Constants.cs
+++ b/LiteDB/Utils/Constants.cs
@@ -6,7 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 
 [assembly: InternalsVisibleTo("LiteDB.Tests")]
-#if DEBUG
+#if DEBUG || TESTING
 [assembly: InternalsVisibleTo("ConsoleApp1")]
 #endif
 
@@ -102,7 +102,7 @@ namespace LiteDB
         /// <summary>
         /// Initial seed for Random
         /// </summary>
-#if DEBUG
+#if DEBUG || TESTING
         public const int RANDOMIZER_SEED = 3131;
 #else
         public const int RANDOMIZER_SEED = 0;

--- a/tests.ci.runsettings
+++ b/tests.ci.runsettings
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Increase timeouts for CI environment -->
+    <!-- <TestSessionTimeout>600000</TestSessionTimeout> 10 minutes -->
+    <TestSessionTimeout>180000</TestSessionTimeout> <!-- 3 minutes -->
+    <TestCaseTimeout>60000</TestCaseTimeout>        <!-- 60 seconds per test -->
+    
+    <!-- Optimize for CI -->
+    <MaxCpuCount>1</MaxCpuCount>                    <!-- Single-threaded to avoid resource contention -->
+    <DisableParallelization>true</DisableParallelization>
+  </RunConfiguration>
+  
+  <!-- CI-specific test filters -->
+  <MSTest>
+    <DeploymentEnabled>false</DeploymentEnabled>
+  </MSTest>
+</RunSettings>


### PR DESCRIPTION
## Summary
- add an IndexedDocumentChunk model and extend the document store with a dedicated chunk collection, vector index management, and pruning support
- split documents into overlapping windows during ingestion, embed each chunk, and persist chunk metadata while keeping a lightweight parent record
- update the search command to query chunk embeddings and display chunk snippets along with parent document details

## Testing
- dotnet build LiteDB.Demo.Tools.VectorSearch.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d1d7e80d08832a9bef350d55f045dd