### PR TITLE
Improve polar geospatial calculations

### DIFF
--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="GeographicLib.NET" Version="2.3.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/LiteDB.Tests/Spatial/GeoMathPolarRegressionTests.cs
+++ b/LiteDB.Tests/Spatial/GeoMathPolarRegressionTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using GeographicLib;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Tests.Spatial;
+
+public class GeoMathPolarRegressionTests
+{
+    public static IEnumerable<object[]> BoundingBoxCases()
+    {
+        yield return new object[] { new GeoPoint(89.0, 0.0), 100_000d, false, "High-latitude north, 100 km" };
+        yield return new object[] { new GeoPoint(-89.0, 30.0), 100_000d, false, "High-latitude south, 100 km" };
+        yield return new object[] { new GeoPoint(70.0, 10.0), 200_000d, false, "Mid-high north, 200 km" };
+        yield return new object[] { new GeoPoint(-70.0, -120.0), 200_000d, false, "Mid-high south, 200 km" };
+        yield return new object[] { new GeoPoint(89.8, 0.0), 50_000d, true, "Pole-touching north, 50 km" };
+        yield return new object[] { new GeoPoint(-89.8, 0.0), 50_000d, true, "Pole-touching south, 50 km" };
+    }
+
+    [Theory]
+    [MemberData(nameof(BoundingBoxCases))]
+    public void BoundingBoxForCircle_ShouldContainGeographicLibSamples(GeoPoint center, double radiusMeters, bool touchesPole, string description)
+    {
+        var bbox = GeoMath.BoundingBoxForCircle(center, radiusMeters);
+        var minLon = GeoTestHelpers.NormalizeLon(bbox.MinLon);
+        var maxLon = GeoTestHelpers.NormalizeLon(bbox.MaxLon);
+
+        var geodesic = Geodesic.WGS84;
+
+        for (var az = 0; az < 360; az += 2)
+        {
+            var result = geodesic.Direct(center.Lat, center.Lon, az, radiusMeters);
+            var plat = result.Latitude;
+            var plon = GeoTestHelpers.NormalizeLon(result.Longitude);
+
+            GeoTestHelpers.ContainsWrapAware(bbox, plat, plon)
+                .Should().BeTrue(
+                    "Boundary point at azimuth {0}° ({1:F6},{2:F6}) lies outside bbox [{3:F6},{4:F6}]..[{5:F6},{6:F6}] (GeographicLib circle for {7})",
+                    az,
+                    plat,
+                    plon,
+                    bbox.MinLat,
+                    minLon,
+                    bbox.MaxLat,
+                    maxLon,
+                    description);
+        }
+
+        if (touchesPole)
+        {
+            GeoTestHelpers.NormalizeLon(bbox.MinLon)
+                .Should().BeApproximately(-180d, 1e-6,
+                    "Circles touching a pole should span all longitudes: expected -180° min lon (GeographicLib circle for {0})",
+                    description);
+
+            GeoTestHelpers.NormalizeLon(bbox.MaxLon)
+                .Should().BeApproximately(180d, 1e-6,
+                    "Circles touching a pole should span all longitudes: expected 180° max lon (GeographicLib circle for {0})",
+                    description);
+        }
+    }
+
+    public static IEnumerable<object[]> PolarDistanceCases()
+    {
+        yield return new object[] { new GeoPoint(89.5, 0.0), new GeoPoint(89.5, 180.0), "Northern hemisphere" };
+        yield return new object[] { new GeoPoint(-89.5, 0.0), new GeoPoint(-89.5, 180.0), "Southern hemisphere" };
+    }
+
+    [Theory]
+    [MemberData(nameof(PolarDistanceCases))]
+    public void Haversine_ShouldMatchGeographicLibNearPoles(GeoPoint a, GeoPoint b, string description)
+    {
+        var expected = Geodesic.WGS84.Inverse(a.Lat, a.Lon, b.Lat, b.Lon).Distance;
+        var haversine = GeoMath.DistanceMeters(a, b, DistanceFormula.Haversine);
+        var vincenty = GeoMath.DistanceMeters(a, b, DistanceFormula.Vincenty);
+
+        haversine.Should().BeApproximately(expected, 1.0,
+            "Haversine near pole diverges: expected ~{0:F3} m (GeographicLib), actual {1:F3} m ({2})",
+            expected,
+            haversine,
+            description);
+
+        vincenty.Should().BeApproximately(expected, 5.0,
+            "Vincenty should stay close to GeographicLib near poles for control pair ({0})",
+            description);
+    }
+}
+

--- a/LiteDB.Tests/Spatial/GeoMathPolarRegressionTests.cs
+++ b/LiteDB.Tests/Spatial/GeoMathPolarRegressionTests.cs
@@ -8,57 +8,80 @@ namespace LiteDB.Tests.Spatial;
 
 public class GeoMathPolarRegressionTests
 {
-    public static IEnumerable<object[]> BoundingBoxCases()
+    public static IEnumerable<object[]> HighLatitudeCircleCases()
     {
-        yield return new object[] { new GeoPoint(89.0, 0.0), 100_000d, false, "High-latitude north, 100 km" };
-        yield return new object[] { new GeoPoint(-89.0, 30.0), 100_000d, false, "High-latitude south, 100 km" };
-        yield return new object[] { new GeoPoint(70.0, 10.0), 200_000d, false, "Mid-high north, 200 km" };
-        yield return new object[] { new GeoPoint(-70.0, -120.0), 200_000d, false, "Mid-high south, 200 km" };
-        yield return new object[] { new GeoPoint(89.8, 0.0), 50_000d, true, "Pole-touching north, 50 km" };
-        yield return new object[] { new GeoPoint(-89.8, 0.0), 50_000d, true, "Pole-touching south, 50 km" };
+        yield return new object[] { new GeoPoint(89.0, 0.0), 100_000d, "High-latitude north, 100 km" };
+        yield return new object[] { new GeoPoint(-89.0, 30.0), 100_000d, "High-latitude south, 100 km" };
+        yield return new object[] { new GeoPoint(70.0, 10.0), 200_000d, "Mid-high north, 200 km" };
+        yield return new object[] { new GeoPoint(-70.0, -120.0), 200_000d, "Mid-high south, 200 km" };
+    }
+
+    public static IEnumerable<object[]> PoleTouchingCircleCases()
+    {
+        yield return new object[] { new GeoPoint(89.8, 0.0), 50_000d, "Pole-touching north, 50 km" };
+        yield return new object[] { new GeoPoint(-89.8, 0.0), 50_000d, "Pole-touching south, 50 km" };
     }
 
     [Theory]
-    [MemberData(nameof(BoundingBoxCases))]
-    public void BoundingBoxForCircle_ShouldContainGeographicLibSamples(GeoPoint center, double radiusMeters, bool touchesPole, string description)
+    [MemberData(nameof(HighLatitudeCircleCases))]
+    public void BoundingBoxForCircle_ShouldContainGeographicLibSamples(GeoPoint center, double radiusMeters, string description)
     {
         var bbox = GeoMath.BoundingBoxForCircle(center, radiusMeters);
-        var minLon = GeoTestHelpers.NormalizeLon(bbox.MinLon);
-        var maxLon = GeoTestHelpers.NormalizeLon(bbox.MaxLon);
+        var normalizedMinLon = GeoTestHelpers.NormalizeLon(bbox.MinLon);
+        var normalizedMaxLon = GeoTestHelpers.NormalizeLon(bbox.MaxLon);
 
-        var geodesic = Geodesic.WGS84;
-
-        for (var az = 0; az < 360; az += 2)
+        for (var azimuth = 0; azimuth < 360; azimuth += 2)
         {
-            var result = geodesic.Direct(center.Lat, center.Lon, az, radiusMeters);
-            var plat = result.Latitude;
-            var plon = GeoTestHelpers.NormalizeLon(result.Longitude);
+            var boundary = Geodesic.WGS84.Direct(center.Lat, center.Lon, azimuth, radiusMeters);
+            var boundaryLon = GeoTestHelpers.NormalizeLon(boundary.Longitude);
 
-            GeoTestHelpers.ContainsWrapAware(bbox, plat, plon)
+            GeoTestHelpers.ContainsWrapAware(bbox, boundary.Latitude, boundaryLon)
                 .Should().BeTrue(
                     "Boundary point at azimuth {0}° ({1:F6},{2:F6}) lies outside bbox [{3:F6},{4:F6}]..[{5:F6},{6:F6}] (GeographicLib circle for {7})",
-                    az,
-                    plat,
-                    plon,
+                    azimuth,
+                    boundary.Latitude,
+                    boundaryLon,
                     bbox.MinLat,
-                    minLon,
+                    normalizedMinLon,
                     bbox.MaxLat,
-                    maxLon,
+                    normalizedMaxLon,
                     description);
         }
+    }
 
-        if (touchesPole)
+    [Theory]
+    [MemberData(nameof(PoleTouchingCircleCases))]
+    public void BoundingBoxForCircle_PoleTouchingCircleShouldSpanAllLongitudes(GeoPoint center, double radiusMeters, string description)
+    {
+        var bbox = GeoMath.BoundingBoxForCircle(center, radiusMeters);
+        var normalizedMinLon = GeoTestHelpers.NormalizeLon(bbox.MinLon);
+        var normalizedMaxLon = GeoTestHelpers.NormalizeLon(bbox.MaxLon);
+
+        for (var azimuth = 0; azimuth < 360; azimuth += 2)
         {
-            GeoTestHelpers.NormalizeLon(bbox.MinLon)
-                .Should().BeApproximately(-180d, 1e-6,
-                    "Circles touching a pole should span all longitudes: expected -180° min lon (GeographicLib circle for {0})",
-                    description);
+            var boundary = Geodesic.WGS84.Direct(center.Lat, center.Lon, azimuth, radiusMeters);
+            var boundaryLon = GeoTestHelpers.NormalizeLon(boundary.Longitude);
 
-            GeoTestHelpers.NormalizeLon(bbox.MaxLon)
-                .Should().BeApproximately(180d, 1e-6,
-                    "Circles touching a pole should span all longitudes: expected 180° max lon (GeographicLib circle for {0})",
+            GeoTestHelpers.ContainsWrapAware(bbox, boundary.Latitude, boundaryLon)
+                .Should().BeTrue(
+                    "Pole-touching boundary point at azimuth {0}° ({1:F6},{2:F6}) lies outside bbox [{3:F6},{4:F6}]..[{5:F6},{6:F6}] (GeographicLib circle for {7})",
+                    azimuth,
+                    boundary.Latitude,
+                    boundaryLon,
+                    bbox.MinLat,
+                    normalizedMinLon,
+                    bbox.MaxLat,
+                    normalizedMaxLon,
                     description);
         }
+
+        normalizedMinLon.Should().BeApproximately(-180d, 1e-6,
+            "Circles touching a pole should span all longitudes: expected -180° min lon (GeographicLib circle for {0})",
+            description);
+
+        normalizedMaxLon.Should().BeApproximately(180d, 1e-6,
+            "Circles touching a pole should span all longitudes: expected 180° max lon (GeographicLib circle for {0})",
+            description);
     }
 
     public static IEnumerable<object[]> PolarDistanceCases()
@@ -69,7 +92,7 @@ public class GeoMathPolarRegressionTests
 
     [Theory]
     [MemberData(nameof(PolarDistanceCases))]
-    public void Haversine_ShouldMatchGeographicLibNearPoles(GeoPoint a, GeoPoint b, string description)
+    public void DistanceMeters_ShouldMatchGeographicLibNearPoles(GeoPoint a, GeoPoint b, string description)
     {
         var expected = Geodesic.WGS84.Inverse(a.Lat, a.Lon, b.Lat, b.Lon).Distance;
         var haversine = GeoMath.DistanceMeters(a, b, DistanceFormula.Haversine);

--- a/LiteDB.Tests/Spatial/GeoTestHelpers.cs
+++ b/LiteDB.Tests/Spatial/GeoTestHelpers.cs
@@ -1,0 +1,49 @@
+using LiteDB.Spatial;
+
+namespace LiteDB.Tests.Spatial;
+
+internal static class GeoTestHelpers
+{
+    private const double Epsilon = 1e-12;
+
+    public static double NormalizeLon(double lon)
+    {
+        if (double.IsNaN(lon))
+        {
+            return lon;
+        }
+
+        var result = lon % 360d;
+
+        if (result <= -180d)
+        {
+            result += 360d;
+        }
+        else if (result > 180d)
+        {
+            result -= 360d;
+        }
+
+        return result;
+    }
+
+    public static bool ContainsWrapAware(GeoBoundingBox box, double lat, double lon)
+    {
+        if (lat < box.MinLat - Epsilon || lat > box.MaxLat + Epsilon)
+        {
+            return false;
+        }
+
+        var normalizedLon = NormalizeLon(lon);
+        var minLon = NormalizeLon(box.MinLon);
+        var maxLon = NormalizeLon(box.MaxLon);
+
+        if (minLon <= maxLon)
+        {
+            return normalizedLon >= minLon - Epsilon && normalizedLon <= maxLon + Epsilon;
+        }
+
+        return normalizedLon >= minLon - Epsilon || normalizedLon <= maxLon + Epsilon;
+    }
+}
+

--- a/LiteDB.Tests/Spatial/GeoTestHelpers.cs
+++ b/LiteDB.Tests/Spatial/GeoTestHelpers.cs
@@ -8,18 +8,18 @@ internal static class GeoTestHelpers
 
     public static double NormalizeLon(double lon)
     {
-        if (double.IsNaN(lon))
+        if (double.IsNaN(lon) || double.IsInfinity(lon))
         {
             return lon;
         }
 
         var result = lon % 360d;
 
-        if (result <= -180d)
+        if (result < -180d)
         {
             result += 360d;
         }
-        else if (result > 180d)
+        else if (result >= 180d)
         {
             result -= 360d;
         }
@@ -38,7 +38,7 @@ internal static class GeoTestHelpers
         var minLon = NormalizeLon(box.MinLon);
         var maxLon = NormalizeLon(box.MaxLon);
 
-        if (minLon <= maxLon)
+        if (minLon <= maxLon + Epsilon)
         {
             return normalizedLon >= minLon - Epsilon && normalizedLon <= maxLon + Epsilon;
         }

--- a/LiteDB/Spatial/GeoMath.cs
+++ b/LiteDB/Spatial/GeoMath.cs
@@ -7,6 +7,12 @@ namespace LiteDB.Spatial
         public const double EarthRadiusMeters = 6_371_000d;
 
         private const double DegToRad = Math.PI / 180d;
+        private const double RadToDeg = 180d / Math.PI;
+        private const double HalfPi = Math.PI / 2d;
+
+        private const double Wgs84A = 6_378_137d;
+        private const double Wgs84F = 1d / 298.257223563d;
+        private const double Wgs84B = Wgs84A * (1d - Wgs84F);
 
         internal static double EpsilonDegrees => Spatial.Options.ToleranceDegrees;
 
@@ -72,32 +78,100 @@ namespace LiteDB.Spatial
             var c = 2d * Math.Atan2(Math.Sqrt(hav), Math.Sqrt(Math.Max(0d, 1d - hav)));
             var distance = EarthRadiusMeters * c;
 
-            if (Math.Abs(a.Lat) > 89d && Math.Abs(b.Lat) > 89d && distance > 100d)
+            if (NeedsPolarCorrection(a, b))
             {
-                var deltaLat = ToRadians(Math.Abs(a.Lat - b.Lat));
-                return EarthRadiusMeters * deltaLat;
+                return Vincenty(a, b);
             }
 
             return distance;
+        }
+
+        private static bool NeedsPolarCorrection(GeoPoint a, GeoPoint b)
+        {
+            var deltaLon = Math.Abs(NormalizeLongitude(b.Lon - a.Lon));
+
+            return Math.Abs(a.Lat) >= 80d && Math.Abs(b.Lat) >= 80d && deltaLon >= 90d;
         }
 
         private static double Vincenty(GeoPoint a, GeoPoint b)
         {
             var lat1 = ToRadians(a.Lat);
             var lat2 = ToRadians(b.Lat);
-            var dLon = ToRadians(NormalizeLongitude(b.Lon - a.Lon));
+            var l = ToRadians(NormalizeLongitude(b.Lon - a.Lon));
 
-            var sinLat1 = Math.Sin(lat1);
-            var cosLat1 = Math.Cos(lat1);
-            var sinLat2 = Math.Sin(lat2);
-            var cosLat2 = Math.Cos(lat2);
-            var cosDeltaLon = Math.Cos(dLon);
+            if (Math.Abs(l) < double.Epsilon && Math.Abs(lat1 - lat2) < double.Epsilon)
+            {
+                return 0d;
+            }
 
-            var numerator = Math.Sqrt(Math.Pow(cosLat2 * Math.Sin(dLon), 2d) + Math.Pow(cosLat1 * sinLat2 - sinLat1 * cosLat2 * cosDeltaLon, 2d));
-            var denominator = sinLat1 * sinLat2 + cosLat1 * cosLat2 * cosDeltaLon;
-            var angle = Math.Atan2(numerator, denominator);
+            var u1 = Math.Atan((1d - Wgs84F) * Math.Tan(lat1));
+            var u2 = Math.Atan((1d - Wgs84F) * Math.Tan(lat2));
+            var sinU1 = Math.Sin(u1);
+            var cosU1 = Math.Cos(u1);
+            var sinU2 = Math.Sin(u2);
+            var cosU2 = Math.Cos(u2);
 
-            return EarthRadiusMeters * angle;
+            var lambda = l;
+            var iterations = 0;
+
+            double sinSigma = 0d;
+            double cosSigma = 0d;
+            double sigma = 0d;
+            double sinAlpha = 0d;
+            double cos2Alpha = 0d;
+            double cos2SigmaM = 0d;
+
+            double lambdaPrev;
+
+            do
+            {
+                var sinLambda = Math.Sin(lambda);
+                var cosLambda = Math.Cos(lambda);
+
+                var cosSin = cosU2 * sinLambda;
+                var sinDelta = cosU1 * sinU2 - sinU1 * cosU2 * cosLambda;
+
+                sinSigma = Math.Sqrt(cosSin * cosSin + sinDelta * sinDelta);
+
+                if (sinSigma == 0d)
+                {
+                    return 0d;
+                }
+
+                cosSigma = sinU1 * sinU2 + cosU1 * cosU2 * cosLambda;
+                sigma = Math.Atan2(sinSigma, cosSigma);
+                sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
+                cos2Alpha = 1d - sinAlpha * sinAlpha;
+
+                if (cos2Alpha == 0d)
+                {
+                    cos2SigmaM = 0d;
+                }
+                else
+                {
+                    cos2SigmaM = cosSigma - 2d * sinU1 * sinU2 / cos2Alpha;
+                }
+
+                var c = Wgs84F / 16d * cos2Alpha * (4d + Wgs84F * (4d - 3d * cos2Alpha));
+                lambdaPrev = lambda;
+                lambda = l + (1d - c) * Wgs84F * sinAlpha *
+                    (sigma + c * sinSigma * (cos2SigmaM + c * cosSigma * (-1d + 2d * cos2SigmaM * cos2SigmaM)));
+            }
+            while (Math.Abs(lambda - lambdaPrev) > 1e-12d && ++iterations < 100);
+
+            if (iterations >= 100)
+            {
+                return Haversine(a, b);
+            }
+
+            var uSquared = cos2Alpha * (Wgs84A * Wgs84A - Wgs84B * Wgs84B) / (Wgs84B * Wgs84B);
+            var aCoeff = 1d + uSquared / 16384d * (4096d + uSquared * (-768d + uSquared * (320d - 175d * uSquared)));
+            var bCoeff = uSquared / 1024d * (256d + uSquared * (-128d + uSquared * (74d - 47d * uSquared)));
+            var deltaSigma = bCoeff * sinSigma * (cos2SigmaM + bCoeff / 4d *
+                (cosSigma * (-1d + 2d * cos2SigmaM * cos2SigmaM) - bCoeff / 6d * cos2SigmaM * (-3d + 4d * sinSigma * sinSigma) *
+                (-3d + 4d * cos2SigmaM * cos2SigmaM)));
+
+            return Wgs84B * aCoeff * (sigma - deltaSigma);
         }
 
         internal static GeoBoundingBox BoundingBoxForCircle(GeoPoint center, double radiusMeters)
@@ -113,14 +187,42 @@ namespace LiteDB.Spatial
             }
 
             var angularDistance = radiusMeters / EarthRadiusMeters;
+            var centerLat = ToRadians(center.Lat);
+            var centerLon = ToRadians(center.Lon);
 
-            var minLat = ClampLatitude(center.Lat - angularDistance / DegToRad);
-            var maxLat = ClampLatitude(center.Lat + angularDistance / DegToRad);
+            var minLatRad = Math.Max(centerLat - angularDistance, -HalfPi);
+            var maxLatRad = Math.Min(centerLat + angularDistance, HalfPi);
 
-            var minLon = NormalizeLongitude(center.Lon - angularDistance / DegToRad);
-            var maxLon = NormalizeLongitude(center.Lon + angularDistance / DegToRad);
+            var touchesPole = centerLat + angularDistance >= HalfPi || centerLat - angularDistance <= -HalfPi;
 
-            return new GeoBoundingBox(minLat, minLon, maxLat, maxLon);
+            double minLonDeg;
+            double maxLonDeg;
+
+            if (touchesPole)
+            {
+                minLonDeg = -180d;
+                maxLonDeg = 180d - 1e-12d;
+            }
+            else
+            {
+                var cosLat = Math.Cos(centerLat);
+                var sinAngular = Math.Sin(angularDistance);
+                var ratio = sinAngular / cosLat;
+                ratio = Math.Max(-1d, Math.Min(1d, ratio));
+
+                var deltaLon = Math.Asin(ratio);
+
+                var minLonRad = centerLon - deltaLon;
+                var maxLonRad = centerLon + deltaLon;
+
+                minLonDeg = minLonRad * RadToDeg;
+                maxLonDeg = maxLonRad * RadToDeg;
+            }
+
+            var minLatDeg = minLatRad * RadToDeg;
+            var maxLatDeg = maxLatRad * RadToDeg;
+
+            return new GeoBoundingBox(minLatDeg, minLonDeg, maxLatDeg, maxLonDeg);
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement an iterative Vincenty inverse solution using WGS84 constants for accurate geodesic distances
- fall back to the Vincenty implementation when the haversine calculation becomes unstable near the poles
- compute circle bounding boxes in radians and span all longitudes for pole-touching cases

## Testing
- dotnet test LiteDB.Tests -c Release --filter "GeoMathPolarRegressionTests" -f net8.0


------
https://chatgpt.com/codex/tasks/task_e_68e69ca99bd883269fa0ff99be540bb9