### PR TITLE
Add tolerance-aware spatial querying

### DIFF
--- a/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
+++ b/LiteDB/Client/Mapper/Linq/TypeResolver/SpatialResolver.cs
@@ -1,6 +1,6 @@
+using System;
 using System.Reflection;
 using LiteDB.Spatial;
-using SpatialMethods = LiteDB.Spatial.Spatial;
 
 namespace LiteDB
 {
@@ -13,31 +13,41 @@ namespace LiteDB
                 return null;
             }
 
-            if (method.DeclaringType != typeof(SpatialMethods))
+            if (method.DeclaringType == typeof(SpatialExpressions) || method.DeclaringType == typeof(Spatial.Spatial))
             {
-                return null;
-            }
+                switch (method.Name)
+                {
+                    case nameof(SpatialExpressions.Near):
+                        return ResolveNearPattern(method);
+                    case nameof(SpatialExpressions.Within):
+                        if (MatchesTwoParameterSignature(method, typeof(GeoShape), typeof(GeoPolygon)))
+                        {
+                            return "SPATIAL_WITHIN(@0, @1)";
+                        }
 
-            var parameters = method.GetParameters();
+                        break;
+                    case nameof(SpatialExpressions.Intersects):
+                        if (MatchesTwoParameterSignature(method, typeof(GeoShape), typeof(GeoShape)))
+                        {
+                            return "SPATIAL_INTERSECTS(@0, @1)";
+                        }
 
-            if (method.Name == nameof(SpatialMethods.Near) && parameters.Length == 3 && parameters[0].ParameterType == typeof(GeoPoint))
-            {
-                return "SPATIAL_NEAR(@0, @1, @2)";
-            }
+                        break;
+                    case nameof(SpatialExpressions.Contains):
+                        if (MatchesTwoParameterSignature(method, typeof(GeoShape), typeof(GeoPoint)))
+                        {
+                            return "SPATIAL_CONTAINS(@0, @1)";
+                        }
 
-            if (method.Name == nameof(SpatialMethods.Within) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
-            {
-                return "SPATIAL_WITHIN(@0, @1)";
-            }
+                        break;
+                    case nameof(SpatialExpressions.WithinBoundingBox):
+                        if (MatchesBoundingBoxSignature(method))
+                        {
+                            return "SPATIAL_WITHIN_BOX(@0, @1, @2, @3, @4)";
+                        }
 
-            if (method.Name == nameof(SpatialMethods.Intersects) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
-            {
-                return "SPATIAL_INTERSECTS(@0, @1)";
-            }
-
-            if (method.Name == nameof(SpatialMethods.Contains) && parameters.Length == 2 && parameters[0].ParameterType == typeof(GeoShape))
-            {
-                return "SPATIAL_CONTAINS_POINT(@0, @1)";
+                        break;
+                }
             }
 
             return null;
@@ -46,5 +56,54 @@ namespace LiteDB
         public string ResolveMember(MemberInfo member) => null;
 
         public string ResolveCtor(ConstructorInfo ctor) => null;
+
+        private static bool MatchesTwoParameterSignature(MethodInfo method, Type first, Type second)
+        {
+            var parameters = method.GetParameters();
+
+            return parameters.Length == 2 &&
+                   first.IsAssignableFrom(parameters[0].ParameterType) &&
+                   second.IsAssignableFrom(parameters[1].ParameterType);
+        }
+
+        private static bool MatchesBoundingBoxSignature(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+
+            if (parameters.Length != 5)
+            {
+                return false;
+            }
+
+            return typeof(GeoPoint).IsAssignableFrom(parameters[0].ParameterType) &&
+                   parameters[1].ParameterType == typeof(double) &&
+                   parameters[2].ParameterType == typeof(double) &&
+                   parameters[3].ParameterType == typeof(double) &&
+                   parameters[4].ParameterType == typeof(double);
+        }
+
+        private string ResolveNearPattern(MethodInfo method)
+        {
+            var parameters = method.GetParameters();
+
+            if (parameters.Length == 3 &&
+                typeof(GeoPoint).IsAssignableFrom(parameters[0].ParameterType) &&
+                typeof(GeoPoint).IsAssignableFrom(parameters[1].ParameterType) &&
+                parameters[2].ParameterType == typeof(double))
+            {
+                var formula = Spatial.Spatial.Options.Distance.ToString();
+                return $"SPATIAL_NEAR(@0, @1, @2, '{formula}')";
+            }
+
+            if (parameters.Length == 4 &&
+                typeof(GeoPoint).IsAssignableFrom(parameters[0].ParameterType) &&
+                typeof(GeoPoint).IsAssignableFrom(parameters[1].ParameterType) &&
+                parameters[2].ParameterType == typeof(double))
+            {
+                return "SPATIAL_NEAR(@0, @1, @2, @3)";
+            }
+
+            throw new NotSupportedException("Unsupported overload for spatial Near expression");
+        }
     }
 }

--- a/LiteDB/Document/Expression/Methods/Spatial.cs
+++ b/LiteDB/Document/Expression/Methods/Spatial.cs
@@ -1,98 +1,157 @@
+using System;
 using LiteDB.Spatial;
 
 namespace LiteDB
 {
     internal partial class BsonExpressionMethods
     {
-        public static BsonValue SPATIAL_INTERSECTS_MBB(BsonValue mbb, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
+        public static BsonValue SPATIAL_MBB_INTERSECTS(BsonValue bboxValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            if (mbb == null || mbb.IsNull || !mbb.IsArray || mbb.AsArray.Count < 4)
+            if (!bboxValue.IsArray || bboxValue.AsArray.Count != 4)
             {
                 return false;
             }
 
-            if (!minLat.IsNumber || !minLon.IsNumber || !maxLat.IsNumber || !maxLon.IsNumber)
-            {
-                return false;
-            }
-
-            var candidate = new GeoBoundingBox(mbb.AsArray[0].AsDouble, mbb.AsArray[1].AsDouble, mbb.AsArray[2].AsDouble, mbb.AsArray[3].AsDouble);
+            var candidate = ToBoundingBox(bboxValue);
             var query = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
-
             return candidate.Intersects(query);
         }
 
-        public static BsonValue SPATIAL_NEAR(BsonValue candidate, BsonValue center, BsonValue radiusMeters)
+        public static BsonValue SPATIAL_INTERSECTS_MBB(BsonValue bboxValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            if (!radiusMeters.IsNumber)
-            {
-                return false;
-            }
-
-            var candidatePoint = ToGeoPoint(candidate);
-            var centerPoint = ToGeoPoint(center);
-
-            if (candidatePoint == null || centerPoint == null)
-            {
-                return false;
-            }
-
-            return Spatial.Spatial.Near(candidatePoint, centerPoint, radiusMeters.AsDouble);
+            return SPATIAL_MBB_INTERSECTS(bboxValue, minLat, minLon, maxLat, maxLon);
         }
 
-        public static BsonValue SPATIAL_WITHIN(BsonValue candidate, BsonValue polygon)
+        public static BsonValue SPATIAL_NEAR(BsonValue shapeValue, BsonValue centerValue, BsonValue radiusValue)
         {
-            var shape = ToGeoShape(candidate);
-            var area = ToGeoShape(polygon) as GeoPolygon;
+            return SPATIAL_NEAR(shapeValue, centerValue, radiusValue, new BsonValue(Spatial.Spatial.Options.Distance.ToString()));
+        }
 
-            if (shape == null || area == null)
+        public static BsonValue SPATIAL_NEAR(BsonValue shapeValue, BsonValue centerValue, BsonValue radiusValue, BsonValue formulaValue)
+        {
+            var shape = ToShape(shapeValue) as GeoPoint;
+            var center = ToShape(centerValue) as GeoPoint;
+
+            if (shape == null || center == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Within(shape, area);
+            var radius = radiusValue.AsDouble;
+            var formula = ParseFormula(formulaValue);
+
+            return SpatialExpressions.Near(shape, center, radius, formula);
         }
 
-        public static BsonValue SPATIAL_INTERSECTS(BsonValue candidate, BsonValue other)
+        public static BsonValue SPATIAL_WITHIN_BOX(BsonValue shapeValue, BsonValue minLat, BsonValue minLon, BsonValue maxLat, BsonValue maxLon)
         {
-            var left = ToGeoShape(candidate);
-            var right = ToGeoShape(other);
+            var shape = ToShape(shapeValue);
+            if (shape == null)
+            {
+                return false;
+            }
+
+            var box = new GeoBoundingBox(minLat.AsDouble, minLon.AsDouble, maxLat.AsDouble, maxLon.AsDouble);
+
+            return shape switch
+            {
+                GeoPoint point => SpatialExpressions.WithinBoundingBox(point, box),
+                GeoShape geoShape => geoShape.GetBoundingBox().Intersects(box),
+                _ => false
+            };
+        }
+
+        public static BsonValue SPATIAL_WITHIN(BsonValue shapeValue, BsonValue polygonValue)
+        {
+            var shape = ToShape(shapeValue);
+            var polygon = ToShape(polygonValue) as GeoPolygon;
+
+            if (shape == null || polygon == null)
+            {
+                return false;
+            }
+
+            return SpatialExpressions.Within(shape, polygon);
+        }
+
+        public static BsonValue SPATIAL_INTERSECTS(BsonValue leftValue, BsonValue rightValue)
+        {
+            var left = ToShape(leftValue);
+            var right = ToShape(rightValue);
 
             if (left == null || right == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Intersects(left, right);
+            return SpatialExpressions.Intersects(left, right);
         }
 
-        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue candidate, BsonValue point)
+        public static BsonValue SPATIAL_CONTAINS(BsonValue shapeValue, BsonValue pointValue)
         {
-            var shape = ToGeoShape(candidate);
-            var geoPoint = ToGeoPoint(point);
+            var shape = ToShape(shapeValue);
+            var point = ToShape(pointValue) as GeoPoint;
 
-            if (shape == null || geoPoint == null)
+            if (shape == null || point == null)
             {
                 return false;
             }
 
-            return Spatial.Spatial.Contains(shape, geoPoint);
+            return SpatialExpressions.Contains(shape, point);
         }
 
-        private static GeoShape ToGeoShape(BsonValue value)
+        public static BsonValue SPATIAL_CONTAINS_POINT(BsonValue shapeValue, BsonValue pointValue)
         {
-            if (value == null || value.IsNull || !value.IsDocument)
+            return SPATIAL_CONTAINS(shapeValue, pointValue);
+        }
+
+        private static GeoBoundingBox ToBoundingBox(BsonValue value)
+        {
+            var array = value.AsArray;
+            return new GeoBoundingBox(array[0].AsDouble, array[1].AsDouble, array[2].AsDouble, array[3].AsDouble);
+        }
+
+        private static GeoShape ToShape(BsonValue value)
+        {
+            if (value == null || value.IsNull)
             {
                 return null;
             }
 
-            return GeoJson.FromBson(value.AsDocument);
+            if (value.IsDocument)
+            {
+                return GeoJson.FromBson(value.AsDocument);
+            }
+
+            if (value.IsArray && value.AsArray.Count >= 2)
+            {
+                var array = value.AsArray;
+                var lon = array[0].AsDouble;
+                var lat = array[1].AsDouble;
+                return new GeoPoint(lat, lon);
+            }
+
+            if (value.RawValue is GeoShape shape)
+            {
+                return shape;
+            }
+
+            return null;
         }
 
-        private static GeoPoint ToGeoPoint(BsonValue value)
+        private static DistanceFormula ParseFormula(BsonValue formulaValue)
         {
-            var shape = ToGeoShape(value);
-            return shape as GeoPoint;
+            if (formulaValue.IsString && Enum.TryParse<DistanceFormula>(formulaValue.AsString, out var parsed))
+            {
+                return parsed;
+            }
+
+            if (formulaValue.IsInt32)
+            {
+                return (DistanceFormula)formulaValue.AsInt32;
+            }
+
+            return Spatial.Spatial.Options.Distance;
         }
     }
 }

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -125,9 +125,12 @@ namespace LiteDB.Engine
             {
                 case "SPATIAL_INTERSECTS":
                 case "SPATIAL_INTERSECTS_MBB":
+                case "SPATIAL_MBB_INTERSECTS":
                 case "SPATIAL_CONTAINS_POINT":
+                case "SPATIAL_CONTAINS":
                 case "SPATIAL_NEAR":
                 case "SPATIAL_WITHIN":
+                case "SPATIAL_WITHIN_BOX":
                     return true;
                 default:
                     return false;

--- a/LiteDB/Spatial/GeoBoundingBox.cs
+++ b/LiteDB/Spatial/GeoBoundingBox.cs
@@ -48,17 +48,55 @@ namespace LiteDB.Spatial
 
         public bool Contains(GeoPoint point)
         {
+            return Contains(point, 0d);
+        }
+
+        public bool Contains(GeoPoint point, double toleranceDegrees)
+        {
             if (point == null)
             {
                 return false;
             }
 
-            return point.Lat >= MinLat && point.Lat <= MaxLat && IsLongitudeWithin(point.Lon);
+            var minLat = MinLat - toleranceDegrees;
+            var maxLat = MaxLat + toleranceDegrees;
+
+            if (point.Lat < minLat || point.Lat > maxLat)
+            {
+                return false;
+            }
+
+            var lonRange = new LongitudeRange(MinLon, MaxLon);
+
+            if (toleranceDegrees <= 0d)
+            {
+                return lonRange.Contains(point.Lon);
+            }
+
+            return lonRange.ContainsWithTolerance(point.Lon, toleranceDegrees);
         }
 
         public bool Intersects(GeoBoundingBox other)
         {
             return !(other.MinLat > MaxLat || other.MaxLat < MinLat) && LongitudesOverlap(other);
+        }
+
+        public GeoBoundingBox Expand(double meters)
+        {
+            if (meters <= 0d)
+            {
+                return this;
+            }
+
+            var angularDistance = meters / GeoMath.EarthRadiusMeters;
+            var deltaDegrees = angularDistance * (180d / Math.PI);
+
+            var minLat = GeoMath.ClampLatitude(MinLat - deltaDegrees);
+            var maxLat = GeoMath.ClampLatitude(MaxLat + deltaDegrees);
+            var minLon = GeoMath.NormalizeLongitude(MinLon - deltaDegrees);
+            var maxLon = GeoMath.NormalizeLongitude(MaxLon + deltaDegrees);
+
+            return new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
         }
 
         private bool LongitudesOverlap(GeoBoundingBox other)
@@ -68,10 +106,5 @@ namespace LiteDB.Spatial
             return lonRange.Intersects(otherRange);
         }
 
-        private bool IsLongitudeWithin(double lon)
-        {
-            var lonRange = new LongitudeRange(MinLon, MaxLon);
-            return lonRange.Contains(lon);
-        }
     }
 }

--- a/LiteDB/Spatial/GeoMath.cs
+++ b/LiteDB/Spatial/GeoMath.cs
@@ -8,7 +8,7 @@ namespace LiteDB.Spatial
 
         private const double DegToRad = Math.PI / 180d;
 
-        internal static double EpsilonDegrees => Spatial.Options.NumericToleranceDegrees;
+        internal static double EpsilonDegrees => Spatial.Options.ToleranceDegrees;
 
         public static double ClampLatitude(double latitude)
         {

--- a/LiteDB/Spatial/LongitudeRange.cs
+++ b/LiteDB/Spatial/LongitudeRange.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace LiteDB.Spatial
 {
@@ -62,6 +63,29 @@ namespace LiteDB.Spatial
             }
 
             return false;
+        }
+
+        public IEnumerable<(double start, double end)> GetSegments()
+        {
+            if (!_wraps)
+            {
+                yield return (_start, _end);
+                yield break;
+            }
+
+            yield return (_start, 180d);
+            yield return (-180d, _end);
+        }
+
+        public bool ContainsWithTolerance(double lon, double toleranceDegrees)
+        {
+            if (toleranceDegrees <= 0d)
+            {
+                return Contains(lon);
+            }
+
+            var expanded = new LongitudeRange(_start - toleranceDegrees, _end + toleranceDegrees);
+            return expanded.Contains(lon);
         }
     }
 }

--- a/LiteDB/Spatial/Spatial.cs
+++ b/LiteDB/Spatial/Spatial.cs
@@ -26,7 +26,7 @@ namespace LiteDB.Spatial
 
             if (precisionBits <= 0)
             {
-                precisionBits = Options.IndexPrecisionBits;
+                precisionBits = Options.DefaultIndexPrecisionBits;
             }
 
             var getter = selector.Compile();
@@ -82,66 +82,26 @@ namespace LiteDB.Spatial
             if (center == null) throw new ArgumentNullException(nameof(center));
             if (radiusMeters < 0d) throw new ArgumentOutOfRangeException(nameof(radiusMeters));
 
-            if (candidate == null)
-            {
-                return false;
-            }
-
-            var distance = GeoMath.DistanceMeters(center, candidate, Options.Distance);
-            return distance <= radiusMeters;
+            return SpatialExpressions.Near(candidate, center, radiusMeters, Options.Distance);
         }
 
         public static bool Within(GeoShape candidate, GeoPolygon area)
         {
             if (area == null) throw new ArgumentNullException(nameof(area));
 
-            return candidate switch
-            {
-                GeoPoint point => Geometry.ContainsPoint(area, point),
-                GeoPolygon polygon => Geometry.Intersects(area, polygon) && polygon.Outer.All(p => Geometry.ContainsPoint(area, p)),
-                GeoLineString line => line.Points.All(p => Geometry.ContainsPoint(area, p)),
-                _ => false
-            };
+            return SpatialExpressions.Within(candidate, area);
         }
 
         public static bool Intersects(GeoShape candidate, GeoShape query)
         {
-            if (candidate == null || query == null)
-            {
-                return false;
-            }
-
-            return candidate switch
-            {
-                GeoPoint point when query is GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
-                GeoPoint point when query is GeoLineString line => Geometry.LineContainsPoint(line, point),
-                GeoPoint point when query is GeoPoint other => Math.Abs(point.Lat - other.Lat) < GeoMath.EpsilonDegrees && Math.Abs(point.Lon - other.Lon) < GeoMath.EpsilonDegrees,
-                GeoLineString line when query is GeoPolygon polygon => Geometry.Intersects(line, polygon),
-                GeoLineString line when query is GeoLineString other => Geometry.Intersects(line, other),
-                GeoLineString line when query is GeoPoint point => Geometry.LineContainsPoint(line, point),
-                GeoPolygon polygon when query is GeoPolygon other => Geometry.Intersects(polygon, other),
-                GeoPolygon polygon when query is GeoLineString line => Geometry.Intersects(line, polygon),
-                GeoPolygon polygon when query is GeoPoint point => Geometry.ContainsPoint(polygon, point),
-                _ => false
-            };
+            return SpatialExpressions.Intersects(candidate, query);
         }
 
         public static bool Contains(GeoShape candidate, GeoPoint point)
         {
             if (point == null) throw new ArgumentNullException(nameof(point));
 
-            if (candidate == null)
-            {
-                return false;
-            }
-
-            return candidate switch
-            {
-                GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
-                GeoLineString line => Geometry.LineContainsPoint(line, point),
-                GeoPoint candidatePoint => Math.Abs(candidatePoint.Lat - point.Lat) < GeoMath.EpsilonDegrees && Math.Abs(candidatePoint.Lon - point.Lon) < GeoMath.EpsilonDegrees,
-                _ => false
-            };
+            return SpatialExpressions.Contains(candidate, point);
         }
 
         public static IEnumerable<T> Near<T>(ILiteCollection<T> collection, Func<T, GeoPoint> selector, GeoPoint center, double radiusMeters, int? limit = null)
@@ -157,24 +117,29 @@ namespace LiteDB.Spatial
 
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
             var boundingBox = GeoMath.BoundingBoxForCircle(center, radiusMeters);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var toleranceDegrees = Options.ToleranceDegrees;
+            var toleranceMeters = toleranceDegrees > 0d ? GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d) : 0d;
+            var paddingMeters = Options.BoundingBoxPaddingMeters + toleranceMeters;
+            var queryBoundingBox = paddingMeters > 0d ? boundingBox.Expand(paddingMeters) : boundingBox;
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBoundingBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBoundingBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
             var matches = new List<(T item, double distance)>();
+            var acceptanceRadius = radiusMeters + toleranceMeters + Options.DistanceToleranceMeters;
 
             foreach (var item in source)
             {
                 var point = selector(item);
-                if (point == null || !boundingBox.Contains(point))
+                if (point == null || !boundingBox.Contains(point, toleranceDegrees))
                 {
                     continue;
                 }
 
                 var distance = GeoMath.DistanceMeters(center, point, Options.Distance);
-                if (distance <= radiusMeters)
+                if (distance <= acceptanceRadius)
                 {
                     matches.Add((item, distance));
                 }
@@ -206,9 +171,13 @@ namespace LiteDB.Spatial
 
             var boundingBox = new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
             var precisionBits = SpatialMetadataStore.GetPointIndexPrecision(lite);
-            var ranges = SpatialIndexing.CoverBoundingBox(boundingBox, precisionBits, Options.MaxCoveringCells);
+            var toleranceDegrees = Options.ToleranceDegrees;
+            var toleranceMeters = toleranceDegrees > 0d ? GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d) : 0d;
+            var paddingMeters = Options.BoundingBoxPaddingMeters + toleranceMeters;
+            var queryBoundingBox = paddingMeters > 0d ? boundingBox.Expand(paddingMeters) : boundingBox;
+            var ranges = SpatialIndexing.CoverBoundingBox(queryBoundingBox, precisionBits, Options.MaxCoveringCells);
             var rangePredicate = SpatialQueryBuilder.BuildRangePredicate(ranges);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBoundingBox);
             var predicate = SpatialQueryBuilder.CombineSpatialPredicates(rangePredicate, boundingPredicate);
 
             var source = predicate != null ? lite.Find(predicate) : lite.FindAll();
@@ -217,7 +186,7 @@ namespace LiteDB.Spatial
                 .Where(entity =>
                 {
                     var point = selector(entity);
-                    return point != null && boundingBox.Contains(point);
+                    return point != null && boundingBox.Contains(point, toleranceDegrees);
                 })
                 .ToList();
         }
@@ -233,7 +202,11 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = area.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var toleranceDegrees = Options.ToleranceDegrees;
+            var toleranceMeters = toleranceDegrees > 0d ? GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d) : 0d;
+            var paddingMeters = Options.BoundingBoxPaddingMeters + toleranceMeters;
+            var queryBoundingBox = paddingMeters > 0d ? boundingBox.Expand(paddingMeters) : boundingBox;
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBoundingBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
@@ -254,7 +227,11 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = query.GetBoundingBox();
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var toleranceDegrees = Options.ToleranceDegrees;
+            var toleranceMeters = toleranceDegrees > 0d ? GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d) : 0d;
+            var paddingMeters = Options.BoundingBoxPaddingMeters + toleranceMeters;
+            var queryBoundingBox = paddingMeters > 0d ? boundingBox.Expand(paddingMeters) : boundingBox;
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBoundingBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>
@@ -275,7 +252,11 @@ namespace LiteDB.Spatial
             EnsureMapperRegistration(mapper);
 
             var boundingBox = new GeoBoundingBox(point.Lat, point.Lon, point.Lat, point.Lon);
-            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(boundingBox);
+            var toleranceDegrees = Options.ToleranceDegrees;
+            var toleranceMeters = toleranceDegrees > 0d ? GeoMath.EarthRadiusMeters * toleranceDegrees * (Math.PI / 180d) : 0d;
+            var paddingMeters = Options.BoundingBoxPaddingMeters + toleranceMeters;
+            var queryBoundingBox = paddingMeters > 0d ? boundingBox.Expand(paddingMeters) : boundingBox;
+            var boundingPredicate = SpatialQueryBuilder.BuildBoundingBoxPredicate(queryBoundingBox);
             var source = boundingPredicate != null ? lite.Find(boundingPredicate) : lite.FindAll();
 
             return source.Where(entity =>

--- a/LiteDB/Spatial/SpatialExpressions.cs
+++ b/LiteDB/Spatial/SpatialExpressions.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Linq;
+using LiteDB.Spatial;
+
+namespace LiteDB
+{
+    public static class SpatialExpressions
+    {
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters)
+        {
+            return Near(point, center, radiusMeters, Spatial.Spatial.Options.Distance);
+        }
+
+        public static bool Near(GeoPoint point, GeoPoint center, double radiusMeters, DistanceFormula formula)
+        {
+            if (point == null || center == null)
+            {
+                return false;
+            }
+
+            var distance = GeoMath.DistanceMeters(point, center, formula);
+            var tolerance = Spatial.Spatial.Options.DistanceToleranceMeters;
+            var angularTolerance = Spatial.Spatial.Options.ToleranceDegrees;
+
+            if (angularTolerance > 0d)
+            {
+                var angularMeters = GeoMath.EarthRadiusMeters * angularTolerance * (Math.PI / 180d);
+                tolerance += angularMeters;
+            }
+
+            return distance <= radiusMeters + tolerance;
+        }
+
+        public static bool Within(GeoShape shape, GeoPolygon polygon)
+        {
+            if (shape == null || polygon == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPoint point => Geometry.ContainsPoint(polygon, point),
+                GeoPolygon other => Geometry.Intersects(polygon, other) && other.Outer.All(p => Geometry.ContainsPoint(polygon, p)),
+                GeoLineString line => line.Points.All(p => Geometry.ContainsPoint(polygon, p)),
+                _ => false
+            };
+        }
+
+        public static bool Intersects(GeoShape shape, GeoShape other)
+        {
+            if (shape == null || other == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPolygon polygon when other is GeoPolygon polygonOther => Geometry.Intersects(polygon, polygonOther),
+                GeoLineString line when other is GeoPolygon polygon => Geometry.Intersects(line, polygon),
+                GeoPolygon polygon when other is GeoLineString line => Geometry.Intersects(line, polygon),
+                GeoLineString line when other is GeoLineString otherLine => Geometry.Intersects(line, otherLine),
+                GeoPoint point when other is GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoPoint point when other is GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint point when other is GeoPoint otherPoint => Math.Abs(point.Lat - otherPoint.Lat) < GeoMath.EpsilonDegrees && Math.Abs(point.Lon - otherPoint.Lon) < GeoMath.EpsilonDegrees,
+                _ => false
+            };
+        }
+
+        public static bool Contains(GeoShape shape, GeoPoint point)
+        {
+            if (shape == null || point == null)
+            {
+                return false;
+            }
+
+            return shape switch
+            {
+                GeoPolygon polygon => Geometry.ContainsPoint(polygon, point),
+                GeoLineString line => Geometry.LineContainsPoint(line, point),
+                GeoPoint candidate => Math.Abs(candidate.Lat - point.Lat) < GeoMath.EpsilonDegrees && Math.Abs(candidate.Lon - point.Lon) < GeoMath.EpsilonDegrees,
+                _ => false
+            };
+        }
+
+        public static bool WithinBoundingBox(GeoPoint point, double minLat, double minLon, double maxLat, double maxLon)
+        {
+            var box = new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+            return WithinBoundingBox(point, box);
+        }
+
+        internal static bool WithinBoundingBox(GeoPoint point, GeoBoundingBox box)
+        {
+            if (point == null)
+            {
+                return false;
+            }
+
+            return box.Contains(point, Spatial.Spatial.Options.ToleranceDegrees);
+        }
+    }
+}

--- a/LiteDB/Spatial/SpatialMetadataStore.cs
+++ b/LiteDB/Spatial/SpatialMetadataStore.cs
@@ -41,7 +41,7 @@ namespace LiteDB.Spatial
             var engine = Spatial.GetEngine(collection);
             if (engine == null)
             {
-                return Spatial.Options.IndexPrecisionBits;
+                return Spatial.Options.DefaultIndexPrecisionBits;
             }
 
             var key = EngineCollectionKey.Create(engine, collection.Name);
@@ -76,7 +76,7 @@ namespace LiteDB.Spatial
                 // Metadata collection may not exist yet; fall back to options.
             }
 
-            return Spatial.Options.IndexPrecisionBits;
+            return Spatial.Options.DefaultIndexPrecisionBits;
         }
 
         private readonly struct SpatialIndexMetadata

--- a/LiteDB/Spatial/SpatialOptions.cs
+++ b/LiteDB/Spatial/SpatialOptions.cs
@@ -14,6 +14,9 @@ namespace LiteDB.Spatial
 
     public sealed class SpatialOptions
     {
+        private int _defaultIndexPrecisionBits = 52;
+        private double _toleranceDegrees = 1e-9;
+
         public DistanceFormula Distance { get; set; } = DistanceFormula.Haversine;
 
         public bool SortNearByDistance { get; set; } = true;
@@ -22,8 +25,32 @@ namespace LiteDB.Spatial
 
         public AngleUnit AngleUnit { get; set; } = AngleUnit.Degrees;
 
-        public int IndexPrecisionBits { get; set; } = 52;
+        public int DefaultIndexPrecisionBits
+        {
+            get => _defaultIndexPrecisionBits;
+            set => _defaultIndexPrecisionBits = value;
+        }
 
-        public double NumericToleranceDegrees { get; set; } = 1e-9;
+        public double BoundingBoxPaddingMeters { get; set; } = 0d;
+
+        public double DistanceToleranceMeters { get; set; } = 0.001d;
+
+        public double ToleranceDegrees
+        {
+            get => _toleranceDegrees;
+            set => _toleranceDegrees = value;
+        }
+
+        public int IndexPrecisionBits
+        {
+            get => _defaultIndexPrecisionBits;
+            set => _defaultIndexPrecisionBits = value;
+        }
+
+        public double NumericToleranceDegrees
+        {
+            get => _toleranceDegrees;
+            set => _toleranceDegrees = value;
+        }
     }
 }

--- a/docs/spatial-guide.md
+++ b/docs/spatial-guide.md
@@ -119,11 +119,13 @@ The endpoint reuses the shared helpers, ensuring metadata is created automatical
 ```csharp
 Spatial.Options = new SpatialOptions
 {
-    IndexPrecisionBits = 48,
-    NumericToleranceDegrees = 1e-8,
+    DefaultIndexPrecisionBits = 48,
+    ToleranceDegrees = 1e-8,
+    DistanceToleranceMeters = 0.05,
+    BoundingBoxPaddingMeters = 2,
     MaxCoveringCells = 64,
     Distance = DistanceFormula.Vincenty
 };
 ```
 
-Changing `IndexPrecisionBits` updates persisted metadata the next time `EnsurePointIndex` runs, so the engine always knows how to slice query ranges. Adjust `NumericToleranceDegrees` if your datasets require more relaxed comparisons for noisy coordinates.
+Changing `DefaultIndexPrecisionBits` updates persisted metadata the next time `EnsurePointIndex` runs, so the engine always knows how to slice query ranges. Adjust `ToleranceDegrees`, `BoundingBoxPaddingMeters`, and `DistanceToleranceMeters` if your datasets require more relaxed comparisons for noisy coordinates or you need to pad index lookups around the query window.

--- a/docs/spatial-roadmap.md
+++ b/docs/spatial-roadmap.md
@@ -54,7 +54,7 @@ dotnet test LiteDB.Tests/LiteDB.Tests.csproj -f net8.0 --filter FullyQualifiedNa
 ### 4. Precision & Options
 - Surface defaults via SpatialOptions (index precision, tolerance, distance formula).
 - Persist precision metadata alongside index definitions for smarter range calculations.
-- ✅ `SpatialOptions` now exposes `IndexPrecisionBits` and `NumericToleranceDegrees`; `EnsurePointIndex` writes metadata into `_spatial_meta` and reuses it during query planning.
+- ✅ `SpatialOptions` now exposes `DefaultIndexPrecisionBits`, `ToleranceDegrees`, `BoundingBoxPaddingMeters`, and `DistanceToleranceMeters`; `EnsurePointIndex` writes metadata into `_spatial_meta` and reuses it during query planning.
 
 ### 5. Migration & Tooling
 - Offer shell commands or utility APIs to backfill `_gh`/`_mbb` for existing datasets.


### PR DESCRIPTION
## Summary
- introduce configurable tolerance and padding options for spatial indexes and fallbacks
- add SpatialExpressions helpers with resolver and expression support for new spatial operators
- expand spatial queries to honor tolerance-aware bounding boxes and document the new configuration knobs

## Testing
- dotnet test LiteDB.Tests/LiteDB.Tests.csproj -c Release --filter Spatial

------
https://chatgpt.com/codex/tasks/task_e_68e2fd61f1f4832abc36cccffa79e520