### PR TITLE
Improve spatial accuracy near poles

### DIFF
--- a/LiteDB.Tests/Spatial/GeoTestHelpers.cs
+++ b/LiteDB.Tests/Spatial/GeoTestHelpers.cs
@@ -38,6 +38,11 @@ internal static class GeoTestHelpers
         var minLon = NormalizeLon(box.MinLon);
         var maxLon = NormalizeLon(box.MaxLon);
 
+        if (box.SpansAllLongitudes)
+        {
+            return true;
+        }
+
         if (minLon <= maxLon + Epsilon)
         {
             return normalizedLon >= minLon - Epsilon && normalizedLon <= maxLon + Epsilon;

--- a/LiteDB/Spatial/GeoBoundingBox.cs
+++ b/LiteDB/Spatial/GeoBoundingBox.cs
@@ -10,13 +10,29 @@ namespace LiteDB.Spatial
         public double MinLon { get; }
         public double MaxLat { get; }
         public double MaxLon { get; }
+        public bool SpansAllLongitudes { get; }
 
         public GeoBoundingBox(double minLat, double minLon, double maxLat, double maxLon)
         {
             MinLat = GeoMath.ClampLatitude(Math.Min(minLat, maxLat));
             MaxLat = GeoMath.ClampLatitude(Math.Max(minLat, maxLat));
-            MinLon = GeoMath.NormalizeLongitude(minLon);
-            MaxLon = GeoMath.NormalizeLongitude(maxLon);
+
+            var rawSpan = Math.Abs(maxLon - minLon);
+            var spansFull = double.IsInfinity(rawSpan) || rawSpan >= 360d - GeoMath.EpsilonDegrees;
+
+            if (spansFull)
+            {
+                SpansAllLongitudes = true;
+                var offset = Math.Max(GeoMath.EpsilonDegrees / 2d, 1e-12);
+                MinLon = -180d + offset;
+                MaxLon = 180d - offset;
+            }
+            else
+            {
+                SpansAllLongitudes = false;
+                MinLon = GeoMath.NormalizeLongitude(minLon);
+                MaxLon = GeoMath.NormalizeLongitude(maxLon);
+            }
         }
 
         public static GeoBoundingBox FromPoints(IEnumerable<GeoPoint> points)
@@ -58,7 +74,17 @@ namespace LiteDB.Spatial
 
         public bool Intersects(GeoBoundingBox other)
         {
-            return !(other.MinLat > MaxLat || other.MaxLat < MinLat) && LongitudesOverlap(other);
+            if (other.MinLat > MaxLat || other.MaxLat < MinLat)
+            {
+                return false;
+            }
+
+            if (SpansAllLongitudes || other.SpansAllLongitudes)
+            {
+                return true;
+            }
+
+            return LongitudesOverlap(other);
         }
 
         public GeoBoundingBox Expand(double meters)
@@ -73,6 +99,11 @@ namespace LiteDB.Spatial
 
             var minLat = GeoMath.ClampLatitude(MinLat - deltaDegrees);
             var maxLat = GeoMath.ClampLatitude(MaxLat + deltaDegrees);
+            if (SpansAllLongitudes)
+            {
+                return new GeoBoundingBox(minLat, -180d, maxLat, 180d);
+            }
+
             var minLon = GeoMath.NormalizeLongitude(MinLon - deltaDegrees);
             var maxLon = GeoMath.NormalizeLongitude(MaxLon + deltaDegrees);
 
@@ -88,6 +119,11 @@ namespace LiteDB.Spatial
 
         private bool IsLongitudeWithin(double lon)
         {
+            if (SpansAllLongitudes)
+            {
+                return true;
+            }
+
             var lonRange = new LongitudeRange(MinLon, MaxLon);
             return lonRange.Contains(lon);
         }

--- a/LiteDB/Spatial/GeoMath.cs
+++ b/LiteDB/Spatial/GeoMath.cs
@@ -7,6 +7,11 @@ namespace LiteDB.Spatial
         public const double EarthRadiusMeters = 6_371_000d;
 
         private const double DegToRad = Math.PI / 180d;
+        private const double RadToDeg = 180d / Math.PI;
+
+        private const double Wgs84EquatorialRadius = 6_378_137d;
+        private const double Wgs84Flattening = 1d / 298.257223563d;
+        private const double Wgs84PolarRadius = Wgs84EquatorialRadius * (1d - Wgs84Flattening);
 
         internal static double EpsilonDegrees => Spatial.Options.ToleranceDegrees;
 
@@ -54,8 +59,21 @@ namespace LiteDB.Spatial
             };
         }
 
-        private static double Haversine(GeoPoint a, GeoPoint b)
+        private static double Haversine(GeoPoint a, GeoPoint b, bool allowVincentyFallback = true)
         {
+            if (allowVincentyFallback && Math.Abs(a.Lat) > 89d && Math.Abs(b.Lat) > 89d)
+            {
+                var lonDifference = Math.Abs(NormalizeLongitude(b.Lon - a.Lon));
+
+                if (lonDifference > 135d)
+                {
+                    return Vincenty(a, b);
+                }
+
+                var deltaLat = ToRadians(Math.Abs(a.Lat - b.Lat));
+                return EarthRadiusMeters * deltaLat;
+            }
+
             var lat1 = ToRadians(a.Lat);
             var lat2 = ToRadians(b.Lat);
             var dLat = lat2 - lat1;
@@ -70,34 +88,91 @@ namespace LiteDB.Spatial
             hav = Math.Min(1d, Math.Max(0d, hav));
 
             var c = 2d * Math.Atan2(Math.Sqrt(hav), Math.Sqrt(Math.Max(0d, 1d - hav)));
-            var distance = EarthRadiusMeters * c;
 
-            if (Math.Abs(a.Lat) > 89d && Math.Abs(b.Lat) > 89d && distance > 100d)
-            {
-                var deltaLat = ToRadians(Math.Abs(a.Lat - b.Lat));
-                return EarthRadiusMeters * deltaLat;
-            }
-
-            return distance;
+            return EarthRadiusMeters * c;
         }
 
         private static double Vincenty(GeoPoint a, GeoPoint b)
         {
-            var lat1 = ToRadians(a.Lat);
-            var lat2 = ToRadians(b.Lat);
-            var dLon = ToRadians(NormalizeLongitude(b.Lon - a.Lon));
+            var phi1 = ToRadians(a.Lat);
+            var phi2 = ToRadians(b.Lat);
+            var lambda = ToRadians(NormalizeLongitude(b.Lon - a.Lon));
 
-            var sinLat1 = Math.Sin(lat1);
-            var cosLat1 = Math.Cos(lat1);
-            var sinLat2 = Math.Sin(lat2);
-            var cosLat2 = Math.Cos(lat2);
-            var cosDeltaLon = Math.Cos(dLon);
+            var f = Wgs84Flattening;
+            var aRadius = Wgs84EquatorialRadius;
+            var bRadius = Wgs84PolarRadius;
 
-            var numerator = Math.Sqrt(Math.Pow(cosLat2 * Math.Sin(dLon), 2d) + Math.Pow(cosLat1 * sinLat2 - sinLat1 * cosLat2 * cosDeltaLon, 2d));
-            var denominator = sinLat1 * sinLat2 + cosLat1 * cosLat2 * cosDeltaLon;
-            var angle = Math.Atan2(numerator, denominator);
+            var tanU1 = (1d - f) * Math.Tan(phi1);
+            var cosU1 = 1d / Math.Sqrt(1d + tanU1 * tanU1);
+            var sinU1 = tanU1 * cosU1;
 
-            return EarthRadiusMeters * angle;
+            var tanU2 = (1d - f) * Math.Tan(phi2);
+            var cosU2 = 1d / Math.Sqrt(1d + tanU2 * tanU2);
+            var sinU2 = tanU2 * cosU2;
+
+            var lambdaIter = lambda;
+            double lambdaPrev;
+
+            const int maxIterations = 100;
+            var iteration = 0;
+
+            double sinSigma;
+            double cosSigma;
+            double sigma;
+            double cosSqAlpha;
+            double cos2SigmaM = 0d;
+
+            do
+            {
+                var sinLambda = Math.Sin(lambdaIter);
+                var cosLambda = Math.Cos(lambdaIter);
+
+                var term1 = cosU2 * sinLambda;
+                var term2 = cosU1 * sinU2 - sinU1 * cosU2 * cosLambda;
+
+                sinSigma = Math.Sqrt(term1 * term1 + term2 * term2);
+
+                if (sinSigma == 0d)
+                {
+                    return 0d;
+                }
+
+                cosSigma = sinU1 * sinU2 + cosU1 * cosU2 * cosLambda;
+                sigma = Math.Atan2(sinSigma, cosSigma);
+
+                var sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
+                cosSqAlpha = 1d - sinAlpha * sinAlpha;
+
+                if (cosSqAlpha != 0d)
+                {
+                    cos2SigmaM = cosSigma - 2d * sinU1 * sinU2 / cosSqAlpha;
+                }
+                else
+                {
+                    cos2SigmaM = 0d;
+                }
+
+                var c = f / 16d * cosSqAlpha * (4d + f * (4d - 3d * cosSqAlpha));
+                lambdaPrev = lambdaIter;
+                lambdaIter = lambda + (1d - c) * f * sinAlpha * (sigma + c * sinSigma * (cos2SigmaM + c * cosSigma * (-1d + 2d * cos2SigmaM * cos2SigmaM)));
+
+                iteration++;
+            }
+            while (Math.Abs(lambdaIter - lambdaPrev) > 1e-12 && iteration < maxIterations);
+
+            if (iteration == maxIterations)
+            {
+                return Haversine(a, b, allowVincentyFallback: false);
+            }
+
+            var uSq = cosSqAlpha * (aRadius * aRadius - bRadius * bRadius) / (bRadius * bRadius);
+            var bigA = 1d + uSq / 16384d * (4096d + uSq * (-768d + uSq * (320d - 175d * uSq)));
+            var bigB = uSq / 1024d * (256d + uSq * (-128d + uSq * (74d - 47d * uSq)));
+
+            var deltaSigma = bigB * sinSigma * (cos2SigmaM + bigB / 4d * (cosSigma * (-1d + 2d * cos2SigmaM * cos2SigmaM) - bigB / 6d * cos2SigmaM * (-3d + 4d * sinSigma * sinSigma) * (-3d + 4d * cos2SigmaM * cos2SigmaM)));
+            var s = bRadius * bigA * (sigma - deltaSigma);
+
+            return s;
         }
 
         internal static GeoBoundingBox BoundingBoxForCircle(GeoPoint center, double radiusMeters)
@@ -114,11 +189,40 @@ namespace LiteDB.Spatial
 
             var angularDistance = radiusMeters / EarthRadiusMeters;
 
-            var minLat = ClampLatitude(center.Lat - angularDistance / DegToRad);
-            var maxLat = ClampLatitude(center.Lat + angularDistance / DegToRad);
+            var centerLatRadians = ToRadians(center.Lat);
+            var minLatRadians = centerLatRadians - angularDistance;
+            var maxLatRadians = centerLatRadians + angularDistance;
 
-            var minLon = NormalizeLongitude(center.Lon - angularDistance / DegToRad);
-            var maxLon = NormalizeLongitude(center.Lon + angularDistance / DegToRad);
+            var minLat = ClampLatitude(minLatRadians * RadToDeg);
+            var maxLat = ClampLatitude(maxLatRadians * RadToDeg);
+
+            double minLon;
+            double maxLon;
+
+            if (minLatRadians <= -Math.PI / 2d || maxLatRadians >= Math.PI / 2d)
+            {
+                minLon = -180d;
+                maxLon = 180d;
+            }
+            else
+            {
+                var cosLat = Math.Cos(centerLatRadians);
+
+                if (cosLat <= 0d)
+                {
+                    minLon = -180d;
+                    maxLon = 180d;
+                }
+                else
+                {
+                    var sinAngular = Math.Sin(angularDistance);
+                    var ratio = Math.Min(1d, Math.Max(-1d, sinAngular / cosLat));
+                    var deltaLon = Math.Asin(ratio) * RadToDeg;
+
+                    minLon = NormalizeLongitude(center.Lon - deltaLon);
+                    maxLon = NormalizeLongitude(center.Lon + deltaLon);
+                }
+            }
 
             return new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
         }


### PR DESCRIPTION
## Summary
- add a WGS84-based Vincenty implementation and improve haversine fallback logic around the poles
- produce polar-safe bounding boxes that correctly span all longitudes and expose that intent to callers
- adjust spatial test helpers to understand all-longitude bounding boxes

## Testing
- dotnet test LiteDB.Tests/LiteDB.Tests.csproj -c Release -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68e69ca99bd883269fa0ff99be540bb9