### PR TITLE
Add tolerance-aware spatial helpers and expressions

### DIFF
--- a/LiteDB.Benchmarks/Benchmarks/Spatial/SpatialQueryBenchmarks.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Spatial/SpatialQueryBenchmarks.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using LiteDB.Benchmarks.Models.Spatial;
 using LiteDB.Spatial;
+using SpatialApi = LiteDB.Spatial.Spatial;
 
 namespace LiteDB.Benchmarks.Benchmarks.Spatial
 {
@@ -23,9 +24,9 @@ namespace LiteDB.Benchmarks.Benchmarks.Spatial
             DatabaseInstance = new LiteDatabase(ConnectionString());
             _collection = DatabaseInstance.GetCollection<SpatialDocument>("places");
 
-            Spatial.EnsurePointIndex(_collection, x => x.Location);
-            Spatial.EnsureShapeIndex(_collection, x => x.Region);
-            Spatial.EnsureShapeIndex(_collection, x => x.Route);
+            SpatialApi.EnsurePointIndex(_collection, x => x.Location);
+            SpatialApi.EnsureShapeIndex(_collection, x => x.Region);
+            SpatialApi.EnsureShapeIndex(_collection, x => x.Route);
 
             var documents = SpatialDocumentGenerator.Generate(DatasetSize);
             _collection.Insert(documents);
@@ -40,25 +41,25 @@ namespace LiteDB.Benchmarks.Benchmarks.Spatial
         [Benchmark(Baseline = true)]
         public List<SpatialDocument> NearQuery()
         {
-            return Spatial.Near(_collection, x => x.Location, _center, _radiusMeters).ToList();
+            return SpatialApi.Near(_collection, x => x.Location, _center, _radiusMeters).ToList();
         }
 
         [Benchmark]
         public List<SpatialDocument> BoundingBoxQuery()
         {
-            return Spatial.WithinBoundingBox(_collection, x => x.Location, -0.2, -0.2, 0.2, 0.2).ToList();
+            return SpatialApi.WithinBoundingBox(_collection, x => x.Location, -0.2, -0.2, 0.2, 0.2).ToList();
         }
 
         [Benchmark]
         public List<SpatialDocument> PolygonContainmentQuery()
         {
-            return Spatial.Within(_collection, x => x.Region, _searchArea).ToList();
+            return SpatialApi.Within(_collection, x => x.Region, _searchArea).ToList();
         }
 
         [Benchmark]
         public List<SpatialDocument> RouteIntersectionQuery()
         {
-            return Spatial.Intersects(_collection, x => x.Route, _searchArea).ToList();
+            return SpatialApi.Intersects(_collection, x => x.Route, _searchArea).ToList();
         }
 
         [GlobalCleanup]

--- a/LiteDB.Benchmarks/Models/Spatial/SpatialDocument.cs
+++ b/LiteDB.Benchmarks/Models/Spatial/SpatialDocument.cs
@@ -1,3 +1,4 @@
+using System;
 using LiteDB.Spatial;
 
 namespace LiteDB.Benchmarks.Models.Spatial

--- a/LiteDB.Benchmarks/Models/Spatial/SpatialDocumentGenerator.cs
+++ b/LiteDB.Benchmarks/Models/Spatial/SpatialDocumentGenerator.cs
@@ -41,10 +41,10 @@ namespace LiteDB.Benchmarks.Models.Spatial
 
         private static GeoPolygon BuildSquare(GeoPoint center, double halfExtent)
         {
-            var minLat = GeoMath.ClampLatitude(center.Lat - halfExtent);
-            var maxLat = GeoMath.ClampLatitude(center.Lat + halfExtent);
-            var minLon = GeoMath.NormalizeLongitude(center.Lon - halfExtent);
-            var maxLon = GeoMath.NormalizeLongitude(center.Lon + halfExtent);
+            var minLat = ClampLatitude(center.Lat - halfExtent);
+            var maxLat = ClampLatitude(center.Lat + halfExtent);
+            var minLon = NormalizeLongitude(center.Lon - halfExtent);
+            var maxLon = NormalizeLongitude(center.Lon + halfExtent);
 
             var points = new List<GeoPoint>
             {
@@ -73,6 +73,32 @@ namespace LiteDB.Benchmarks.Models.Spatial
             };
 
             return new GeoLineString(points);
+        }
+
+        private static double ClampLatitude(double latitude)
+        {
+            return Math.Max(-90d, Math.Min(90d, latitude));
+        }
+
+        private static double NormalizeLongitude(double lon)
+        {
+            if (double.IsNaN(lon))
+            {
+                return lon;
+            }
+
+            var result = lon % 360d;
+
+            if (result <= -180d)
+            {
+                result += 360d;
+            }
+            else if (result > 180d)
+            {
+                result -= 360d;
+            }
+
+            return result;
         }
     }
 }

--- a/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using LiteDB.Spatial;
 using SpatialMethods = LiteDB.Spatial.Spatial;
@@ -13,16 +14,49 @@ namespace LiteDB
                 return null;
             }
 
-            if (method.DeclaringType != typeof(SpatialMethods))
+            if (method.DeclaringType == typeof(SpatialExpressions))
             {
-                return null;
+                return ResolveSpatialExpressions(method);
             }
 
+            if (method.DeclaringType == typeof(SpatialMethods))
+            {
+                return ResolveSpatialMethods(method);
+            }
+
+            return null;
+        }
+
+        public string ResolveMember(MemberInfo member) => null;
+
+        public string ResolveCtor(ConstructorInfo ctor) => null;
+
+        private static string ResolveSpatialExpressions(MethodInfo method)
+        {
+            switch (method.Name)
+            {
+                case nameof(SpatialExpressions.Near):
+                    return ResolveNearPattern(method);
+                case nameof(SpatialExpressions.Within):
+                    return "SPATIAL_WITHIN(@0, @1)";
+                case nameof(SpatialExpressions.Intersects):
+                    return "SPATIAL_INTERSECTS(@0, @1)";
+                case nameof(SpatialExpressions.Contains):
+                    return "SPATIAL_CONTAINS(@0, @1)";
+                case nameof(SpatialExpressions.WithinBoundingBox):
+                    return "SPATIAL_WITHIN_BOX(@0, @1, @2, @3, @4)";
+            }
+
+            return null;
+        }
+
+        private static string ResolveSpatialMethods(MethodInfo method)
+        {
             var parameters = method.GetParameters();
 
             if (method.Name == nameof(SpatialMethods.Near) && parameters.Length == 3 && parameters[0].ParameterType == typeof(GeoPoint))
             {
-                return "SPATIAL_NEAR(@0, @1, @2)";
+                return ResolveNearPattern(method);
             }
 
             if (method.Name == nameof(SpatialMethods.Within) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
@@ -43,8 +77,22 @@ namespace LiteDB
             return null;
         }
 
-        public string ResolveMember(MemberInfo member) => null;
+        private static string ResolveNearPattern(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
 
-        public string ResolveCtor(ConstructorInfo ctor) => null;
+            if (parameters.Length == 3)
+            {
+                var formula = SpatialMethods.Options.Distance.ToString();
+                return $"SPATIAL_NEAR(@0, @1, @2, '{formula}')";
+            }
+
+            if (parameters.Length == 4)
+            {
+                return "SPATIAL_NEAR(@0, @1, @2, @3)";
+            }
+
+            throw new NotSupportedException("Unsupported overload for spatial Near expression");
+        }
     }
 }

--- a/LiteDB/Document/Expression/Methods/Spatial.cs
+++ b/LiteDB/Document/Expression/Methods/Spatial.cs
@@ -1,3 +1,4 @@
+using System;
 using LiteDB.Spatial;
 
 namespace LiteDB
@@ -6,7 +7,7 @@ namespace LiteDB
     {
         public static BsonValue SPATIAL_INTERSECTS_MBB(BsonValue mbb, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            if (mbb == null || mbb.IsNull || !mbb.IsArray || mbb.AsArray.Count < 4)
+            if (mbb == null || mbb.IsNull || !mbb.IsArray || mbb.AsArray.Count != 4)
             {
                 return false;
             }
@@ -16,83 +17,157 @@ namespace LiteDB
                 return false;
             }
 
-            var candidate = new GeoBoundingBox(mbb.AsArray[0].AsDouble, mbb.AsArray[1].AsDouble, mbb.AsArray[2].AsDouble, mbb.AsArray[3].AsDouble);
+            var candidate = ToBoundingBox(mbb);
             var query = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
 
             return candidate.Intersects(query);
         }
 
-        public static BsonValue SPATIAL_NEAR(BsonValue candidate, BsonValue center, BsonValue radiusMeters)
+        public static BsonValue SPATIAL_MBB_INTERSECTS(BsonValue mbb, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            if (!radiusMeters.IsNumber)
+            return SPATIAL_INTERSECTS_MBB(mbb, minLat, minLon, maxLat, maxLon);
+        }
+
+        public static BsonValue SPATIAL_NEAR(BsonValue candidate, BsonValue center, BsonValue radius)
+        {
+            return SPATIAL_NEAR(candidate, center, radius, BsonValue.Null);
+        }
+
+        public static BsonValue SPATIAL_NEAR(BsonValue candidate, BsonValue center, BsonValue radius, BsonValue formula)
+        {
+            if (!radius.IsNumber)
             {
                 return false;
             }
 
-            var candidatePoint = ToGeoPoint(candidate);
-            var centerPoint = ToGeoPoint(center);
+            var candidatePoint = ToShape(candidate) as GeoPoint;
+            var centerPoint = ToShape(center) as GeoPoint;
 
             if (candidatePoint == null || centerPoint == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Near(candidatePoint, centerPoint, radiusMeters.AsDouble);
+            var distanceFormula = ParseFormula(formula);
+            var radiusMeters = radius.AsDouble;
+
+            return SpatialExpressions.Near(candidatePoint, centerPoint, radiusMeters, distanceFormula);
+        }
+
+        public static BsonValue SPATIAL_WITHIN_BOX(BsonValue value, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
+        {
+            var shape = ToShape(value);
+            if (shape == null)
+            {
+                return false;
+            }
+
+            var box = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
+
+            return shape switch
+            {
+                GeoPoint point => SpatialExpressions.WithinBoundingBox(point, box.MinLat, box.MinLon, box.MaxLat, box.MaxLon),
+                GeoShape geoShape => geoShape.GetBoundingBox().Intersects(box),
+                _ => false
+            };
         }
 
         public static BsonValue SPATIAL_WITHIN(BsonValue candidate, BsonValue polygon)
         {
-            var shape = ToGeoShape(candidate);
-            var area = ToGeoShape(polygon) as GeoPolygon;
+            var shape = ToShape(candidate);
+            var area = ToShape(polygon) as GeoPolygon;
 
             if (shape == null || area == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Within(shape, area);
+            return SpatialExpressions.Within(shape, area);
         }
 
         public static BsonValue SPATIAL_INTERSECTS(BsonValue candidate, BsonValue other)
         {
-            var left = ToGeoShape(candidate);
-            var right = ToGeoShape(other);
+            var left = ToShape(candidate);
+            var right = ToShape(other);
 
             if (left == null || right == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Intersects(left, right);
+            return SpatialExpressions.Intersects(left, right);
         }
 
-        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue candidate, BsonValue point)
+        public static BsonValue SPATIAL_CONTAINS(BsonValue candidate, BsonValue point)
         {
-            var shape = ToGeoShape(candidate);
-            var geoPoint = ToGeoPoint(point);
+            var shape = ToShape(candidate);
+            var geoPoint = ToShape(point) as GeoPoint;
 
             if (shape == null || geoPoint == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Contains(shape, geoPoint);
+            return SpatialExpressions.Contains(shape, geoPoint);
         }
 
-        private static GeoShape ToGeoShape(BsonValue value)
+        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue candidate, BsonValue point)
         {
-            if (value == null || value.IsNull || !value.IsDocument)
+            return SPATIAL_CONTAINS(candidate, point);
+        }
+
+        private static GeoBoundingBox ToBoundingBox(BsonValue value)
+        {
+            var array = value.AsArray;
+            return new GeoBoundingBox(array[0].AsDouble, array[1].AsDouble, array[2].AsDouble, array[3].AsDouble);
+        }
+
+        private static GeoShape ToShape(BsonValue value)
+        {
+            if (value == null || value.IsNull)
             {
                 return null;
             }
 
-            return GeoJson.FromBson(value.AsDocument);
+            if (value.IsDocument)
+            {
+                return GeoJson.FromBson(value.AsDocument);
+            }
+
+            if (value.IsArray && value.AsArray.Count >= 2)
+            {
+                var array = value.AsArray;
+                var lon = array[0].AsDouble;
+                var lat = array[1].AsDouble;
+                return new GeoPoint(lat, lon);
+            }
+
+            if (value.RawValue is GeoShape shape)
+            {
+                return shape;
+            }
+
+            return null;
         }
 
-        private static GeoPoint ToGeoPoint(BsonValue value)
+        private static DistanceFormula ParseFormula(BsonValue formula)
         {
-            var shape = ToGeoShape(value);
-            return shape as GeoPoint;
+            if (formula == null || formula.IsNull)
+            {
+                return Spatial.Spatial.Options.Distance;
+            }
+
+            if (formula.IsString && Enum.TryParse(formula.AsString, out DistanceFormula parsed))
+            {
+                return parsed;
+            }
+
+            if (formula.IsInt32)
+            {
+                return (DistanceFormula)formula.AsInt32;
+            }
+
+            return Spatial.Spatial.Options.Distance;
         }
     }
 }

--- a/LiteDB/Spatial/GeoBoundingBox.cs
+++ b/LiteDB/Spatial/GeoBoundingBox.cs
@@ -61,6 +61,24 @@ namespace LiteDB.Spatial
             return !(other.MinLat > MaxLat || other.MaxLat < MinLat) && LongitudesOverlap(other);
         }
 
+        public GeoBoundingBox Expand(double meters)
+        {
+            if (meters <= 0d)
+            {
+                return this;
+            }
+
+            var angularDistance = meters / GeoMath.EarthRadiusMeters;
+            var deltaDegrees = angularDistance * (180d / Math.PI);
+
+            var minLat = GeoMath.ClampLatitude(MinLat - deltaDegrees);
+            var maxLat = GeoMath.ClampLatitude(MaxLat + deltaDegrees);
+            var minLon = GeoMath.NormalizeLongitude(MinLon - deltaDegrees);
+            var maxLon = GeoMath.NormalizeLongitude(MaxLon + deltaDegrees);
+
+            return new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+        }
+
         private bool LongitudesOverlap(GeoBoundingBox other)
         {
             var lonRange = new LongitudeRange(MinLon, MaxLon);

--- a/LiteDB/Spatial/GeoMath.cs
+++ b/LiteDB/Spatial/GeoMath.cs
@@ -8,7 +8,7 @@ namespace LiteDB.Spatial
 
         private const double DegToRad = Math.PI / 180d;
 
-        internal static double EpsilonDegrees => Spatial.Options.NumericToleranceDegrees;
+        internal static double EpsilonDegrees => Spatial.Options.ToleranceDegrees;
 
         public static double ClampLatitude(double latitude)
         {

--- a/LiteDB/Spatial/Spatial.cs
+++ b/LiteDB/Spatial/Spatial.cs
@@ -26,7 +26,7 @@ namespace LiteDB.Spatial
 
             if (precisionBits <= 0)
             {
-                precisionBits = Options.IndexPrecisionBits;
+                precisionBits = Options.DefaultIndexPrecisionBits;
             }
 
             var getter = selector.Compile();
@@ -82,26 +82,14 @@ namespace LiteDB.Spatial
             if (center == null) throw new ArgumentNullException(nameof(center));
             if (radiusMeters < 0d) throw new ArgumentOutOfRangeException(nameof(radiusMeters));
 
-            if (candidate == null)
-            {
-                return false;
-            }
-
-            var distance = GeoMath.DistanceMeters(center, candidate, Options.Distance);
-            return distance <= radiusMeters;
+            return SpatialExpressions.Near(candidate, center, radiusMeters, Options.Distance);
         }
 
         public static bool Within(GeoShape candidate, GeoPolygon area)
         {
             if (area == null) throw new ArgumentNullException(nameof(area));
 
-            return candidate switch
-            {
-                GeoPoint point => Geometry.ContainsPoint(area, point),
-                GeoPolygon polygon => Geometry.Intersects(area, polygon) && polygon.Outer.All(p => Geometry.ContainsPoint(area, p)),
-                GeoLineString line => line.Points.All(p => Geometry.ContainsPoint(area, p)),
-                _ => false
-            };
+            return SpatialExpressions.Within(candidate, area);
         }
 
         public static bool Intersects(GeoShape candidate, GeoShape query)
@@ -111,37 +99,14 @@ namespace LiteDB.Spatial
                 return false;
             }
 
-            return candidate switch
-            {
-                GeoPoint point when query is GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
-                GeoPoint point when query is GeoLineString line => Geometry.LineContainsPoint(line, point),
-                GeoPoint point when query is GeoPoint other => Math.Abs(point.Lat - other.Lat) < GeoMath.EpsilonDegrees && Math.Abs(point.Lon - other.Lon) < GeoMath.EpsilonDegrees,
-                GeoLineString line when query is GeoPolygon polygon => Geometry.Intersects(line, polygon),
-                GeoLineString line when query is GeoLineString other => Geometry.Intersects(line, other),
-                GeoLineString line when query is GeoPoint point => Geometry.LineContainsPoint(line, point),
-                GeoPolygon polygon when query is GeoPolygon other => Geometry.Intersects(polygon, other),
-                GeoPolygon polygon when query is GeoLineString line => Geometry.Intersects(line, polygon),
-                GeoPolygon polygon when query is GeoPoint point => Geometry.ContainsPoint(polygon, point),
-                _ => false
-            };
+            return SpatialExpressions.Intersects(candidate, query);
         }
 
         public static bool Contains(GeoShape candidate, GeoPoint point)
         {
             if (point == null) throw new ArgumentNullException(nameof(point));
 
-            if (candidate == null)
-            {
-                return false;
-            }
-
-            return candidate switch
-            {
-                GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
-                GeoLineString line => Geometry.LineContainsPoint(line, point),
-                GeoPoint candidatePoint => Math.Abs(candidatePoint.Lat - point.Lat) < GeoMath.EpsilonDegrees && Math.Abs(candidatePoint.Lon - point.Lon) < GeoMath.EpsilonDegrees,
-                _ => false
-            };
+            return SpatialExpressions.Contains(candidate, point);
         }
 
         public static IEnumerable<T> Near<T>(ILiteCollection<T> collection, Func<T, GeoPoint> selector, GeoPoint center, double radiusMeters, int? limit = null)
@@ -155,11 +120,13 @@ namespace LiteDB.Spatial
             var mapper = GetMapper(lite);
             EnsureMapperRegistration(mapper);
 
+            var normalizedCenter = center.Normalize();
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
-            var boundingBox = GeoMath.BoundingBoxForCircle(center, radiusMeters);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var boundingBox = GeoMath.BoundingBoxForCircle(normalizedCenter, radiusMeters);
+            var queryBoundingBox = ExpandBoundingBoxForQuery(boundingBox);
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBoundingBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBoundingBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
@@ -168,13 +135,13 @@ namespace LiteDB.Spatial
             foreach (var item in source)
             {
                 var point = selector(item);
-                if (point == null || !boundingBox.Contains(point))
+                if (point == null || !queryBoundingBox.Contains(point))
                 {
                     continue;
                 }
 
-                var distance = GeoMath.DistanceMeters(center, point, Options.Distance);
-                if (distance <= radiusMeters)
+                var distance = GeoMath.DistanceMeters(normalizedCenter, point, Options.Distance);
+                if (distance <= radiusMeters + GetDistanceToleranceMeters())
                 {
                     matches.Add((item, distance));
                 }
@@ -205,10 +172,11 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+            var queryBoundingBox = ExpandBoundingBoxForQuery(boundingBox);
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBoundingBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBoundingBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
@@ -217,7 +185,12 @@ namespace LiteDB.Spatial
                 .Where(entity =>
                 {
                     var point = selector(entity);
-                    return point != null && boundingBox.Contains(point);
+                    if (point == null || !queryBoundingBox.Contains(point))
+                    {
+                        return false;
+                    }
+
+                    return boundingBox.Contains(point);
                 })
                 .ToList();
         }
@@ -233,7 +206,7 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = area.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(ExpandBoundingBoxForQuery(boundingBox));
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
@@ -254,7 +227,7 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = query.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(ExpandBoundingBoxForQuery(boundingBox));
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
@@ -275,7 +248,7 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = new GeoBoundingBox(point.Lat, point.Lon, point.Lat, point.Lon);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(ExpandBoundingBoxForQuery(boundingBox));
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
@@ -283,6 +256,35 @@ namespace LiteDB.Spatial
                 var shape = selector(entity);
                 return shape != null && Contains(shape, point);
             }).ToList();
+        }
+
+        private static GeoBoundingBox ExpandBoundingBoxForQuery(GeoBoundingBox box)
+        {
+            var padding = GetCombinedBoundingPaddingMeters();
+            return padding > 0d ? box.Expand(padding) : box;
+        }
+
+        private static double GetCombinedBoundingPaddingMeters()
+        {
+            var padding = Math.Max(0d, Options.BoundingBoxPaddingMeters);
+            return padding + GetAngularToleranceMeters();
+        }
+
+        internal static double GetDistanceToleranceMeters()
+        {
+            var distanceTolerance = Math.Max(0d, Options.DistanceToleranceMeters);
+            return distanceTolerance + GetAngularToleranceMeters();
+        }
+
+        private static double GetAngularToleranceMeters()
+        {
+            var toleranceDegrees = Options.ToleranceDegrees;
+            if (toleranceDegrees <= 0d)
+            {
+                return 0d;
+            }
+
+            return GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d);
         }
 
         private static LiteCollection<T> GetLiteCollection<T>(ILiteCollection<T> collection)

--- a/LiteDB/Spatial/SpatialExpressions.cs
+++ b/LiteDB/Spatial/SpatialExpressions.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using LiteDB.Spatial;
+
+namespace LiteDB
+{
+    public static class SpatialExpressions
+    {
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters)
+        {
+            return Near(point, center, radiusMeters, Spatial.Spatial.Options.Distance);
+        }
+
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters, DistanceFormula formula)
+        {
+            if (point == null || center == null)
+            {
+                return false;
+            }
+
+            if (radiusMeters < 0d)
+            {
+                return false;
+            }
+
+            var distance = GeoMath.DistanceMeters(point, center, formula);
+            return distance <= radiusMeters + Spatial.Spatial.GetDistanceToleranceMeters();
+        }
+
+        public static bool Within(GeoShape shape, GeoPolygon polygon)
+        {
+            if (shape == null || polygon == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPoint point => Geometry.ContainsPoint(polygon, point),
+                GeoPolygon other => Geometry.Intersects(polygon, other) && other.Outer.All(p => Geometry.ContainsPoint(polygon, p)),
+                GeoLineString line => line.Points.All(p => Geometry.ContainsPoint(polygon, p)),
+                _ => false
+            };
+        }
+
+        public static bool Intersects(GeoShape shape, GeoShape other)
+        {
+            if (shape == null || other == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPoint point when other is GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoPoint point when other is GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint point when other is GeoPoint otherPoint => Math.Abs(point.Lat - otherPoint.Lat) < GeoMath.EpsilonDegrees && Math.Abs(point.Lon - otherPoint.Lon) < GeoMath.EpsilonDegrees,
+                GeoLineString line when other is GeoPolygon polygon => Geometry.Intersects(line, polygon),
+                GeoLineString line when other is GeoLineString otherLine => Geometry.Intersects(line, otherLine),
+                GeoLineString line when other is GeoPoint point => Geometry.LineContainsPoint(line, point),
+                GeoPolygon polygon when other is GeoPolygon otherPolygon => Geometry.Intersects(polygon, otherPolygon),
+                GeoPolygon polygon when other is GeoLineString line => Geometry.Intersects(line, polygon),
+                GeoPolygon polygon when other is GeoPoint point => Geometry.ContainsPoint(polygon, point),
+                _ => false
+            };
+        }
+
+        public static bool Contains(GeoShape shape, GeoPoint point)
+        {
+            if (shape == null || point == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint candidate => Math.Abs(candidate.Lat - point.Lat) < GeoMath.EpsilonDegrees && Math.Abs(candidate.Lon - point.Lon) < GeoMath.EpsilonDegrees,
+                _ => false
+            };
+        }
+
+        public static bool WithinBoundingBox(GeoPoint point, double minLat, double minLon, double maxLat, double maxLon)
+        {
+            if (point == null)
+            {
+                return false;
+            }
+
+            var box = new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+            return box.Contains(point);
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialMetadataStore.cs
+++ b/LiteDB/Spatial/SpatialMetadataStore.cs
@@ -41,7 +41,7 @@ namespace LiteDB.Spatial
             var engine = Spatial.GetEngine(collection);
             if (engine == null)
             {
-                return Spatial.Options.IndexPrecisionBits;
+                return Spatial.Options.DefaultIndexPrecisionBits;
             }
 
             var key = EngineCollectionKey.Create(engine, collection.Name);
@@ -76,7 +76,7 @@ namespace LiteDB.Spatial
                 // Metadata collection may not exist yet; fall back to options.
             }
 
-            return Spatial.Options.IndexPrecisionBits;
+            return Spatial.Options.DefaultIndexPrecisionBits;
         }
 
         private readonly struct SpatialIndexMetadata

--- a/LiteDB/Spatial/SpatialOptions.cs
+++ b/LiteDB/Spatial/SpatialOptions.cs
@@ -14,6 +14,9 @@ namespace LiteDB.Spatial
 
     public sealed class SpatialOptions
     {
+        private int _defaultIndexPrecisionBits = 52;
+        private double _toleranceDegrees = 1e-9;
+
         public DistanceFormula Distance { get; set; } = DistanceFormula.Haversine;
 
         public bool SortNearByDistance { get; set; } = true;
@@ -22,8 +25,32 @@ namespace LiteDB.Spatial
 
         public AngleUnit AngleUnit { get; set; } = AngleUnit.Degrees;
 
-        public int IndexPrecisionBits { get; set; } = 52;
+        public int DefaultIndexPrecisionBits
+        {
+            get => _defaultIndexPrecisionBits;
+            set => _defaultIndexPrecisionBits = value;
+        }
 
-        public double NumericToleranceDegrees { get; set; } = 1e-9;
+        public int IndexPrecisionBits
+        {
+            get => _defaultIndexPrecisionBits;
+            set => _defaultIndexPrecisionBits = value;
+        }
+
+        public double NumericToleranceDegrees
+        {
+            get => _toleranceDegrees;
+            set => _toleranceDegrees = value;
+        }
+
+        public double ToleranceDegrees
+        {
+            get => _toleranceDegrees;
+            set => _toleranceDegrees = value;
+        }
+
+        public double BoundingBoxPaddingMeters { get; set; } = 0d;
+
+        public double DistanceToleranceMeters { get; set; } = 0.001d;
     }
 }


### PR DESCRIPTION
## Summary
- extend SpatialOptions with padding and tolerance settings and reuse metadata defaults during index lookup
- add tolerance-aware spatial query filtering and helper methods shared through new SpatialExpressions
- update expression resolver and BSON helpers to expose SpatialExpressions APIs for LINQ and script usage

## Testing
- dotnet build LiteDB/LiteDB.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e2fd61f1f4832abc36cccffa79e520