### PR TITLE
Add tolerance-aware spatial queries and expression helpers

### DIFF
--- a/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using LiteDB.Spatial;
 using SpatialMethods = LiteDB.Spatial.Spatial;
@@ -13,16 +14,44 @@ namespace LiteDB
                 return null;
             }
 
-            if (method.DeclaringType != typeof(SpatialMethods))
+            if (method.DeclaringType == typeof(SpatialExpressions))
             {
-                return null;
+                return ResolveExpressions(method);
             }
 
+            if (method.DeclaringType == typeof(SpatialMethods))
+            {
+                return ResolveLegacy(method);
+            }
+
+            return null;
+        }
+
+        public string ResolveMember(MemberInfo member) => null;
+
+        public string ResolveCtor(ConstructorInfo ctor) => null;
+
+        private string ResolveExpressions(MethodInfo method)
+        {
+            return method.Name switch
+            {
+                nameof(SpatialExpressions.Near) => ResolveExpressionsNear(method),
+                nameof(SpatialExpressions.Within) => "SPATIAL_WITHIN(@0, @1)",
+                nameof(SpatialExpressions.Intersects) => "SPATIAL_INTERSECTS(@0, @1)",
+                nameof(SpatialExpressions.Contains) => "SPATIAL_CONTAINS(@0, @1)",
+                nameof(SpatialExpressions.WithinBoundingBox) => "SPATIAL_WITHIN_BOX(@0, @1, @2, @3, @4)",
+                _ => null
+            };
+        }
+
+        private string ResolveLegacy(MethodInfo method)
+        {
             var parameters = method.GetParameters();
 
             if (method.Name == nameof(SpatialMethods.Near) && parameters.Length == 3 && parameters[0].ParameterType == typeof(GeoPoint))
             {
-                return "SPATIAL_NEAR(@0, @1, @2)";
+                var formula = Spatial.Spatial.Options.Distance.ToString();
+                return $"SPATIAL_NEAR(@0, @1, @2, '{formula}')";
             }
 
             if (method.Name == nameof(SpatialMethods.Within) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
@@ -37,14 +66,28 @@ namespace LiteDB
 
             if (method.Name == nameof(SpatialMethods.Contains) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
             {
-                return "SPATIAL_CONTAINS_POINT(@0, @1)";
+                return "SPATIAL_CONTAINS(@0, @1)";
             }
 
             return null;
         }
 
-        public string ResolveMember(MemberInfo member) => null;
+        private string ResolveExpressionsNear(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
 
-        public string ResolveCtor(ConstructorInfo ctor) => null;
+            if (parameters.Length == 3)
+            {
+                var formula = Spatial.Spatial.Options.Distance.ToString();
+                return $"SPATIAL_NEAR(@0, @1, @2, '{formula}')";
+            }
+
+            if (parameters.Length == 4)
+            {
+                return "SPATIAL_NEAR(@0, @1, @2, @3)";
+            }
+
+            throw new NotSupportedException("Unsupported overload for SpatialExpressions.Near");
+        }
     }
 }

--- a/LiteDB/Document/Expression/Methods/Spatial.cs
+++ b/LiteDB/Document/Expression/Methods/Spatial.cs
@@ -1,98 +1,163 @@
+using System;
 using LiteDB.Spatial;
 
 namespace LiteDB
 {
     internal partial class BsonExpressionMethods
     {
-        public static BsonValue SPATIAL_INTERSECTS_MBB(BsonValue mbb, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
+        public static BsonValue SPATIAL_MBB_INTERSECTS(BsonValue bboxValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            if (mbb == null || mbb.IsNull || !mbb.IsArray || mbb.AsArray.Count < 4)
+            if (!bboxValue.IsArray || bboxValue.AsArray.Count != 4)
             {
                 return false;
             }
 
-            if (!minLat.IsNumber || !minLon.IsNumber || !maxLat.IsNumber || !maxLon.IsNumber)
-            {
-                return false;
-            }
-
-            var candidate = new GeoBoundingBox(mbb.AsArray[0].AsDouble, mbb.AsArray[1].AsDouble, mbb.AsArray[2].AsDouble, mbb.AsArray[3].AsDouble);
+            var candidate = ToBoundingBox(bboxValue);
             var query = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
-
             return candidate.Intersects(query);
         }
 
-        public static BsonValue SPATIAL_NEAR(BsonValue candidate, BsonValue center, BsonValue radiusMeters)
+        public static BsonValue SPATIAL_INTERSECTS_MBB(BsonValue bboxValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            if (!radiusMeters.IsNumber)
-            {
-                return false;
-            }
-
-            var candidatePoint = ToGeoPoint(candidate);
-            var centerPoint = ToGeoPoint(center);
-
-            if (candidatePoint == null || centerPoint == null)
-            {
-                return false;
-            }
-
-            return Spatial.Spatial.Near(candidatePoint, centerPoint, radiusMeters.AsDouble);
+            return SPATIAL_MBB_INTERSECTS(bboxValue, minLat, minLon, maxLat, maxLon);
         }
 
-        public static BsonValue SPATIAL_WITHIN(BsonValue candidate, BsonValue polygon)
+        public static BsonValue SPATIAL_NEAR(BsonValue shapeValue, BsonValue centerValue, BsonValue radiusValue)
         {
-            var shape = ToGeoShape(candidate);
-            var area = ToGeoShape(polygon) as GeoPolygon;
+            return SPATIAL_NEAR(shapeValue, centerValue, radiusValue, new BsonValue(Spatial.Spatial.Options.Distance.ToString()));
+        }
 
-            if (shape == null || area == null)
+        public static BsonValue SPATIAL_NEAR(BsonValue shapeValue, BsonValue centerValue, BsonValue radiusValue, BsonValue formulaValue)
+        {
+            var shape = ToShape(shapeValue) as GeoPoint;
+            var center = ToShape(centerValue) as GeoPoint;
+
+            if (shape == null || center == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Within(shape, area);
+            var radius = radiusValue.AsDouble;
+            var formula = ParseFormula(formulaValue);
+            var distance = GeoMath.DistanceMeters(shape, center, formula);
+            return distance <= radius + Spatial.Spatial.Options.DistanceToleranceMeters;
         }
 
-        public static BsonValue SPATIAL_INTERSECTS(BsonValue candidate, BsonValue other)
+        public static BsonValue SPATIAL_WITHIN_BOX(BsonValue shapeValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            var left = ToGeoShape(candidate);
-            var right = ToGeoShape(other);
+            var shape = ToShape(shapeValue);
+            if (shape == null)
+            {
+                return false;
+            }
+
+            var box = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
+            var tolerance = Spatial.Spatial.Options.NumericToleranceDegrees;
+
+            return shape switch
+            {
+                GeoPoint point => box.Contains(point, tolerance),
+                GeoShape geoShape => geoShape.GetBoundingBox().Intersects(box),
+                _ => false
+            };
+        }
+
+        public static BsonValue SPATIAL_WITHIN(BsonValue shapeValue, BsonValue polygonValue)
+        {
+            var shape = ToShape(shapeValue);
+            var polygon = ToShape(polygonValue) as GeoPolygon;
+
+            if (shape == null || polygon == null)
+            {
+                return false;
+            }
+
+            return SpatialExpressions.Within(shape, polygon);
+        }
+
+        public static BsonValue SPATIAL_INTERSECTS(BsonValue leftValue, BsonValue rightValue)
+        {
+            var left = ToShape(leftValue);
+            var right = ToShape(rightValue);
 
             if (left == null || right == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Intersects(left, right);
+            return SpatialExpressions.Intersects(left, right);
         }
 
-        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue candidate, BsonValue point)
+        public static BsonValue SPATIAL_CONTAINS(BsonValue shapeValue, BsonValue pointValue)
         {
-            var shape = ToGeoShape(candidate);
-            var geoPoint = ToGeoPoint(point);
+            var shape = ToShape(shapeValue);
+            var point = ToShape(pointValue) as GeoPoint;
 
-            if (shape == null || geoPoint == null)
+            if (shape == null || point == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Contains(shape, geoPoint);
+            return SpatialExpressions.Contains(shape, point);
         }
 
-        private static GeoShape ToGeoShape(BsonValue value)
+        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue shapeValue, BsonValue pointValue)
         {
-            if (value == null || value.IsNull || !value.IsDocument)
+            return SPATIAL_CONTAINS(shapeValue, pointValue);
+        }
+
+        private static GeoBoundingBox ToBoundingBox(BsonValue value)
+        {
+            var array = value.AsArray;
+            return new GeoBoundingBox(array[0].AsDouble, array[1].AsDouble, array[2].AsDouble, array[3].AsDouble);
+        }
+
+        private static GeoShape ToShape(BsonValue value)
+        {
+            if (value == null || value.IsNull)
             {
                 return null;
             }
 
-            return GeoJson.FromBson(value.AsDocument);
+            if (value.IsDocument)
+            {
+                return GeoJson.FromBson(value.AsDocument);
+            }
+
+            if (value.IsArray && value.AsArray.Count >= 2)
+            {
+                var array = value.AsArray;
+                var lon = array[0].AsDouble;
+                var lat = array[1].AsDouble;
+                return new GeoPoint(lat, lon);
+            }
+
+            if (value.RawValue is GeoShape shape)
+            {
+                return shape;
+            }
+
+            if (value.RawValue is GeoPoint point)
+            {
+                return point;
+            }
+
+            return null;
         }
 
-        private static GeoPoint ToGeoPoint(BsonValue value)
+        private static DistanceFormula ParseFormula(BsonValue formulaValue)
         {
-            var shape = ToGeoShape(value);
-            return shape as GeoPoint;
+            if (formulaValue.IsString && Enum.TryParse<DistanceFormula>(formulaValue.AsString, out var parsed))
+            {
+                return parsed;
+            }
+
+            if (formulaValue.IsInt32)
+            {
+                return (DistanceFormula)formulaValue.AsInt32;
+            }
+
+            return Spatial.Spatial.Options.Distance;
         }
     }
 }

--- a/LiteDB/Spatial/GeoBoundingBox.cs
+++ b/LiteDB/Spatial/GeoBoundingBox.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace LiteDB.Spatial
 {
-    internal readonly struct GeoBoundingBox
+    public readonly struct GeoBoundingBox
     {
         public double MinLat { get; }
         public double MinLon { get; }
@@ -48,17 +48,48 @@ namespace LiteDB.Spatial
 
         public bool Contains(GeoPoint point)
         {
+            return Contains(point, 0d);
+        }
+
+        public bool Contains(GeoPoint point, double toleranceDegrees)
+        {
             if (point == null)
             {
                 return false;
             }
 
-            return point.Lat >= MinLat && point.Lat <= MaxLat && IsLongitudeWithin(point.Lon);
+            var minLat = MinLat - toleranceDegrees;
+            var maxLat = MaxLat + toleranceDegrees;
+
+            if (point.Lat < minLat || point.Lat > maxLat)
+            {
+                return false;
+            }
+
+            return IsLongitudeWithin(point.Lon, toleranceDegrees);
         }
 
         public bool Intersects(GeoBoundingBox other)
         {
             return !(other.MinLat > MaxLat || other.MaxLat < MinLat) && LongitudesOverlap(other);
+        }
+
+        public GeoBoundingBox Expand(double meters)
+        {
+            if (meters <= 0d)
+            {
+                return this;
+            }
+
+            var angularDistance = meters / GeoMath.EarthRadiusMeters;
+            var deltaDegrees = angularDistance * (180d / Math.PI);
+
+            var minLat = GeoMath.ClampLatitude(MinLat - deltaDegrees);
+            var maxLat = GeoMath.ClampLatitude(MaxLat + deltaDegrees);
+            var minLon = GeoMath.NormalizeLongitude(MinLon - deltaDegrees);
+            var maxLon = GeoMath.NormalizeLongitude(MaxLon + deltaDegrees);
+
+            return new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
         }
 
         private bool LongitudesOverlap(GeoBoundingBox other)
@@ -70,7 +101,14 @@ namespace LiteDB.Spatial
 
         private bool IsLongitudeWithin(double lon)
         {
-            var lonRange = new LongitudeRange(MinLon, MaxLon);
+            return IsLongitudeWithin(lon, 0d);
+        }
+
+        private bool IsLongitudeWithin(double lon, double toleranceDegrees)
+        {
+            var lonRange = toleranceDegrees > 0d
+                ? new LongitudeRange(MinLon - toleranceDegrees, MaxLon + toleranceDegrees)
+                : new LongitudeRange(MinLon, MaxLon);
             return lonRange.Contains(lon);
         }
     }

--- a/LiteDB/Spatial/LongitudeRange.cs
+++ b/LiteDB/Spatial/LongitudeRange.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace LiteDB.Spatial
 {
@@ -62,6 +63,18 @@ namespace LiteDB.Spatial
             }
 
             return false;
+        }
+
+        public IEnumerable<(double start, double end)> GetSegments()
+        {
+            if (!_wraps)
+            {
+                yield return (_start, _end);
+                yield break;
+            }
+
+            yield return (_start, 180d);
+            yield return (-180d, _end);
         }
     }
 }

--- a/LiteDB/Spatial/Spatial.cs
+++ b/LiteDB/Spatial/Spatial.cs
@@ -26,7 +26,7 @@ namespace LiteDB.Spatial
 
             if (precisionBits <= 0)
             {
-                precisionBits = Options.IndexPrecisionBits;
+                precisionBits = Options.DefaultIndexPrecisionBits;
             }
 
             var getter = selector.Compile();
@@ -156,25 +156,36 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
-            var boundingBox = GeoMath.BoundingBoxForCircle(center, radiusMeters);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var normalizedCenter = center.Normalize();
+            var searchBox = GeoMath.BoundingBoxForCircle(normalizedCenter, radiusMeters);
+            var expansionMeters = Math.Max(0d, Options.BoundingBoxPaddingMeters + Options.DistanceToleranceMeters);
+            var queryBox = expansionMeters > 0d ? searchBox.Expand(expansionMeters) : searchBox;
+
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
             var matches = new List<(T item, double distance)>();
+            var toleranceDegrees = Options.NumericToleranceDegrees;
+            var distanceTolerance = Math.Max(0d, Options.DistanceToleranceMeters);
 
             foreach (var item in source)
             {
                 var point = selector(item);
-                if (point == null || !boundingBox.Contains(point))
+                if (point == null)
                 {
                     continue;
                 }
 
-                var distance = GeoMath.DistanceMeters(center, point, Options.Distance);
-                if (distance <= radiusMeters)
+                if (!queryBox.Contains(point, toleranceDegrees))
+                {
+                    continue;
+                }
+
+                var distance = GeoMath.DistanceMeters(normalizedCenter, point, Options.Distance);
+                if (distance <= radiusMeters + distanceTolerance)
                 {
                     matches.Add((item, distance));
                 }
@@ -206,9 +217,11 @@ namespace LiteDB.Spatial
 
             var boundingBox = new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var expansionMeters = Math.Max(0d, Options.BoundingBoxPaddingMeters + Options.DistanceToleranceMeters);
+            var queryBox = expansionMeters > 0d ? boundingBox.Expand(expansionMeters) : boundingBox;
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
@@ -217,7 +230,7 @@ namespace LiteDB.Spatial
                 .Where(entity =>
                 {
                     var point = selector(entity);
-                    return point != null && boundingBox.Contains(point);
+                    return point != null && boundingBox.Contains(point, Options.NumericToleranceDegrees);
                 })
                 .ToList();
         }
@@ -233,7 +246,9 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = area.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var expansionMeters = Math.Max(0d, Options.BoundingBoxPaddingMeters + Options.DistanceToleranceMeters);
+            var queryBox = expansionMeters > 0d ? boundingBox.Expand(expansionMeters) : boundingBox;
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
@@ -254,7 +269,9 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = query.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var expansionMeters = Math.Max(0d, Options.BoundingBoxPaddingMeters + Options.DistanceToleranceMeters);
+            var queryBox = expansionMeters > 0d ? boundingBox.Expand(expansionMeters) : boundingBox;
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
@@ -275,7 +292,9 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = new GeoBoundingBox(point.Lat, point.Lon, point.Lat, point.Lon);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var expansionMeters = Math.Max(0d, Options.BoundingBoxPaddingMeters + Options.DistanceToleranceMeters);
+            var queryBox = expansionMeters > 0d ? boundingBox.Expand(expansionMeters) : boundingBox;
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>

--- a/LiteDB/Spatial/SpatialExpressions.cs
+++ b/LiteDB/Spatial/SpatialExpressions.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Linq;
+using LiteDB.Spatial;
+
+namespace LiteDB
+{
+    public static class SpatialExpressions
+    {
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters)
+        {
+            return Near(point, center, radiusMeters, Spatial.Spatial.Options.Distance);
+        }
+
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters, DistanceFormula formula)
+        {
+            if (point == null || center == null)
+            {
+                return false;
+            }
+
+            var distance = GeoMath.DistanceMeters(point, center, formula);
+            return distance <= radiusMeters + Spatial.Spatial.Options.DistanceToleranceMeters;
+        }
+
+        public static bool Within(GeoShape shape, GeoPolygon polygon)
+        {
+            if (shape == null || polygon == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPoint point => Geometry.ContainsPoint(polygon, point),
+                GeoPolygon other => Geometry.Intersects(polygon, other) && other.Outer.All(p => Geometry.ContainsPoint(polygon, p)),
+                GeoLineString line => line.Points.All(p => Geometry.ContainsPoint(polygon, p)),
+                _ => false
+            };
+        }
+
+        public static bool Intersects(GeoShape shape, GeoShape other)
+        {
+            if (shape == null || other == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPolygon polygon when other is GeoPolygon polygonOther => Geometry.Intersects(polygon, polygonOther),
+                GeoLineString line when other is GeoPolygon polygon => Geometry.Intersects(line, polygon),
+                GeoPolygon polygon when other is GeoLineString line => Geometry.Intersects(line, polygon),
+                GeoLineString line when other is GeoLineString otherLine => Geometry.Intersects(line, otherLine),
+                GeoPoint point when other is GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoPoint point when other is GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint point when other is GeoPoint otherPoint => Math.Abs(point.Lat - otherPoint.Lat) <= GeoMath.EpsilonDegrees && Math.Abs(point.Lon - otherPoint.Lon) <= GeoMath.EpsilonDegrees,
+                GeoLineString line when other is GeoPoint point => Geometry.LineContainsPoint(line, point),
+                GeoPolygon polygon when other is GeoPoint point => Geometry.ContainsPoint(polygon, point),
+                _ => false
+            };
+        }
+
+        public static bool Contains(GeoShape shape, GeoPoint point)
+        {
+            if (shape == null || point == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint candidate => Math.Abs(candidate.Lat - point.Lat) <= GeoMath.EpsilonDegrees && Math.Abs(candidate.Lon - point.Lon) <= GeoMath.EpsilonDegrees,
+                _ => false
+            };
+        }
+
+        public static bool WithinBoundingBox(GeoPoint point, double minLat, double minLon, double maxLat, double maxLon)
+        {
+            if (point == null)
+            {
+                return false;
+            }
+
+            var box = new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+            return box.Contains(point, Spatial.Spatial.Options.NumericToleranceDegrees);
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialIndexing.cs
+++ b/LiteDB/Spatial/SpatialIndexing.cs
@@ -119,6 +119,80 @@ namespace LiteDB.Spatial
             return new[] { first, second };
         }
 
+        public static IReadOnlyList<(long Min, long Max)> GetMortonRanges(GeoBoundingBox box, int precisionBits)
+        {
+            if (precisionBits <= 0 || precisionBits > 60)
+            {
+                throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be between 1 and 60 bits");
+            }
+
+            var splits = SplitBoundingBox(box);
+            var ranges = new List<(long Min, long Max)>(splits.Count);
+
+            foreach (var split in splits)
+            {
+                var corners = new[]
+                {
+                    new GeoPoint(split.MinLat, split.MinLon),
+                    new GeoPoint(split.MinLat, split.MaxLon),
+                    new GeoPoint(split.MaxLat, split.MinLon),
+                    new GeoPoint(split.MaxLat, split.MaxLon)
+                };
+
+                long min = long.MaxValue;
+                long max = long.MinValue;
+
+                foreach (var corner in corners)
+                {
+                    var morton = ComputeMorton(corner, precisionBits);
+
+                    if (morton < min)
+                    {
+                        min = morton;
+                    }
+
+                    if (morton > max)
+                    {
+                        max = morton;
+                    }
+                }
+
+                if (min > max)
+                {
+                    (min, max) = (max, min);
+                }
+
+                ranges.Add((min, max));
+            }
+
+            if (ranges.Count <= 1)
+            {
+                return ranges;
+            }
+
+            ranges.Sort((a, b) => a.Min.CompareTo(b.Min));
+
+            var merged = new List<(long Min, long Max)> { ranges[0] };
+
+            for (var i = 1; i < ranges.Count; i++)
+            {
+                var current = ranges[i];
+                var lastIndex = merged.Count - 1;
+                var last = merged[lastIndex];
+
+                if (current.Min <= last.Max + 1)
+                {
+                    merged[lastIndex] = (last.Min, Math.Max(last.Max, current.Max));
+                }
+                else
+                {
+                    merged.Add(current);
+                }
+            }
+
+            return merged;
+        }
+
         private static IReadOnlyList<(long Start, long End)> MergeRanges(List<(long Start, long End)> ranges)
         {
             if (ranges.Count == 0)

--- a/LiteDB/Spatial/SpatialMetadataStore.cs
+++ b/LiteDB/Spatial/SpatialMetadataStore.cs
@@ -41,7 +41,7 @@ namespace LiteDB.Spatial
             var engine = Spatial.GetEngine(collection);
             if (engine == null)
             {
-                return Spatial.Options.IndexPrecisionBits;
+                return Spatial.Options.DefaultIndexPrecisionBits;
             }
 
             var key = EngineCollectionKey.Create(engine, collection.Name);
@@ -76,7 +76,7 @@ namespace LiteDB.Spatial
                 // Metadata collection may not exist yet; fall back to options.
             }
 
-            return Spatial.Options.IndexPrecisionBits;
+            return Spatial.Options.DefaultIndexPrecisionBits;
         }
 
         private readonly struct SpatialIndexMetadata

--- a/LiteDB/Spatial/SpatialOptions.cs
+++ b/LiteDB/Spatial/SpatialOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace LiteDB.Spatial
 {
     public enum DistanceFormula
@@ -14,6 +16,8 @@ namespace LiteDB.Spatial
 
     public sealed class SpatialOptions
     {
+        private double _numericToleranceDegrees = 1e-9;
+
         public DistanceFormula Distance { get; set; } = DistanceFormula.Haversine;
 
         public bool SortNearByDistance { get; set; } = true;
@@ -22,8 +26,25 @@ namespace LiteDB.Spatial
 
         public AngleUnit AngleUnit { get; set; } = AngleUnit.Degrees;
 
-        public int IndexPrecisionBits { get; set; } = 52;
+        public int DefaultIndexPrecisionBits { get; set; } = 52;
 
-        public double NumericToleranceDegrees { get; set; } = 1e-9;
+        public double BoundingBoxPaddingMeters { get; set; } = 0d;
+
+        public double DistanceToleranceMeters { get; set; } = 0.001d;
+
+        public double NumericToleranceDegrees
+        {
+            get => _numericToleranceDegrees;
+            set => _numericToleranceDegrees = Math.Max(0d, value);
+        }
+
+#pragma warning disable CS0618 // Maintain compatibility for callers still using IndexPrecisionBits.
+        [Obsolete("Use DefaultIndexPrecisionBits instead.")]
+        public int IndexPrecisionBits
+        {
+            get => DefaultIndexPrecisionBits;
+            set => DefaultIndexPrecisionBits = value;
+        }
+#pragma warning restore CS0618
     }
 }

--- a/LiteDB/Spatial/SpatialQuery.cs
+++ b/LiteDB/Spatial/SpatialQuery.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using LiteDB;
+
+namespace LiteDB.Spatial
+{
+    public static class SpatialQuery
+    {
+        public static BsonExpression Near<T>(BsonExpression field, GeoPoint center, double radiusMeters, LiteCollection<T> collection = null, int? precisionBits = null)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (center == null) throw new ArgumentNullException(nameof(center));
+            if (radiusMeters < 0d) throw new ArgumentOutOfRangeException(nameof(radiusMeters));
+
+            var precision = ResolvePrecision(collection, precisionBits);
+            var normalizedCenter = center.Normalize();
+            var searchBox = GeoMath.BoundingBoxForCircle(normalizedCenter, radiusMeters);
+            var expansionMeters = Math.Max(0d, Spatial.Options.BoundingBoxPaddingMeters + Spatial.Options.DistanceToleranceMeters);
+            var queryBox = expansionMeters > 0d ? searchBox.Expand(expansionMeters) : searchBox;
+
+            var predicates = new List<BsonExpression>();
+
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBox);
+            if (boundingPredicate != null)
+            {
+                predicates.Add(boundingPredicate);
+            }
+
+            var centerBson = GeoJson.ToBson(normalizedCenter);
+            predicates.Add(BsonExpression.Create($"SPATIAL_NEAR({field.Source}, @0, @1, @2)",
+                centerBson,
+                new BsonValue(radiusMeters),
+                new BsonValue(Spatial.Options.Distance.ToString())));
+
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBox, precision, Spatial.Options.MaxCoveringCells);
+            var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
+            if (rangePredicate != null)
+            {
+                predicates.Add(rangePredicate);
+            }
+
+            return Query.And(predicates.ToArray());
+        }
+
+        public static BsonExpression WithinBoundingBox(BsonExpression field, GeoBoundingBox box)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+
+            return BsonExpression.Create($"SPATIAL_WITHIN_BOX({field.Source}, @0, @1, @2, @3)",
+                box.MinLat, box.MinLon, box.MaxLat, box.MaxLon);
+        }
+
+        public static BsonExpression Within(BsonExpression field, GeoPolygon polygon)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (polygon == null) throw new ArgumentNullException(nameof(polygon));
+
+            var bson = GeoJson.ToBson(polygon);
+            return BsonExpression.Create($"SPATIAL_WITHIN({field.Source}, @0)", bson);
+        }
+
+        public static BsonExpression Intersects(BsonExpression field, GeoShape shape)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (shape == null) throw new ArgumentNullException(nameof(shape));
+
+            var bson = GeoJson.ToBson(shape);
+            return BsonExpression.Create($"SPATIAL_INTERSECTS({field.Source}, @0)", bson);
+        }
+
+        public static BsonExpression Contains(BsonExpression field, GeoPoint point)
+        {
+            if (field == null) throw new ArgumentNullException(nameof(field));
+            if (point == null) throw new ArgumentNullException(nameof(point));
+
+            var bson = GeoJson.ToBson(point);
+            return BsonExpression.Create($"SPATIAL_CONTAINS({field.Source}, @0)", bson);
+        }
+
+        private static int ResolvePrecision<T>(LiteCollection<T> collection, int? precisionBits)
+        {
+            if (precisionBits.HasValue)
+            {
+                return precisionBits.Value;
+            }
+
+            if (collection != null)
+            {
+                return SpatialMetadataStore.GetPointIndexPrecision(collection);
+            }
+
+            return Spatial.Options.DefaultIndexPrecisionBits;
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialQueryBuilder.cs
+++ b/LiteDB/Spatial/SpatialQueryBuilder.cs
@@ -24,22 +24,22 @@ namespace LiteDB.Spatial
 
         public static BsonExpression BuildBoundingBoxPredicate(GeoBoundingBox box)
         {
-            if (box.MaxLon < box.MinLon)
+            var range = new LongitudeRange(box.MinLon, box.MaxLon);
+            var expressions = new List<BsonExpression>();
+
+            foreach (var (start, end) in range.GetSegments())
             {
-                return null;
+                var segmentBox = new GeoBoundingBox(box.MinLat, start, box.MaxLat, end);
+
+                expressions.Add(BsonExpression.Create(
+                    "SPATIAL_MBB_INTERSECTS($._mbb, @0, @1, @2, @3)",
+                    segmentBox.MinLat,
+                    segmentBox.MinLon,
+                    segmentBox.MaxLat,
+                    segmentBox.MaxLon));
             }
 
-            var parameters = new[]
-            {
-                new BsonValue(box.MaxLat),
-                new BsonValue(box.MinLat),
-                new BsonValue(box.MaxLon),
-                new BsonValue(box.MinLon)
-            };
-
-            const string predicate = "($._mbb != null) AND $._mbb[0] <= @0 AND $._mbb[2] >= @1 AND $._mbb[1] <= @2 AND $._mbb[3] >= @3";
-
-            return BsonExpression.Create(predicate, parameters);
+            return CombineOr(expressions);
         }
 
         public static BsonExpression CombineSpatialPredicates(BsonExpression rangeExpression, BsonExpression boundingExpression)


### PR DESCRIPTION
## Summary
- add distance tolerance, padding, and default precision configuration to `SpatialOptions` and metadata usage
- expand spatial query helpers to pad bounding boxes, apply tolerances, and expose new LINQ/query helpers via `SpatialExpressions` and `SpatialQuery`
- update expression evaluator and resolver to support new spatial intrinsics and range handling across the dateline

## Testing
- dotnet build LiteDB/LiteDB.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e2fd61f1f4832abc36cccffa79e520