### PR TITLE
Move vector APIs to LiteDB.Vector extension surface

### DIFF
--- a/LiteDB.Benchmarks/Benchmarks/Queries/QueryWithVectorSimilarity.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Queries/QueryWithVectorSimilarity.cs
@@ -6,6 +6,7 @@ using BenchmarkDotNet.Attributes;
 using LiteDB;
 using LiteDB.Benchmarks.Models;
 using LiteDB.Benchmarks.Models.Generators;
+using LiteDB.Vector;
 
 namespace LiteDB.Benchmarks.Benchmarks.Queries
 {

--- a/LiteDB.Demo.Tools.VectorSearch/Services/DocumentStore.cs
+++ b/LiteDB.Demo.Tools.VectorSearch/Services/DocumentStore.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using LiteDB;
 using LiteDB.Demo.Tools.VectorSearch.Models;
+using LiteDB.Vector;
 
 namespace LiteDB.Demo.Tools.VectorSearch.Services
 {

--- a/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
+++ b/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Vector;
 using Xunit;
 
 namespace LiteDB.Tests.BsonValue_Types;

--- a/LiteDB.Tests/Engine/DropCollection_Tests.cs
+++ b/LiteDB.Tests/Engine/DropCollection_Tests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using LiteDB;
 using LiteDB.Engine;
 using LiteDB.Tests.Utils;
+using LiteDB.Vector;
 using Xunit;
 
 namespace LiteDB.Tests.Engine

--- a/LiteDB.Tests/Query/VectorExtensionSurface_Tests.cs
+++ b/LiteDB.Tests/Query/VectorExtensionSurface_Tests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using LiteDB;
+using LiteDB.Vector;
+using Xunit;
+
+namespace LiteDB.Tests.QueryTest
+{
+    public class VectorExtensionSurface_Tests
+    {
+        private class VectorDocument
+        {
+            public int Id { get; set; }
+
+            public float[] Embedding { get; set; }
+        }
+
+        [Fact]
+        public void Collection_Extension_Produces_Vector_Index_Plan()
+        {
+            using var db = new LiteDatabase(":memory:");
+            var collection = db.GetCollection<VectorDocument>("vectors");
+
+            collection.Insert(new VectorDocument { Id = 1, Embedding = new[] { 1f, 0f } });
+            collection.Insert(new VectorDocument { Id = 2, Embedding = new[] { 0f, 1f } });
+
+            collection.EnsureIndex(x => x.Embedding, new VectorIndexOptions(2));
+
+            var plan = collection.Query()
+                .WhereNear(x => x.Embedding, new[] { 1f, 0f }, maxDistance: 0.25)
+                .GetPlan();
+
+            plan["index"]["mode"].AsString.Should().Be("VECTOR INDEX SEARCH");
+            plan["index"]["expr"].AsString.Should().Be("$.Embedding");
+        }
+
+        [Fact]
+        public void Repository_Extension_Delegates_To_Vector_Index_Implementation()
+        {
+            using var db = new LiteDatabase(":memory:");
+            ILiteRepository repository = new LiteRepository(db);
+
+            repository.EnsureIndex<VectorDocument, float[]>(x => x.Embedding, new VectorIndexOptions(2));
+
+            var plan = repository.Query<VectorDocument>()
+                .WhereNear(x => x.Embedding, new[] { 1f, 0f }, maxDistance: 0.25)
+                .GetPlan();
+
+            plan["index"]["mode"].AsString.Should().Be("VECTOR INDEX SEARCH");
+            plan["index"]["expr"].AsString.Should().Be("$.Embedding");
+        }
+    }
+}

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using LiteDB;
 using LiteDB.Engine;
 using LiteDB.Tests;
+using LiteDB.Vector;
 using MathNet.Numerics.LinearAlgebra;
 using System;
 using System.Collections.Generic;

--- a/LiteDB/Client/Database/Collections/Index.cs
+++ b/LiteDB/Client/Database/Collections/Index.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
+using LiteDB.Vector;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -23,13 +24,19 @@ namespace LiteDB
             return _engine.EnsureIndex(_collection, name, expression, unique);
         }
 
-        public bool EnsureIndex(string name, BsonExpression expression, VectorIndexOptions options)
+        internal bool EnsureVectorIndex(string name, BsonExpression expression, VectorIndexOptions options)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
             if (expression == null) throw new ArgumentNullException(nameof(expression));
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             return _engine.EnsureVectorIndex(_collection, name, expression, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteCollectionVectorExtensions.EnsureIndex instead.")]
+        public bool EnsureIndex(string name, BsonExpression expression, VectorIndexOptions options)
+        {
+            return this.EnsureVectorIndex(name, expression, options);
         }
 
         /// <summary>
@@ -46,14 +53,20 @@ namespace LiteDB
             return this.EnsureIndex(name, expression, unique);
         }
 
-        public bool EnsureIndex(BsonExpression expression, VectorIndexOptions options)
+        internal bool EnsureVectorIndex(BsonExpression expression, VectorIndexOptions options)
         {
             if (expression == null) throw new ArgumentNullException(nameof(expression));
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             var name = Regex.Replace(expression.Source, @"[^a-z0-9]", "", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-            return this.EnsureIndex(name, expression, options);
+            return this.EnsureVectorIndex(name, expression, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteCollectionVectorExtensions.EnsureIndex instead.")]
+        public bool EnsureIndex(BsonExpression expression, VectorIndexOptions options)
+        {
+            return this.EnsureVectorIndex(expression, options);
         }
 
         /// <summary>
@@ -68,13 +81,19 @@ namespace LiteDB
             return this.EnsureIndex(expression, unique);
         }
 
-        public bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, VectorIndexOptions options)
+        internal bool EnsureVectorIndex<K>(Expression<Func<T, K>> keySelector, VectorIndexOptions options)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             var expression = this.GetIndexExpression(keySelector, convertEnumerableToMultiKey: false);
 
-            return this.EnsureIndex(expression, options);
+            return this.EnsureVectorIndex(expression, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteCollectionVectorExtensions.EnsureIndex instead.")]
+        public bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, VectorIndexOptions options)
+        {
+            return this.EnsureVectorIndex(keySelector, options);
         }
 
         /// <summary>
@@ -90,13 +109,19 @@ namespace LiteDB
             return this.EnsureIndex(name, expression, unique);
         }
 
-        public bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options)
+        internal bool EnsureVectorIndex<K>(string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
             var expression = this.GetIndexExpression(keySelector, convertEnumerableToMultiKey: false);
 
-            return this.EnsureIndex(name, expression, options);
+            return this.EnsureVectorIndex(name, expression, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteCollectionVectorExtensions.EnsureIndex instead.")]
+        public bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options)
+        {
+            return this.EnsureVectorIndex(name, keySelector, options);
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/ILiteCollection.cs
+++ b/LiteDB/Client/Database/ILiteCollection.cs
@@ -102,7 +102,6 @@ namespace LiteDB
         /// <param name="expression">Create a custom expression function to be indexed</param>
         /// <param name="unique">If is a unique index</param>
         bool EnsureIndex(string name, BsonExpression expression, bool unique = false);
-        bool EnsureIndex(string name, BsonExpression expression, VectorIndexOptions options);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already. Returns true if index was created or false if already exits
@@ -110,7 +109,6 @@ namespace LiteDB
         /// <param name="expression">Document field/expression</param>
         /// <param name="unique">If is a unique index</param>
         bool EnsureIndex(BsonExpression expression, bool unique = false);
-        bool EnsureIndex(BsonExpression expression, VectorIndexOptions options);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already.
@@ -118,7 +116,6 @@ namespace LiteDB
         /// <param name="keySelector">LinqExpression to be converted into BsonExpression to be indexed</param>
         /// <param name="unique">Create a unique keys index?</param>
         bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, bool unique = false);
-        bool EnsureIndex<K>(Expression<Func<T, K>> keySelector, VectorIndexOptions options);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already.
@@ -127,7 +124,6 @@ namespace LiteDB
         /// <param name="keySelector">LinqExpression to be converted into BsonExpression to be indexed</param>
         /// <param name="unique">Create a unique keys index?</param>
         bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, bool unique = false);
-        bool EnsureIndex<K>(string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options);
 
         /// <summary>
         /// Drop index and release slot for another index

--- a/LiteDB/Client/Database/ILiteQueryable.cs
+++ b/LiteDB/Client/Database/ILiteQueryable.cs
@@ -31,20 +31,6 @@ namespace LiteDB
         ILiteQueryableResult<BsonDocument> Select(BsonExpression selector);
         ILiteQueryableResult<K> Select<K>(Expression<Func<T, K>> selector);
 
-        /// <summary>
-        /// Filters documents where the given vector field is within cosine distance from the target vector.
-        /// </summary>
-        ILiteQueryable<T> WhereNear(string vectorField, float[] target, double maxDistance);
-        
-        /// <summary>
-        /// Immediately returns documents nearest to the target vector based on cosine distance.
-        /// </summary>
-        IEnumerable<T> FindNearest(string vectorField, float[] target, double maxDistance);
-        ILiteQueryable<T> WhereNear<K>(Expression<Func<T, K>> field, float[] target, double maxDistance);
-        ILiteQueryable<T> WhereNear(BsonExpression fieldExpr, float[] target, double maxDistance);
-        ILiteQueryableResult<T> TopKNear<K>(Expression<Func<T, K>> field, float[] target, int k);
-        ILiteQueryableResult<T> TopKNear(string field, float[] target, int k);
-        ILiteQueryableResult<T> TopKNear(BsonExpression fieldExpr, float[] target, int k);
     }
 
     public interface ILiteQueryableResult<T>

--- a/LiteDB/Client/Database/ILiteRepository.cs
+++ b/LiteDB/Client/Database/ILiteRepository.cs
@@ -69,7 +69,6 @@ namespace LiteDB
         /// <param name="unique">If is a unique index</param>
         /// <param name="collectionName">Collection Name</param>
         bool EnsureIndex<T>(string name, BsonExpression expression, bool unique = false, string collectionName = null);
-        bool EnsureIndex<T>(string name, BsonExpression expression, VectorIndexOptions options, string collectionName = null);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already. Returns true if index was created or false if already exits
@@ -78,7 +77,6 @@ namespace LiteDB
         /// <param name="unique">If is a unique index</param>
         /// <param name="collectionName">Collection Name</param>
         bool EnsureIndex<T>(BsonExpression expression, bool unique = false, string collectionName = null);
-        bool EnsureIndex<T>(BsonExpression expression, VectorIndexOptions options, string collectionName = null);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already.
@@ -87,7 +85,6 @@ namespace LiteDB
         /// <param name="unique">Create a unique keys index?</param>
         /// <param name="collectionName">Collection Name</param>
         bool EnsureIndex<T, K>(Expression<Func<T, K>> keySelector, bool unique = false, string collectionName = null);
-        bool EnsureIndex<T, K>(Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null);
 
         /// <summary>
         /// Create a new permanent index in all documents inside this collections if index not exists already.
@@ -97,7 +94,6 @@ namespace LiteDB
         /// <param name="unique">Create a unique keys index?</param>
         /// <param name="collectionName">Collection Name</param>
         bool EnsureIndex<T, K>(string name, Expression<Func<T, K>> keySelector, bool unique = false, string collectionName = null);
-        bool EnsureIndex<T, K>(string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null);
 
         /// <summary>
         /// Search for a single instance of T by Id. Shortcut from Query.SingleById

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -242,15 +242,15 @@ namespace LiteDB
             return BsonExpression.Create($"{fieldExpr.Source} VECTOR_SIM @0 <= @1", targetArray, new BsonValue(maxDistance));
         }
 
-        public ILiteQueryable<T> WhereNear(string vectorField, float[] target, double maxDistance)
+        internal ILiteQueryable<T> VectorWhereNear(string vectorField, float[] target, double maxDistance)
         {
             if (string.IsNullOrWhiteSpace(vectorField)) throw new ArgumentNullException(nameof(vectorField));
 
             var fieldExpr = BsonExpression.Create($"$.{vectorField}");
-            return this.WhereNear(fieldExpr, target, maxDistance);
+            return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
-        public ILiteQueryable<T> WhereNear(BsonExpression fieldExpr, float[] target, double maxDistance)
+        internal ILiteQueryable<T> VectorWhereNear(BsonExpression fieldExpr, float[] target, double maxDistance)
         {
             var filter = CreateVectorSimilarityFilter(fieldExpr, target, maxDistance);
 
@@ -263,34 +263,27 @@ namespace LiteDB
             return this;
         }
 
-        public ILiteQueryable<T> WhereNear<K>(Expression<Func<T, K>> field, float[] target, double maxDistance)
+        internal ILiteQueryable<T> VectorWhereNear<K>(Expression<Func<T, K>> field, float[] target, double maxDistance)
         {
             if (field == null) throw new ArgumentNullException(nameof(field));
 
             var fieldExpr = _mapper.GetExpression(field);
-            return this.WhereNear(fieldExpr, target, maxDistance);
-        }
-        
-        public IEnumerable<T> FindNearest(string vectorField, float[] target, double maxDistance)
-        {
-            this.WhereNear(vectorField, target, maxDistance);
-            return this.ToEnumerable();
+            return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
-
-        public ILiteQueryableResult<T> TopKNear<K>(Expression<Func<T, K>> field, float[] target, int k)
+        internal ILiteQueryableResult<T> VectorTopKNear<K>(Expression<Func<T, K>> field, float[] target, int k)
         {
             var fieldExpr = _mapper.GetExpression(field);
-            return this.TopKNear(fieldExpr, target, k);
+            return this.VectorTopKNear(fieldExpr, target, k);
         }
 
-        public ILiteQueryableResult<T> TopKNear(string field, float[] target, int k)
+        internal ILiteQueryableResult<T> VectorTopKNear(string field, float[] target, int k)
         {
             var fieldExpr = BsonExpression.Create($"$.{field}");
-            return this.TopKNear(fieldExpr, target, k);
+            return this.VectorTopKNear(fieldExpr, target, k);
         }
 
-        public ILiteQueryableResult<T> TopKNear(BsonExpression fieldExpr, float[] target, int k)
+        internal ILiteQueryableResult<T> VectorTopKNear(BsonExpression fieldExpr, float[] target, int k)
         {
             if (fieldExpr == null) throw new ArgumentNullException(nameof(fieldExpr));
             if (target == null || target.Length == 0) throw new ArgumentException("Target vector must be provided.", nameof(target));
@@ -308,6 +301,48 @@ namespace LiteDB
             return this
                 .OrderBy(simExpr, Query.Ascending)
                 .Limit(k);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]
+        public ILiteQueryable<T> WhereNear(string vectorField, float[] target, double maxDistance)
+        {
+            return this.VectorWhereNear(vectorField, target, maxDistance);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]
+        public ILiteQueryable<T> WhereNear(BsonExpression fieldExpr, float[] target, double maxDistance)
+        {
+            return this.VectorWhereNear(fieldExpr, target, maxDistance);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]
+        public ILiteQueryable<T> WhereNear<K>(Expression<Func<T, K>> field, float[] target, double maxDistance)
+        {
+            return this.VectorWhereNear(field, target, maxDistance);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.FindNearest extension instead.")]
+        public IEnumerable<T> FindNearest(string vectorField, float[] target, double maxDistance)
+        {
+            return this.VectorWhereNear(vectorField, target, maxDistance).ToEnumerable();
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.TopKNear extension instead.")]
+        public ILiteQueryableResult<T> TopKNear<K>(Expression<Func<T, K>> field, float[] target, int k)
+        {
+            return this.VectorTopKNear(field, target, k);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.TopKNear extension instead.")]
+        public ILiteQueryableResult<T> TopKNear(string field, float[] target, int k)
+        {
+            return this.VectorTopKNear(field, target, k);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.TopKNear extension instead.")]
+        public ILiteQueryableResult<T> TopKNear(BsonExpression fieldExpr, float[] target, int k)
+        {
+            return this.VectorTopKNear(fieldExpr, target, k);
         }
 
         #endregion

--- a/LiteDB/Client/Database/LiteRepository.cs
+++ b/LiteDB/Client/Database/LiteRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using LiteDB.Vector;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -15,6 +16,18 @@ namespace LiteDB
         #region Properties
 
         private readonly ILiteDatabase _db = null;
+
+        private LiteCollection<T> GetLiteCollection<T>(string collectionName)
+        {
+            var collection = _db.GetCollection<T>(collectionName);
+
+            if (collection is LiteCollection<T> liteCollection)
+            {
+                return liteCollection;
+            }
+
+            throw new InvalidOperationException("The current collection implementation does not support vector operations.");
+        }
 
         /// <summary>
         /// Get database instance
@@ -173,9 +186,15 @@ namespace LiteDB
             return _db.GetCollection<T>(collectionName).EnsureIndex(name, expression, unique);
         }
 
+        internal bool EnsureVectorIndex<T>(string name, BsonExpression expression, VectorIndexOptions options, string collectionName = null)
+        {
+            return this.GetLiteCollection<T>(collectionName).EnsureVectorIndex(name, expression, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteRepositoryVectorExtensions.EnsureIndex instead.")]
         public bool EnsureIndex<T>(string name, BsonExpression expression, VectorIndexOptions options, string collectionName = null)
         {
-            return _db.GetCollection<T>(collectionName).EnsureIndex(name, expression, options);
+            return this.EnsureVectorIndex<T>(name, expression, options, collectionName);
         }
 
         /// <summary>
@@ -189,9 +208,15 @@ namespace LiteDB
             return _db.GetCollection<T>(collectionName).EnsureIndex(expression, unique);
         }
 
+        internal bool EnsureVectorIndex<T>(BsonExpression expression, VectorIndexOptions options, string collectionName = null)
+        {
+            return this.GetLiteCollection<T>(collectionName).EnsureVectorIndex(expression, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteRepositoryVectorExtensions.EnsureIndex instead.")]
         public bool EnsureIndex<T>(BsonExpression expression, VectorIndexOptions options, string collectionName = null)
         {
-            return _db.GetCollection<T>(collectionName).EnsureIndex(expression, options);
+            return this.EnsureVectorIndex<T>(expression, options, collectionName);
         }
 
         /// <summary>
@@ -205,9 +230,15 @@ namespace LiteDB
             return _db.GetCollection<T>(collectionName).EnsureIndex(keySelector, unique);
         }
 
+        internal bool EnsureVectorIndex<T, K>(Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null)
+        {
+            return this.GetLiteCollection<T>(collectionName).EnsureVectorIndex(keySelector, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteRepositoryVectorExtensions.EnsureIndex instead.")]
         public bool EnsureIndex<T, K>(Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null)
         {
-            return _db.GetCollection<T>(collectionName).EnsureIndex(keySelector, options);
+            return this.EnsureVectorIndex<T, K>(keySelector, options, collectionName);
         }
 
         /// <summary>
@@ -222,9 +253,15 @@ namespace LiteDB
             return _db.GetCollection<T>(collectionName).EnsureIndex(name, keySelector, unique);
         }
 
+        internal bool EnsureVectorIndex<T, K>(string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null)
+        {
+            return this.GetLiteCollection<T>(collectionName).EnsureVectorIndex(name, keySelector, options);
+        }
+
+        [Obsolete("Add `using LiteDB.Vector;` and call LiteRepositoryVectorExtensions.EnsureIndex instead.")]
         public bool EnsureIndex<T, K>(string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null)
         {
-            return _db.GetCollection<T>(collectionName).EnsureIndex(name, keySelector, options);
+            return this.EnsureVectorIndex<T, K>(name, keySelector, options, collectionName);
         }
 
         #endregion

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using LiteDB.Vector;
 #if NETFRAMEWORK
 using System.Security.AccessControl;
 using System.Security.Principal;

--- a/LiteDB/Client/Vector/LiteCollectionVectorExtensions.cs
+++ b/LiteDB/Client/Vector/LiteCollectionVectorExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq.Expressions;
+
+namespace LiteDB.Vector
+{
+    /// <summary>
+    /// Extension methods that expose vector-aware index creation for <see cref="ILiteCollection{T}"/>.
+    /// </summary>
+    public static class LiteCollectionVectorExtensions
+    {
+        public static bool EnsureIndex<T>(this ILiteCollection<T> collection, string name, BsonExpression expression, VectorIndexOptions options)
+        {
+            return Unwrap(collection).EnsureVectorIndex(name, expression, options);
+        }
+
+        public static bool EnsureIndex<T>(this ILiteCollection<T> collection, BsonExpression expression, VectorIndexOptions options)
+        {
+            return Unwrap(collection).EnsureVectorIndex(expression, options);
+        }
+
+        public static bool EnsureIndex<T, K>(this ILiteCollection<T> collection, Expression<Func<T, K>> keySelector, VectorIndexOptions options)
+        {
+            return Unwrap(collection).EnsureVectorIndex(keySelector, options);
+        }
+
+        public static bool EnsureIndex<T, K>(this ILiteCollection<T> collection, string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options)
+        {
+            return Unwrap(collection).EnsureVectorIndex(name, keySelector, options);
+        }
+
+        private static LiteCollection<T> Unwrap<T>(ILiteCollection<T> collection)
+        {
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (collection is LiteCollection<T> concrete)
+            {
+                return concrete;
+            }
+
+            throw new ArgumentException("Vector index operations require LiteDB's default collection implementation.", nameof(collection));
+        }
+    }
+}

--- a/LiteDB/Client/Vector/LiteQueryableVectorExtensions.cs
+++ b/LiteDB/Client/Vector/LiteQueryableVectorExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace LiteDB.Vector
+{
+    /// <summary>
+    /// Extension methods that surface vector-aware query capabilities for <see cref="ILiteQueryable{T}"/>.
+    /// </summary>
+    public static class LiteQueryableVectorExtensions
+    {
+        public static ILiteQueryable<T> WhereNear<T>(this ILiteQueryable<T> source, string vectorField, float[] target, double maxDistance)
+        {
+            return Unwrap(source).VectorWhereNear(vectorField, target, maxDistance);
+        }
+
+        public static ILiteQueryable<T> WhereNear<T>(this ILiteQueryable<T> source, BsonExpression fieldExpr, float[] target, double maxDistance)
+        {
+            return Unwrap(source).VectorWhereNear(fieldExpr, target, maxDistance);
+        }
+
+        public static ILiteQueryable<T> WhereNear<T, K>(this ILiteQueryable<T> source, Expression<Func<T, K>> field, float[] target, double maxDistance)
+        {
+            return Unwrap(source).VectorWhereNear(field, target, maxDistance);
+        }
+
+        public static IEnumerable<T> FindNearest<T>(this ILiteQueryable<T> source, string vectorField, float[] target, double maxDistance)
+        {
+            var queryable = Unwrap(source);
+            return queryable.VectorWhereNear(vectorField, target, maxDistance).ToEnumerable();
+        }
+
+        public static ILiteQueryableResult<T> TopKNear<T, K>(this ILiteQueryable<T> source, Expression<Func<T, K>> field, float[] target, int k)
+        {
+            return Unwrap(source).VectorTopKNear(field, target, k);
+        }
+
+        public static ILiteQueryableResult<T> TopKNear<T>(this ILiteQueryable<T> source, string field, float[] target, int k)
+        {
+            return Unwrap(source).VectorTopKNear(field, target, k);
+        }
+
+        public static ILiteQueryableResult<T> TopKNear<T>(this ILiteQueryable<T> source, BsonExpression fieldExpr, float[] target, int k)
+        {
+            return Unwrap(source).VectorTopKNear(fieldExpr, target, k);
+        }
+
+        private static LiteQueryable<T> Unwrap<T>(ILiteQueryable<T> source)
+        {
+            if (source is null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (source is LiteQueryable<T> liteQueryable)
+            {
+                return liteQueryable;
+            }
+
+            throw new ArgumentException("Vector operations require LiteDB's default queryable implementation.", nameof(source));
+        }
+    }
+}

--- a/LiteDB/Client/Vector/LiteRepositoryVectorExtensions.cs
+++ b/LiteDB/Client/Vector/LiteRepositoryVectorExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq.Expressions;
+
+namespace LiteDB.Vector
+{
+    /// <summary>
+    /// Extension methods that expose vector-aware index creation for <see cref="ILiteRepository"/>.
+    /// </summary>
+    public static class LiteRepositoryVectorExtensions
+    {
+        public static bool EnsureIndex<T>(this ILiteRepository repository, string name, BsonExpression expression, VectorIndexOptions options, string collectionName = null)
+        {
+            return Unwrap(repository).EnsureVectorIndex<T>(name, expression, options, collectionName);
+        }
+
+        public static bool EnsureIndex<T>(this ILiteRepository repository, BsonExpression expression, VectorIndexOptions options, string collectionName = null)
+        {
+            return Unwrap(repository).EnsureVectorIndex<T>(expression, options, collectionName);
+        }
+
+        public static bool EnsureIndex<T, K>(this ILiteRepository repository, Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null)
+        {
+            return Unwrap(repository).EnsureVectorIndex<T, K>(keySelector, options, collectionName);
+        }
+
+        public static bool EnsureIndex<T, K>(this ILiteRepository repository, string name, Expression<Func<T, K>> keySelector, VectorIndexOptions options, string collectionName = null)
+        {
+            return Unwrap(repository).EnsureVectorIndex<T, K>(name, keySelector, options, collectionName);
+        }
+
+        private static LiteRepository Unwrap(ILiteRepository repository)
+        {
+            if (repository is null)
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
+            if (repository is LiteRepository liteRepository)
+            {
+                return liteRepository;
+            }
+
+            throw new ArgumentException("Vector index operations require LiteDB's default repository implementation.", nameof(repository));
+        }
+    }
+}

--- a/LiteDB/Client/Vector/VectorDistanceMetric.cs
+++ b/LiteDB/Client/Vector/VectorDistanceMetric.cs
@@ -1,0 +1,12 @@
+namespace LiteDB.Vector
+{
+    /// <summary>
+    /// Supported metrics for vector similarity operations.
+    /// </summary>
+    public enum VectorDistanceMetric : byte
+    {
+        Euclidean = 0,
+        Cosine = 1,
+        DotProduct = 2
+    }
+}

--- a/LiteDB/Client/Vector/VectorIndexOptions.cs
+++ b/LiteDB/Client/Vector/VectorIndexOptions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace LiteDB
+namespace LiteDB.Vector
 {
     /// <summary>
     /// Options used when creating a vector-aware index.

--- a/LiteDB/Engine/Engine/Index.cs
+++ b/LiteDB/Engine/Engine/Index.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using LiteDB.Vector;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine

--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Vector;
 
 using static LiteDB.Constants;
 

--- a/LiteDB/Engine/ILiteEngine.cs
+++ b/LiteDB/Engine/ILiteEngine.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using LiteDB.Vector;
 
 namespace LiteDB.Engine
 {

--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Vector;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine

--- a/LiteDB/Engine/Services/VectorIndexService.cs
+++ b/LiteDB/Engine/Services/VectorIndexService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using LiteDB;
+using LiteDB.Vector;
 
 namespace LiteDB.Engine
 {

--- a/LiteDB/Engine/Structures/VectorIndexMetadata.cs
+++ b/LiteDB/Engine/Structures/VectorIndexMetadata.cs
@@ -1,17 +1,5 @@
+using LiteDB.Vector;
 using System;
-
-namespace LiteDB
-{
-    /// <summary>
-    /// Supported metrics for vector similarity operations.
-    /// </summary>
-    public enum VectorDistanceMetric : byte
-    {
-        Euclidean = 0,
-        Cosine = 1,
-        DotProduct = 2
-    }
-}
 
 namespace LiteDB.Engine
 {


### PR DESCRIPTION
## Summary
- remove vector query/index overloads from the core interfaces and keep the concrete types delegating through obsolete helpers
- add the LiteDB.Vector namespace with extension methods plus relocated VectorIndexOptions/VectorDistanceMetric
- update engine/client callers for the new namespace and add tests that exercise the extension surface

## Testing
- dotnet test LiteDB.Tests/LiteDB.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68d7ef1f9544832ab0d52012492d8635