### PR TITLE
Fix vector index cleanup and key normalization

### DIFF
--- a/LiteDB.Tests/Engine/DropCollection_Tests.cs
+++ b/LiteDB.Tests/Engine/DropCollection_Tests.cs
@@ -376,8 +376,15 @@ namespace LiteDB.Tests.Engine
 
                 foreach (var pageID in pageIds.Distinct())
                 {
-                    var page = snapshot.GetPage<BasePage>(pageID);
-                    map[pageID] = page.PageType;
+                    try
+                    {
+                        var page = snapshot.GetPage<BasePage>(pageID);
+                        map[pageID] = page.PageType;
+                    }
+                    catch (LiteException ex) when (ex.Message.Contains("request page must be less or equals lastest page", StringComparison.Ordinal))
+                    {
+                        map[pageID] = PageType.Empty;
+                    }
                 }
 
                 return map;

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -295,7 +295,7 @@ namespace LiteDB.Tests.QueryTest
             inspection.NodeCount.Should().Be(documents.Count);
             inspection.ExternalNodes.Should().BeGreaterThan(0, "vectors large enough should be stored externally");
             inspection.MultiBlockNodes.Should().BeGreaterThan(0, "vectors should span multiple data blocks");
-            inspection.Mismatched.Should().NotBeEmpty("vector payloads spanning multiple data blocks are currently reconstructed incorrectly");
+            inspection.Mismatched.Should().BeEmpty("vector payloads spanning multiple data blocks must be reconstructed correctly");
 
             var target = documents[0].Embedding;
             var expectedTop = ComputeExpectedRanking(documents, target, VectorDistanceMetric.Cosine, 8);
@@ -646,7 +646,7 @@ namespace LiteDB.Tests.QueryTest
                             }
                         }
 
-                        hasMismatch.Should().BeTrue("multi-block vector payloads are currently reconstructed incorrectly");
+                        hasMismatch.Should().BeFalse("multi-block vector payloads spanning multiple data blocks must be reconstructed correctly");
 
                         for (var level = 0; level < node.LevelCount; level++)
                         {


### PR DESCRIPTION
## Summary
- normalize document key access so lookups treat Id and _id equivalently
- release reserved vector index pages and trim trailing empty pages when dropping collections
- update vector index tests to expect correct multi-block reconstruction and treat reclaimed pages as empty

## Testing
- dotnet test LiteDB.Tests/LiteDB.Tests.csproj -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68d589cd3718832a9474e94d398b6a2a