### PR TITLE
Add tolerance-aware spatial helpers

### DIFF
--- a/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
@@ -1,6 +1,6 @@
+using System;
 using System.Reflection;
 using LiteDB.Spatial;
-using SpatialMethods = LiteDB.Spatial.Spatial;
 
 namespace LiteDB
 {
@@ -13,31 +13,14 @@ namespace LiteDB
                 return null;
             }
 
-            if (method.DeclaringType != typeof(SpatialMethods))
+            if (method.DeclaringType == typeof(SpatialExpressions))
             {
-                return null;
+                return ResolveExpressions(method);
             }
 
-            var parameters = method.GetParameters();
-
-            if (method.Name == nameof(SpatialMethods.Near) && parameters.Length == 3 && parameters[0].ParameterType == typeof(GeoPoint))
+            if (method.DeclaringType == typeof(Spatial.Spatial))
             {
-                return "SPATIAL_NEAR(@0, @1, @2)";
-            }
-
-            if (method.Name == nameof(SpatialMethods.Within) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
-            {
-                return "SPATIAL_WITHIN(@0, @1)";
-            }
-
-            if (method.Name == nameof(SpatialMethods.Intersects) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
-            {
-                return "SPATIAL_INTERSECTS(@0, @1)";
-            }
-
-            if (method.Name == nameof(SpatialMethods.Contains) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
-            {
-                return "SPATIAL_CONTAINS_POINT(@0, @1)";
+                return ResolveSpatial(method);
             }
 
             return null;
@@ -46,5 +29,69 @@ namespace LiteDB
         public string ResolveMember(MemberInfo member) => null;
 
         public string ResolveCtor(ConstructorInfo ctor) => null;
+
+        private string ResolveExpressions(MethodInfo method)
+        {
+            switch (method.Name)
+            {
+                case nameof(SpatialExpressions.Near):
+                    return ResolveNearPattern(method);
+                case nameof(SpatialExpressions.Within):
+                    return "SPATIAL_WITHIN(@0, @1)";
+                case nameof(SpatialExpressions.Intersects):
+                    return "SPATIAL_INTERSECTS(@0, @1)";
+                case nameof(SpatialExpressions.Contains):
+                    return "SPATIAL_CONTAINS(@0, @1)";
+                case nameof(SpatialExpressions.WithinBoundingBox):
+                    return "SPATIAL_WITHIN_BOX(@0, @1, @2, @3, @4)";
+            }
+
+            return null;
+        }
+
+        private string ResolveSpatial(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+
+            if (method.Name == nameof(Spatial.Spatial.Near) && parameters.Length == 3 && parameters[0].ParameterType == typeof(GeoPoint))
+            {
+                return "SPATIAL_NEAR(@0, @1, @2)";
+            }
+
+            if (method.Name == nameof(Spatial.Spatial.Within) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
+            {
+                return "SPATIAL_WITHIN(@0, @1)";
+            }
+
+            if (method.Name == nameof(Spatial.Spatial.Intersects) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
+            {
+                return "SPATIAL_INTERSECTS(@0, @1)";
+            }
+
+            if (method.Name == nameof(Spatial.Spatial.Contains) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
+            {
+                return "SPATIAL_CONTAINS(@0, @1)";
+            }
+
+            return null;
+        }
+
+        private string ResolveNearPattern(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+
+            if (parameters.Length == 3)
+            {
+                var formula = Spatial.Spatial.Options.Distance.ToString();
+                return $"SPATIAL_NEAR(@0, @1, @2, '{formula}')";
+            }
+
+            if (parameters.Length == 4)
+            {
+                return "SPATIAL_NEAR(@0, @1, @2, @3)";
+            }
+
+            throw new NotSupportedException("Unsupported overload for SpatialExpressions.Near");
+        }
     }
 }

--- a/LiteDB/Document/Expression/Methods/Spatial.cs
+++ b/LiteDB/Document/Expression/Methods/Spatial.cs
@@ -1,12 +1,13 @@
+using System;
 using LiteDB.Spatial;
 
 namespace LiteDB
 {
     internal partial class BsonExpressionMethods
     {
-        public static BsonValue SPATIAL_INTERSECTS_MBB(BsonValue mbb, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
+        public static BsonValue SPATIAL_MBB_INTERSECTS(BsonValue bboxValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            if (mbb == null || mbb.IsNull || !mbb.IsArray || mbb.AsArray.Count < 4)
+            if (!bboxValue.IsArray || bboxValue.AsArray.Count != 4)
             {
                 return false;
             }
@@ -16,83 +17,155 @@ namespace LiteDB
                 return false;
             }
 
-            var candidate = new GeoBoundingBox(mbb.AsArray[0].AsDouble, mbb.AsArray[1].AsDouble, mbb.AsArray[2].AsDouble, mbb.AsArray[3].AsDouble);
+            var candidate = ToBoundingBox(bboxValue);
             var query = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
-
             return candidate.Intersects(query);
         }
 
-        public static BsonValue SPATIAL_NEAR(BsonValue candidate, BsonValue center, BsonValue radiusMeters)
+        public static BsonValue SPATIAL_NEAR(BsonValue shapeValue, BsonValue centerValue, BsonValue radiusValue)
         {
-            if (!radiusMeters.IsNumber)
-            {
-                return false;
-            }
-
-            var candidatePoint = ToGeoPoint(candidate);
-            var centerPoint = ToGeoPoint(center);
-
-            if (candidatePoint == null || centerPoint == null)
-            {
-                return false;
-            }
-
-            return Spatial.Spatial.Near(candidatePoint, centerPoint, radiusMeters.AsDouble);
+            return SPATIAL_NEAR(shapeValue, centerValue, radiusValue, BsonValue.Null);
         }
 
-        public static BsonValue SPATIAL_WITHIN(BsonValue candidate, BsonValue polygon)
+        public static BsonValue SPATIAL_NEAR(BsonValue shapeValue, BsonValue centerValue, BsonValue radiusValue, BsonValue formulaValue)
         {
-            var shape = ToGeoShape(candidate);
-            var area = ToGeoShape(polygon) as GeoPolygon;
-
-            if (shape == null || area == null)
+            if (!radiusValue.IsNumber)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Within(shape, area);
+            var shape = ToGeoShape(shapeValue) as GeoPoint;
+            var center = ToGeoShape(centerValue) as GeoPoint;
+
+            if (shape == null || center == null)
+            {
+                return false;
+            }
+
+            var radius = radiusValue.AsDouble;
+            var formula = ParseFormula(formulaValue);
+            return SpatialExpressions.Near(shape, center, radius, formula);
         }
 
-        public static BsonValue SPATIAL_INTERSECTS(BsonValue candidate, BsonValue other)
+        public static BsonValue SPATIAL_WITHIN_BOX(BsonValue shapeValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            var left = ToGeoShape(candidate);
-            var right = ToGeoShape(other);
+            if (!minLat.IsNumber || !minLon.IsNumber || !maxLat.IsNumber || !maxLon.IsNumber)
+            {
+                return false;
+            }
+
+            var shape = ToGeoShape(shapeValue);
+            if (shape == null)
+            {
+                return false;
+            }
+
+            var box = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
+
+            return shape switch
+            {
+                GeoPoint point => box.Contains(point),
+                GeoShape geoShape => geoShape.GetBoundingBox().Intersects(box),
+                _ => false
+            };
+        }
+
+        public static BsonValue SPATIAL_WITHIN(BsonValue shapeValue, BsonValue polygonValue)
+        {
+            var shape = ToGeoShape(shapeValue);
+            var polygon = ToGeoShape(polygonValue) as GeoPolygon;
+
+            if (shape == null || polygon == null)
+            {
+                return false;
+            }
+
+            return SpatialExpressions.Within(shape, polygon);
+        }
+
+        public static BsonValue SPATIAL_INTERSECTS(BsonValue leftValue, BsonValue rightValue)
+        {
+            var left = ToGeoShape(leftValue);
+            var right = ToGeoShape(rightValue);
 
             if (left == null || right == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Intersects(left, right);
+            return SpatialExpressions.Intersects(left, right);
         }
 
-        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue candidate, BsonValue point)
+        public static BsonValue SPATIAL_CONTAINS(BsonValue shapeValue, BsonValue pointValue)
         {
-            var shape = ToGeoShape(candidate);
-            var geoPoint = ToGeoPoint(point);
+            var shape = ToGeoShape(shapeValue);
+            var point = ToGeoShape(pointValue) as GeoPoint;
 
-            if (shape == null || geoPoint == null)
+            if (shape == null || point == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Contains(shape, geoPoint);
+            return SpatialExpressions.Contains(shape, point);
+        }
+
+        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue shapeValue, BsonValue pointValue)
+        {
+            return SPATIAL_CONTAINS(shapeValue, pointValue);
+        }
+
+        private static GeoBoundingBox ToBoundingBox(BsonValue value)
+        {
+            var array = value.AsArray;
+            return new GeoBoundingBox(array[0].AsDouble, array[1].AsDouble, array[2].AsDouble, array[3].AsDouble);
         }
 
         private static GeoShape ToGeoShape(BsonValue value)
         {
-            if (value == null || value.IsNull || !value.IsDocument)
+            if (value == null || value.IsNull)
             {
                 return null;
             }
 
-            return GeoJson.FromBson(value.AsDocument);
+            if (value.IsDocument)
+            {
+                return GeoJson.FromBson(value.AsDocument);
+            }
+
+            if (value.IsArray && value.AsArray.Count >= 2)
+            {
+                var array = value.AsArray;
+                var lon = array[0].AsDouble;
+                var lat = array[1].AsDouble;
+                return new GeoPoint(lat, lon);
+            }
+
+            if (value.RawValue is GeoShape shape)
+            {
+                return shape;
+            }
+
+            return null;
         }
 
-        private static GeoPoint ToGeoPoint(BsonValue value)
+        private static DistanceFormula ParseFormula(BsonValue formulaValue)
         {
-            var shape = ToGeoShape(value);
-            return shape as GeoPoint;
+            if (formulaValue == null || formulaValue.IsNull)
+            {
+                return Spatial.Spatial.Options.Distance;
+            }
+
+            if (formulaValue.IsString && Enum.TryParse(formulaValue.AsString, out DistanceFormula parsed))
+            {
+                return parsed;
+            }
+
+            if (formulaValue.IsInt32)
+            {
+                return (DistanceFormula)formulaValue.AsInt32;
+            }
+
+            return Spatial.Spatial.Options.Distance;
         }
     }
 }

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -125,9 +125,12 @@ namespace LiteDB.Engine
             {
                 case "SPATIAL_INTERSECTS":
                 case "SPATIAL_INTERSECTS_MBB":
+                case "SPATIAL_MBB_INTERSECTS":
                 case "SPATIAL_CONTAINS_POINT":
+                case "SPATIAL_CONTAINS":
                 case "SPATIAL_NEAR":
                 case "SPATIAL_WITHIN":
+                case "SPATIAL_WITHIN_BOX":
                     return true;
                 default:
                     return false;

--- a/LiteDB/Spatial/GeoBoundingBox.cs
+++ b/LiteDB/Spatial/GeoBoundingBox.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace LiteDB.Spatial
 {
-    internal readonly struct GeoBoundingBox
+    public readonly struct GeoBoundingBox
     {
         public double MinLat { get; }
         public double MinLon { get; }
@@ -59,6 +59,24 @@ namespace LiteDB.Spatial
         public bool Intersects(GeoBoundingBox other)
         {
             return !(other.MinLat > MaxLat || other.MaxLat < MinLat) && LongitudesOverlap(other);
+        }
+
+        public GeoBoundingBox Expand(double meters)
+        {
+            if (meters <= 0d)
+            {
+                return this;
+            }
+
+            var angularDistance = meters / GeoMath.EarthRadiusMeters;
+            var deltaDegrees = angularDistance * (180d / Math.PI);
+
+            var minLat = GeoMath.ClampLatitude(MinLat - deltaDegrees);
+            var maxLat = GeoMath.ClampLatitude(MaxLat + deltaDegrees);
+            var minLon = GeoMath.NormalizeLongitude(MinLon - deltaDegrees);
+            var maxLon = GeoMath.NormalizeLongitude(MaxLon + deltaDegrees);
+
+            return new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
         }
 
         private bool LongitudesOverlap(GeoBoundingBox other)

--- a/LiteDB/Spatial/Spatial.cs
+++ b/LiteDB/Spatial/Spatial.cs
@@ -26,7 +26,7 @@ namespace LiteDB.Spatial
 
             if (precisionBits <= 0)
             {
-                precisionBits = Options.IndexPrecisionBits;
+                precisionBits = Options.DefaultIndexPrecisionBits;
             }
 
             var getter = selector.Compile();
@@ -88,7 +88,7 @@ namespace LiteDB.Spatial
             }
 
             var distance = GeoMath.DistanceMeters(center, candidate, Options.Distance);
-            return distance <= radiusMeters;
+            return distance <= radiusMeters + GetDistanceAllowanceMeters();
         }
 
         public static bool Within(GeoShape candidate, GeoPolygon area)
@@ -156,25 +156,28 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
-            var boundingBox = GeoMath.BoundingBoxForCircle(center, radiusMeters);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var normalizedCenter = center.Normalize();
+            var boundingBox = GeoMath.BoundingBoxForCircle(normalizedCenter, radiusMeters);
+            var expandedBoundingBox = ExpandForQuery(boundingBox);
+            var ranges = SpatialIndexing.CoverBoundingBox(expandedBoundingBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(expandedBoundingBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
             var matches = new List<(T item, double distance)>();
+            var distanceAllowance = GetDistanceAllowanceMeters();
 
             foreach (var item in source)
             {
                 var point = selector(item);
-                if (point == null || !boundingBox.Contains(point))
+                if (point == null || !expandedBoundingBox.Contains(point))
                 {
                     continue;
                 }
 
-                var distance = GeoMath.DistanceMeters(center, point, Options.Distance);
-                if (distance <= radiusMeters)
+                var distance = GeoMath.DistanceMeters(normalizedCenter, point, Options.Distance);
+                if (distance <= radiusMeters + distanceAllowance)
                 {
                     matches.Add((item, distance));
                 }
@@ -205,10 +208,11 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+            var expandedBoundingBox = ExpandForQuery(boundingBox);
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var ranges = SpatialIndexing.CoverBoundingBox(expandedBoundingBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(expandedBoundingBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
@@ -217,7 +221,12 @@ namespace LiteDB.Spatial
                 .Where(entity =>
                 {
                     var point = selector(entity);
-                    return point != null && boundingBox.Contains(point);
+                    if (point == null || !expandedBoundingBox.Contains(point))
+                    {
+                        return false;
+                    }
+
+                    return boundingBox.Contains(point);
                 })
                 .ToList();
         }
@@ -233,13 +242,24 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = area.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var expandedBoundingBox = ExpandForQuery(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(expandedBoundingBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
             {
                 var shape = selector(entity);
-                return shape != null && Within(shape, area);
+                if (shape == null)
+                {
+                    return false;
+                }
+
+                if (!expandedBoundingBox.Intersects(shape.GetBoundingBox()))
+                {
+                    return false;
+                }
+
+                return Within(shape, area);
             }).ToList();
         }
 
@@ -254,13 +274,24 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = query.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var expandedBoundingBox = ExpandForQuery(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(expandedBoundingBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
             {
                 var shape = selector(entity);
-                return shape != null && Intersects(shape, query);
+                if (shape == null)
+                {
+                    return false;
+                }
+
+                if (!expandedBoundingBox.Intersects(shape.GetBoundingBox()))
+                {
+                    return false;
+                }
+
+                return Intersects(shape, query);
             }).ToList();
         }
 
@@ -275,14 +306,58 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = new GeoBoundingBox(point.Lat, point.Lon, point.Lat, point.Lon);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var expandedBoundingBox = ExpandForQuery(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(expandedBoundingBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
             {
                 var shape = selector(entity);
-                return shape != null && Contains(shape, point);
+                if (shape == null)
+                {
+                    return false;
+                }
+
+                if (!expandedBoundingBox.Intersects(shape.GetBoundingBox()))
+                {
+                    return false;
+                }
+
+                return Contains(shape, point);
             }).ToList();
+        }
+
+        private static GeoBoundingBox ExpandForQuery(GeoBoundingBox boundingBox)
+        {
+            var padding = GetTotalBoundingPaddingMeters();
+            if (padding <= 0d)
+            {
+                return boundingBox;
+            }
+
+            return boundingBox.Expand(padding);
+        }
+
+        private static double GetDistanceAllowanceMeters()
+        {
+            var angularTolerance = GetCoordinateToleranceMeters();
+            return Math.Max(Options.DistanceToleranceMeters, angularTolerance);
+        }
+
+        private static double GetTotalBoundingPaddingMeters()
+        {
+            return Options.BoundingBoxPaddingMeters + GetCoordinateToleranceMeters();
+        }
+
+        private static double GetCoordinateToleranceMeters()
+        {
+            var toleranceDegrees = Options.NumericToleranceDegrees;
+            if (toleranceDegrees <= 0d)
+            {
+                return 0d;
+            }
+
+            return GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d);
         }
 
         private static LiteCollection<T> GetLiteCollection<T>(ILiteCollection<T> collection)

--- a/LiteDB/Spatial/SpatialExpressions.cs
+++ b/LiteDB/Spatial/SpatialExpressions.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using LiteDB.Spatial;
+
+namespace LiteDB
+{
+    public static class SpatialExpressions
+    {
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters)
+        {
+            return Near(point, center, radiusMeters, Spatial.Spatial.Options.Distance);
+        }
+
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters, DistanceFormula formula)
+        {
+            if (point == null || center == null)
+            {
+                return false;
+            }
+
+            var distance = GeoMath.DistanceMeters(point, center, formula);
+            var allowance = Spatial.Spatial.Options.DistanceToleranceMeters;
+            var toleranceDegrees = Spatial.Spatial.Options.NumericToleranceDegrees;
+
+            if (toleranceDegrees > 0d)
+            {
+                var angularMeters = GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d);
+                allowance = Math.Max(allowance, angularMeters);
+            }
+
+            return distance <= radiusMeters + allowance;
+        }
+
+        public static bool Within(GeoShape shape, GeoPolygon polygon)
+        {
+            if (shape == null || polygon == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPoint point => Geometry.ContainsPoint(polygon, point),
+                GeoPolygon other => Geometry.Intersects(polygon, other) && other.Outer.All(p => Geometry.ContainsPoint(polygon, p)),
+                GeoLineString line => line.Points.All(p => Geometry.ContainsPoint(polygon, p)),
+                _ => false
+            };
+        }
+
+        public static bool Intersects(GeoShape shape, GeoShape other)
+        {
+            if (shape == null || other == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPolygon polygon when other is GeoPolygon polygonOther => Geometry.Intersects(polygon, polygonOther),
+                GeoLineString line when other is GeoPolygon polygon => Geometry.Intersects(line, polygon),
+                GeoPolygon polygon when other is GeoLineString line => Geometry.Intersects(line, polygon),
+                GeoLineString line when other is GeoLineString otherLine => Geometry.Intersects(line, otherLine),
+                GeoPoint point when other is GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoPoint point when other is GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint point when other is GeoPoint otherPoint =>
+                    Math.Abs(point.Lat - otherPoint.Lat) < GeoMath.EpsilonDegrees &&
+                    Math.Abs(point.Lon - otherPoint.Lon) < GeoMath.EpsilonDegrees,
+                GeoLineString line when other is GeoPoint point => Geometry.LineContainsPoint(line, point),
+                GeoPolygon polygon when other is GeoPoint point => Geometry.ContainsPoint(polygon, point),
+                _ => false
+            };
+        }
+
+        public static bool Contains(GeoShape shape, GeoPoint point)
+        {
+            if (shape == null || point == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint candidate => Math.Abs(candidate.Lat - point.Lat) < GeoMath.EpsilonDegrees && Math.Abs(candidate.Lon - point.Lon) < GeoMath.EpsilonDegrees,
+                _ => false
+            };
+        }
+
+        public static bool WithinBoundingBox(GeoPoint point, GeoBoundingBox box)
+        {
+            if (point == null)
+            {
+                return false;
+            }
+
+            return box.Contains(point);
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialMetadataStore.cs
+++ b/LiteDB/Spatial/SpatialMetadataStore.cs
@@ -41,7 +41,7 @@ namespace LiteDB.Spatial
             var engine = Spatial.GetEngine(collection);
             if (engine == null)
             {
-                return Spatial.Options.IndexPrecisionBits;
+                return Spatial.Options.DefaultIndexPrecisionBits;
             }
 
             var key = EngineCollectionKey.Create(engine, collection.Name);
@@ -76,7 +76,7 @@ namespace LiteDB.Spatial
                 // Metadata collection may not exist yet; fall back to options.
             }
 
-            return Spatial.Options.IndexPrecisionBits;
+            return Spatial.Options.DefaultIndexPrecisionBits;
         }
 
         private readonly struct SpatialIndexMetadata

--- a/LiteDB/Spatial/SpatialOptions.cs
+++ b/LiteDB/Spatial/SpatialOptions.cs
@@ -14,6 +14,9 @@ namespace LiteDB.Spatial
 
     public sealed class SpatialOptions
     {
+        private int _defaultIndexPrecisionBits = 52;
+        private double _coordinateToleranceDegrees = 1e-9;
+
         public DistanceFormula Distance { get; set; } = DistanceFormula.Haversine;
 
         public bool SortNearByDistance { get; set; } = true;
@@ -22,8 +25,32 @@ namespace LiteDB.Spatial
 
         public AngleUnit AngleUnit { get; set; } = AngleUnit.Degrees;
 
-        public int IndexPrecisionBits { get; set; } = 52;
+        public int DefaultIndexPrecisionBits
+        {
+            get => _defaultIndexPrecisionBits;
+            set => _defaultIndexPrecisionBits = value;
+        }
 
-        public double NumericToleranceDegrees { get; set; } = 1e-9;
+        public int IndexPrecisionBits
+        {
+            get => _defaultIndexPrecisionBits;
+            set => _defaultIndexPrecisionBits = value;
+        }
+
+        public double BoundingBoxPaddingMeters { get; set; } = 0d;
+
+        public double DistanceToleranceMeters { get; set; } = 0.001d;
+
+        public double NumericToleranceDegrees
+        {
+            get => _coordinateToleranceDegrees;
+            set => _coordinateToleranceDegrees = value;
+        }
+
+        public double ToleranceDegrees
+        {
+            get => _coordinateToleranceDegrees;
+            set => _coordinateToleranceDegrees = value;
+        }
     }
 }

--- a/LiteDB/Spatial/SpatialQuery.cs
+++ b/LiteDB/Spatial/SpatialQuery.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using LiteDB;
+
+namespace LiteDB.Spatial
+{
+    public static class SpatialQuery
+    {
+        private const string MortonField = "$._gh";
+        private const string BoundingBoxField = "$._mbb";
+
+        public static BsonExpression Near<T>(BsonExpression field, GeoPoint center, double radiusMeters, LiteCollection<T> collection = null, int? precisionBits = null)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (center == null) throw new ArgumentNullException(nameof(center));
+            if (radiusMeters < 0d) throw new ArgumentOutOfRangeException(nameof(radiusMeters));
+
+            var precision = ResolvePrecision(collection, precisionBits);
+            var normalizedCenter = center.Normalize();
+            var queryBox = GeoMath.BoundingBoxForCircle(normalizedCenter, radiusMeters);
+            queryBox = ExpandBoundingBox(queryBox);
+
+            var predicates = new List<BsonExpression>();
+
+            var bounding = BsonExpression.Create($"SPATIAL_MBB_INTERSECTS({BoundingBoxField}, @0, @1, @2, @3)",
+                new BsonValue(queryBox.MinLat),
+                new BsonValue(queryBox.MinLon),
+                new BsonValue(queryBox.MaxLat),
+                new BsonValue(queryBox.MaxLon));
+            predicates.Add(bounding);
+
+            var near = BsonExpression.Create($"SPATIAL_NEAR({field.Source}, @0, @1, @2, @3)",
+                new BsonValue(normalizedCenter.Lat),
+                new BsonValue(normalizedCenter.Lon),
+                new BsonValue(radiusMeters),
+                new BsonValue(Spatial.Options.Distance.ToString()));
+            predicates.Add(near);
+
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBox, precision, Spatial.Options.MaxCoveringCells);
+
+            if (ranges.Count == 1)
+            {
+                var range = ranges[0];
+                predicates.Add(Query.Between(MortonField, new BsonValue(range.Start), new BsonValue(range.End)));
+            }
+            else if (ranges.Count > 1)
+            {
+                var buffer = new BsonExpression[ranges.Count];
+
+                for (var i = 0; i < ranges.Count; i++)
+                {
+                    var range = ranges[i];
+                    buffer[i] = Query.Between(MortonField, new BsonValue(range.Start), new BsonValue(range.End));
+                }
+
+                predicates.Add(Query.Or(buffer));
+            }
+
+            return Query.And(predicates.ToArray());
+        }
+
+        public static BsonExpression WithinBoundingBox(BsonExpression field, GeoBoundingBox box)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+
+            var expanded = ExpandBoundingBox(box);
+            return BsonExpression.Create($"SPATIAL_WITHIN_BOX({field.Source}, @0, @1, @2, @3)",
+                new BsonValue(expanded.MinLat),
+                new BsonValue(expanded.MinLon),
+                new BsonValue(expanded.MaxLat),
+                new BsonValue(expanded.MaxLon));
+        }
+
+        public static BsonExpression Within(BsonExpression field, GeoPolygon polygon)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (polygon == null) throw new ArgumentNullException(nameof(polygon));
+
+            var bson = GeoJson.ToBson(polygon);
+            return BsonExpression.Create($"SPATIAL_WITHIN({field.Source}, @0)", bson);
+        }
+
+        public static BsonExpression Intersects(BsonExpression field, GeoShape shape)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (shape == null) throw new ArgumentNullException(nameof(shape));
+
+            var bson = GeoJson.ToBson(shape);
+            return BsonExpression.Create($"SPATIAL_INTERSECTS({field.Source}, @0)", bson);
+        }
+
+        public static BsonExpression Contains(BsonExpression field, GeoPoint point)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (point == null) throw new ArgumentNullException(nameof(point));
+
+            var bson = GeoJson.ToBson(point);
+            return BsonExpression.Create($"SPATIAL_CONTAINS({field.Source}, @0)", bson);
+        }
+
+        private static int ResolvePrecision<T>(LiteCollection<T> collection, int? precisionBits)
+        {
+            if (precisionBits.HasValue)
+            {
+                return precisionBits.Value;
+            }
+
+            if (collection != null)
+            {
+                return SpatialMetadataStore.GetPointIndexPrecision(collection);
+            }
+
+            return Spatial.Options.DefaultIndexPrecisionBits;
+        }
+
+        private static GeoBoundingBox ExpandBoundingBox(GeoBoundingBox box)
+        {
+            var padding = GetTotalBoundingPaddingMeters();
+            if (padding <= 0d)
+            {
+                return box;
+            }
+
+            return box.Expand(padding);
+        }
+
+        private static double GetTotalBoundingPaddingMeters()
+        {
+            return Spatial.Options.BoundingBoxPaddingMeters + GetAngularToleranceMeters();
+        }
+
+        private static double GetAngularToleranceMeters()
+        {
+            var toleranceDegrees = Spatial.Options.NumericToleranceDegrees;
+            if (toleranceDegrees <= 0d)
+            {
+                return 0d;
+            }
+
+            return GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d);
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialQueryBuilder.cs
+++ b/LiteDB/Spatial/SpatialQueryBuilder.cs
@@ -26,7 +26,19 @@ namespace LiteDB.Spatial
         {
             if (box.MaxLon < box.MinLon)
             {
-                return null;
+                var segments = SpatialIndexing.SplitBoundingBox(box);
+                var expressions = new List<BsonExpression>(segments.Count);
+
+                foreach (var segment in segments)
+                {
+                    var expression = BuildBoundingBoxPredicate(segment);
+                    if (expression != null)
+                    {
+                        expressions.Add(expression);
+                    }
+                }
+
+                return CombineOr(expressions);
             }
 
             var parameters = new[]


### PR DESCRIPTION
## Summary
- expand spatial query helpers to honour distance tolerances and configurable bounding-box padding
- expose SpatialExpressions and SpatialQuery entry points for LINQ/script usage and wire them through the resolver
- extend GeoBoundingBox utilities and query planning to handle padded morton ranges and metadata defaults

## Testing
- dotnet build LiteDB/LiteDB.csproj -c Release

------
https://chatgpt.com/codex/tasks/task_e_68e2fd61f1f4832abc36cccffa79e520