### PR TITLE
Add regression tests for vector index regressions

### DIFF
--- a/LiteDB.Tests/Engine/DropCollection_Tests.cs
+++ b/LiteDB.Tests/Engine/DropCollection_Tests.cs
@@ -1,5 +1,9 @@
-﻿using System.Linq;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FluentAssertions;
+using LiteDB;
+using LiteDB.Engine;
 using LiteDB.Tests.Utils;
 using Xunit;
 
@@ -7,6 +11,23 @@ namespace LiteDB.Tests.Engine
 {
     public class DropCollection_Tests
     {
+        private static Dictionary<PageType, int> CountPagesByType(string filename)
+        {
+            var counts = new Dictionary<PageType, int>();
+            var buffer = new byte[Constants.PAGE_SIZE];
+
+            using var stream = File.OpenRead(filename);
+
+            while (stream.Read(buffer, 0, buffer.Length) == buffer.Length)
+            {
+                var pageType = (PageType)buffer[BasePage.P_PAGE_TYPE];
+                counts.TryGetValue(pageType, out var current);
+                counts[pageType] = current + 1;
+            }
+
+            return counts;
+        }
+
         [Fact]
         public void DropCollection()
         {
@@ -16,7 +37,7 @@ namespace LiteDB.Tests.Engine
 
                 var col = db.GetCollection("col");
 
-                col.Insert(new BsonDocument {["a"] = 1});
+                col.Insert(new BsonDocument { ["a"] = 1 });
 
                 db.GetCollectionNames().Should().Contain("col");
 
@@ -45,6 +66,55 @@ namespace LiteDB.Tests.Engine
                     col.Insert(new BsonDocument { ["_id"] = 1 });
                 }
             }
+        }
+
+        [Fact]
+        public void DropCollection_WithVectorIndex_Regression()
+        {
+            using var file = new TempFile();
+
+            const ushort dimensions = 6;
+
+            using (var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename))
+            {
+                var collection = db.GetCollection("docs");
+
+                collection.EnsureIndex(
+                    "embedding_idx",
+                    BsonExpression.Create("$.embedding"),
+                    new VectorIndexOptions(dimensions, VectorDistanceMetric.Cosine));
+
+                for (var i = 0; i < 8; i++)
+                {
+                    var embedding = new BsonArray(Enumerable.Range(0, dimensions)
+                        .Select(j => new BsonValue(i + (j * 0.1))));
+
+                    collection.Insert(new BsonDocument
+                    {
+                        ["_id"] = i + 1,
+                        ["embedding"] = embedding
+                    });
+                }
+
+                db.Checkpoint();
+            }
+
+            var beforeCounts = CountPagesByType(file.Filename);
+            beforeCounts.TryGetValue(PageType.VectorIndex, out var vectorPagesBefore);
+            vectorPagesBefore.Should().BeGreaterThan(0, "creating a vector index should allocate vector pages");
+
+            var drop = () =>
+            {
+                using var db = DatabaseFactory.Create(TestDatabaseType.Disk, file.Filename);
+                db.DropCollection("docs");
+                db.Checkpoint();
+            };
+
+            drop.Should().NotThrow();
+
+            var afterCounts = CountPagesByType(file.Filename);
+            afterCounts.TryGetValue(PageType.VectorIndex, out var vectorPagesAfter);
+            vectorPagesAfter.Should().BeLessThan(vectorPagesBefore, "dropping the collection should reclaim vector pages");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add VectorIndex_HandlesVectorsSpanningMultipleDataBlocks_Regression to capture corruption when large vectors are stored across multiple data blocks
- add DropCollection_WithVectorIndex_Regression to demonstrate the invalid cast and leaked pages when dropping collections that own vector indexes

## Testing
- `dotnet test LiteDB.Tests -f net8.0 --filter FullyQualifiedName~VectorIndex_HandlesVectorsSpanningMultipleDataBlocks_Regression`
- `dotnet test LiteDB.Tests -f net8.0 --filter FullyQualifiedName~DropCollection_WithVectorIndex_Regression`


------
https://chatgpt.com/codex/tasks/task_e_68d52dccdbcc832aa711aeade56c5398