### PR TITLE
Add regression tests for vector index issues

### DIFF
--- a/LiteDB.Tests/Engine/DropCollection_Tests.cs
+++ b/LiteDB.Tests/Engine/DropCollection_Tests.cs
@@ -1,5 +1,10 @@
-﻿using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using FluentAssertions;
+using LiteDB;
+using LiteDB.Engine;
 using LiteDB.Tests.Utils;
 using Xunit;
 
@@ -7,6 +12,13 @@ namespace LiteDB.Tests.Engine
 {
     public class DropCollection_Tests
     {
+        private class VectorDocument
+        {
+            public int Id { get; set; }
+
+            public float[] Embedding { get; set; }
+        }
+
         [Fact]
         public void DropCollection()
         {
@@ -16,7 +28,7 @@ namespace LiteDB.Tests.Engine
 
                 var col = db.GetCollection("col");
 
-                col.Insert(new BsonDocument {["a"] = 1});
+                col.Insert(new BsonDocument { ["a"] = 1 });
 
                 db.GetCollectionNames().Should().Contain("col");
 
@@ -44,6 +56,57 @@ namespace LiteDB.Tests.Engine
                     var col = db.GetCollection("test");
                     col.Insert(new BsonDocument { ["_id"] = 1 });
                 }
+            }
+        }
+
+        [Fact]
+        public void DropCollection_WithVectorIndex_Regression()
+        {
+            using var tempFile = new TempFile();
+
+            using (var db = new LiteDatabase(tempFile.Filename))
+            {
+                var collection = db.GetCollection<VectorDocument>("vectors");
+                var dimensions = 192;
+                var options = new VectorIndexOptions((ushort)dimensions, VectorDistanceMetric.Cosine);
+
+                var documents = new List<VectorDocument>();
+
+                for (var i = 0; i < 64; i++)
+                {
+                    var embedding = new float[dimensions];
+
+                    for (var j = 0; j < dimensions; j++)
+                    {
+                        embedding[j] = (float)Math.Cos((i + 1) * (j + 1) * 0.03125d);
+                    }
+
+                    documents.Add(new VectorDocument
+                    {
+                        Id = i + 1,
+                        Embedding = embedding
+                    });
+                }
+
+                collection.Insert(documents);
+                collection.EnsureIndex("embedding_idx", x => x.Embedding, options);
+
+                db.Checkpoint();
+
+                var fileInfo = new FileInfo(tempFile.Filename);
+                var sizeAfterInsert = fileInfo.Length;
+                sizeAfterInsert.Should().BeGreaterThan(0);
+
+                var drop = () => db.DropCollection("vectors");
+
+                drop.Should().NotThrow("dropping a collection that owns vector indexes should release all associated pages");
+
+                db.Checkpoint();
+
+                fileInfo.Refresh();
+                var sizeAfterDrop = fileInfo.Length;
+
+                sizeAfterDrop.Should().BeLessThan(sizeAfterInsert, "vector index pages must be reclaimed when the collection is dropped");
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a regression test that indexes large vectors spanning multiple data blocks and asserts the reconstructed payloads remain intact
- add a regression test that drops a collection with a vector index to surface the skip-list cleanup bug

## Testing
- `dotnet test LiteDB.Tests -f net8.0 --filter FullyQualifiedName~VectorIndex_HandlesVectorsSpanningMultipleDataBlocks_Regression` *(fails: existing engine drops nodes for large vectors)*
- `dotnet test LiteDB.Tests -f net8.0 --filter FullyQualifiedName~DropCollection_WithVectorIndex_Regression` *(fails: existing engine throws InvalidCastException during drop)*

------
https://chatgpt.com/codex/tasks/task_e_68d52dccdbcc832aa711aeade56c5398