### PR TITLE
Improve LiteFileStream chunk handling

### DIFF
--- a/LiteDB.Tests/Storage/LiteFileStreamTests.cs
+++ b/LiteDB.Tests/Storage/LiteFileStreamTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.IO;
+using System.Linq;
+using LiteDB.Tests.Utils;
+using Xunit;
+
+namespace LiteDB.Tests.Storage;
+
+public class LiteFileStreamTests
+{
+    [Fact]
+    public void StreamedWritesDeferPartialChunks()
+    {
+        using var db = DatabaseFactory.Create();
+        var fs = db.FileStorage;
+        var bufferSize = LiteFileStream<string>.MAX_CHUNK_SIZE - 8192;
+        var buffer = Enumerable.Range(0, bufferSize).Select(i => (byte)(i % 251)).ToArray();
+        var remainder = LiteFileStream<string>.MAX_CHUNK_SIZE / 2;
+
+        using var expected = new MemoryStream();
+        using (var stream = fs.OpenWrite("file", "file.bin"))
+        {
+            for (var i = 0; i < 5; i++)
+            {
+                stream.Write(buffer, 0, buffer.Length);
+                expected.Write(buffer, 0, buffer.Length);
+            }
+
+            stream.Write(buffer, 0, remainder);
+            expected.Write(buffer, 0, remainder);
+        }
+
+        var expectedBytes = expected.ToArray();
+        var fileInfo = fs.FindById("file");
+        Assert.NotNull(fileInfo);
+
+        var expectedLength = (long)buffer.Length * 5 + remainder;
+        var expectedFullChunks = expectedLength / LiteFileStream<string>.MAX_CHUNK_SIZE;
+        var expectedRemainder = (int)(expectedLength % LiteFileStream<string>.MAX_CHUNK_SIZE);
+        var expectedChunks = (int)expectedFullChunks + (expectedRemainder > 0 ? 1 : 0);
+
+        Assert.Equal(expectedLength, fileInfo.Length);
+        Assert.Equal(expectedChunks, fileInfo.Chunks);
+
+        var chunkDocs = db.GetCollection("_chunks")
+            .Query()
+            .Where("_id.f = @0", new BsonValue("file"))
+            .OrderBy("_id.n")
+            .ToList();
+
+        Assert.Equal(expectedChunks, chunkDocs.Count);
+
+        for (var i = 0; i < chunkDocs.Count; i++)
+        {
+            var length = chunkDocs[i]["data"].BinaryLength;
+            if (i < chunkDocs.Count - 1)
+            {
+                Assert.Equal(LiteFileStream<string>.MAX_CHUNK_SIZE, length);
+            }
+            else
+            {
+                Assert.Equal(expectedRemainder == 0 ? LiteFileStream<string>.MAX_CHUNK_SIZE : expectedRemainder, length);
+            }
+        }
+
+        using var readStream = fs.OpenRead("file");
+        using var actual = new MemoryStream();
+        readStream.CopyTo(actual);
+        Assert.Equal(expectedBytes, actual.ToArray());
+    }
+
+    [Fact]
+    public void SeekWithinReadStreamReturnsConsistentData()
+    {
+        using var db = DatabaseFactory.Create();
+        var fs = db.FileStorage;
+        var fullChunk = Enumerable.Range(0, LiteFileStream<string>.MAX_CHUNK_SIZE).Select(i => (byte)(i % 223)).ToArray();
+        var partial = LiteFileStream<string>.MAX_CHUNK_SIZE / 3;
+
+        using var expected = new MemoryStream();
+        using (var stream = fs.OpenWrite("seek", "seek.bin"))
+        {
+            stream.Write(fullChunk, 0, fullChunk.Length);
+            expected.Write(fullChunk, 0, fullChunk.Length);
+
+            stream.Write(fullChunk, 0, partial);
+            expected.Write(fullChunk, 0, partial);
+
+            stream.Write(fullChunk, 0, fullChunk.Length);
+            expected.Write(fullChunk, 0, fullChunk.Length);
+        }
+
+        var expectedBytes = expected.ToArray();
+        var seekOffset = LiteFileStream<string>.MAX_CHUNK_SIZE + 1234;
+        var readLength = 8192;
+        var buffer = new byte[readLength];
+
+        using var readStream = fs.OpenRead("seek");
+        readStream.Position = seekOffset;
+        var read = readStream.Read(buffer, 0, buffer.Length);
+        Assert.Equal(readLength, read);
+        Assert.True(expectedBytes.Skip(seekOffset).Take(readLength).SequenceEqual(buffer));
+        Assert.Equal(seekOffset + readLength, readStream.Position);
+
+        using var remainder = new MemoryStream();
+        readStream.CopyTo(remainder);
+        var remainingBytes = expectedBytes.Skip(seekOffset + readLength).ToArray();
+        Assert.Equal(remainingBytes, remainder.ToArray());
+    }
+}

--- a/LiteDB/Client/Storage/LiteFileStream.Read.cs
+++ b/LiteDB/Client/Storage/LiteFileStream.Read.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -8,7 +9,9 @@ namespace LiteDB
 {
     public partial class LiteFileStream<TFileId> : Stream
     {
-        private Dictionary<int, long> _chunkLengths = new Dictionary<int, long>();
+        private readonly Dictionary<int, long> _chunkLengths = new Dictionary<int, long>();
+        private readonly BsonDocument _chunkIdFilter;
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (_mode != FileAccess.Read) throw new NotSupportedException();
@@ -19,41 +22,105 @@ namespace LiteDB
 
             var bytesLeft = count;
 
-            while (_currentChunkData != null && bytesLeft > 0)
+            while (_currentChunkData.Length > 0 && bytesLeft > 0)
             {
-                var bytesToCopy = Math.Min(bytesLeft, _currentChunkData.Length - _positionInChunk);
+                var chunkSpan = _currentChunkData.Span;
+                if (_positionInChunk >= chunkSpan.Length)
+                {
+                    this.LoadChunkIntoState(_currentChunkIndex + 1);
+                    continue;
+                }
 
-                Buffer.BlockCopy(_currentChunkData, _positionInChunk, buffer, offset, bytesToCopy);
+                var bytesAvailable = chunkSpan.Length - _positionInChunk;
+                var bytesToCopy = Math.Min(bytesLeft, bytesAvailable);
+
+                chunkSpan.Slice(_positionInChunk, bytesToCopy)
+                    .CopyTo(new Span<byte>(buffer, offset, bytesToCopy));
 
                 _positionInChunk += bytesToCopy;
                 bytesLeft -= bytesToCopy;
                 offset += bytesToCopy;
                 _streamPosition += bytesToCopy;
 
-                if (_positionInChunk >= _currentChunkData.Length)
+                if (_positionInChunk >= chunkSpan.Length)
                 {
-                    _positionInChunk = 0;
-
-                    _currentChunkData = this.GetChunkData(++_currentChunkIndex);
+                    this.LoadChunkIntoState(_currentChunkIndex + 1);
                 }
             }
 
             return count - bytesLeft;
         }
 
-        private byte[] GetChunkData(int index)
+        private ReadOnlyMemory<byte> FetchChunk(int index, out IMemoryOwner<byte> owner)
         {
-            // check if there is no more chunks in this file
-            var chunk = _chunks
-                .FindOne("_id = { f: @0, n: @1 }", _fileId, index);
-
-            // if chunk is null there is no more chunks
-            byte[] result = chunk?["data"].AsBinary;
-            if (result != null)
+            if (_chunkIdFilter == null)
             {
-                _chunkLengths[index] = result.Length;
+                owner = null;
+                return ReadOnlyMemory<byte>.Empty;
             }
-            return result;
+
+            _chunkIdFilter["n"] = index;
+
+            var chunk = _chunks.FindById(_chunkIdFilter);
+
+            if (chunk == null)
+            {
+                owner = null;
+                return ReadOnlyMemory<byte>.Empty;
+            }
+
+            var value = chunk["data"];
+            var memory = value.AsBinaryMemory;
+            owner = value.DetachBinaryOwner();
+
+            return memory;
+        }
+
+        private void LoadChunkIntoState(int index)
+        {
+            this.DisposeCurrentChunkOwner();
+
+            if (index < 0)
+            {
+                _currentChunkData = ReadOnlyMemory<byte>.Empty;
+                _currentChunkIndex = index;
+                _positionInChunk = 0;
+                return;
+            }
+
+            var memory = this.FetchChunk(index, out var owner);
+
+            _currentChunkData = memory;
+            _currentChunkOwner = owner;
+            _currentChunkIndex = index;
+            _positionInChunk = 0;
+
+            if (!memory.IsEmpty)
+            {
+                _chunkLengths[index] = memory.Length;
+            }
+        }
+
+        private long GetChunkLength(int index)
+        {
+            if (_chunkLengths.TryGetValue(index, out var length))
+            {
+                return length;
+            }
+
+            var memory = this.FetchChunk(index, out var owner);
+
+            try
+            {
+                length = memory.Length;
+                _chunkLengths[index] = length;
+            }
+            finally
+            {
+                owner?.Dispose();
+            }
+
+            return length;
         }
 
         private void SetReadStreamPosition(long newPosition)
@@ -62,39 +129,49 @@ namespace LiteDB
             {
                 throw new ArgumentOutOfRangeException();
             }
+
             if (newPosition >= Length)
             {
                 _streamPosition = Length;
+                _positionInChunk = 0;
+                _currentChunkIndex = _file.Chunks;
+                this.DisposeCurrentChunkOwner();
+                _currentChunkData = ReadOnlyMemory<byte>.Empty;
                 return;
             }
+
             _streamPosition = newPosition;
 
-            // calculate new chunk position
-            long seekStreamPosition = 0;
-            int loadedChunk = _currentChunkIndex;
-            int newChunkIndex = 0;
-            while (seekStreamPosition <= _streamPosition)
+            long remaining = newPosition;
+            int index = 0;
+
+            while (true)
             {
-                if (_chunkLengths.TryGetValue(newChunkIndex, out long length))
+                var chunkLength = this.GetChunkLength(index);
+
+                if (chunkLength == 0)
                 {
-                    seekStreamPosition += length;
+                    this.DisposeCurrentChunkOwner();
+                    _currentChunkData = ReadOnlyMemory<byte>.Empty;
+                    _positionInChunk = 0;
+                    _currentChunkIndex = index;
+                    return;
                 }
-                else
+
+                if (remaining < chunkLength)
                 {
-                    loadedChunk = newChunkIndex;
-                    _currentChunkData = GetChunkData(newChunkIndex);
-                    seekStreamPosition += _currentChunkData.Length;
+                    if (_currentChunkIndex != index || _currentChunkData.Length == 0)
+                    {
+                        this.LoadChunkIntoState(index);
+                    }
+
+                    _positionInChunk = (int)remaining;
+                    _currentChunkIndex = index;
+                    return;
                 }
-                newChunkIndex++;
-            }
-            
-            newChunkIndex--;
-            seekStreamPosition -= _chunkLengths[newChunkIndex];
-            _positionInChunk = (int)(_streamPosition - seekStreamPosition);
-            _currentChunkIndex = newChunkIndex;
-            if (loadedChunk != _currentChunkIndex)
-            {
-                _currentChunkData = GetChunkData(_currentChunkIndex);
+
+                remaining -= chunkLength;
+                index++;
             }
         }
     }

--- a/LiteDB/Client/Storage/LiteFileStream.Write.cs
+++ b/LiteDB/Client/Storage/LiteFileStream.Write.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using static LiteDB.Constants;
@@ -30,13 +31,25 @@ namespace LiteDB
         /// </summary>
         private void WriteChunks(bool flush)
         {
-            var buffer = new byte[MAX_CHUNK_SIZE];
-            var read = 0;
-
-            _buffer.Seek(0, SeekOrigin.Begin);
-
-            while ((read = _buffer.Read(buffer, 0, MAX_CHUNK_SIZE)) > 0)
+            if (_buffer.Length == 0 && flush == false)
             {
+                return;
+            }
+
+            if (!_buffer.TryGetBuffer(out ArraySegment<byte> segment))
+            {
+                var bufferCopy = _buffer.ToArray();
+                segment = new ArraySegment<byte>(bufferCopy, 0, bufferCopy.Length);
+            }
+
+            var totalLength = (int)_buffer.Length;
+            var bytesToPersist = flush ? totalLength : totalLength - (totalLength % MAX_CHUNK_SIZE);
+            var processed = 0;
+
+            while (processed < bytesToPersist)
+            {
+                var chunkSize = Math.Min(MAX_CHUNK_SIZE, bytesToPersist - processed);
+
                 var chunk = new BsonDocument
                 {
                     ["_id"] = new BsonDocument
@@ -46,32 +59,63 @@ namespace LiteDB
                     }
                 };
 
-                // get chunk byte array part
-                if (read != MAX_CHUNK_SIZE)
+                var owner = MemoryPool<byte>.Shared.Rent(chunkSize);
+                BsonValue dataValue = null;
+                try
                 {
-                    var bytes = new byte[read];
-                    Buffer.BlockCopy(buffer, 0, bytes, 0, read);
-                    chunk["data"] = bytes;
+                    var target = owner.Memory.Span.Slice(0, chunkSize);
+                    new ReadOnlySpan<byte>(segment.Array, segment.Offset + processed, chunkSize).CopyTo(target);
+
+                    dataValue = new BsonValue(owner, chunkSize);
+                    chunk["data"] = dataValue;
+
+                    _chunks.Insert(chunk);
+                }
+                finally
+                {
+                    if (dataValue != null)
+                    {
+                        dataValue.DisposeBinaryOwner();
+                    }
+                    else
+                    {
+                        owner.Dispose();
+                    }
+                }
+
+                processed += chunkSize;
+            }
+
+            var remaining = totalLength - processed;
+
+            if (!flush)
+            {
+                if (remaining > 0)
+                {
+                    if (segment.Array != null)
+                    {
+                        Buffer.BlockCopy(segment.Array, segment.Offset + processed, segment.Array, segment.Offset, remaining);
+                    }
+
+                    _buffer.SetLength(remaining);
+                    _buffer.Position = remaining;
                 }
                 else
                 {
-                    chunk["data"] = buffer;
+                    _buffer.SetLength(0);
+                    _buffer.Position = 0;
                 }
-
-                // insert chunk part
-                _chunks.Insert(chunk);
             }
-
-            // if stream was closed/flush, update file too
-            if (flush)
+            else
             {
+                _buffer.SetLength(0);
+                _buffer.Position = 0;
+
                 _file.UploadDate = DateTime.Now;
                 _file.Length = _streamPosition;
 
                 _files.Upsert(_file);
             }
-
-            _buffer = new MemoryStream();
         }
     }
 }

--- a/LiteDB/Client/Storage/LiteFileStream.cs
+++ b/LiteDB/Client/Storage/LiteFileStream.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.IO;
 using System.Linq;
 using static LiteDB.Constants;
@@ -20,7 +21,8 @@ namespace LiteDB
 
         private long _streamPosition = 0;
         private int _currentChunkIndex = 0;
-        private byte[] _currentChunkData = null;
+        private ReadOnlyMemory<byte> _currentChunkData = ReadOnlyMemory<byte>.Empty;
+        private IMemoryOwner<byte> _currentChunkOwner = null;
         private int _positionInChunk = 0;
         private MemoryStream _buffer;
 
@@ -32,10 +34,17 @@ namespace LiteDB
             _fileId = fileId;
             _mode = mode;
 
+            _chunkIdFilter = mode == FileAccess.Read
+                ? new BsonDocument
+                {
+                    ["f"] = _fileId,
+                    ["n"] = 0
+                }
+                : null;
+
             if (mode == FileAccess.Read)
             {
-                // initialize first data block
-                _currentChunkData = this.GetChunkData(_currentChunkIndex);
+                this.LoadChunkIntoState(_currentChunkIndex);
             }
             else if(mode == FileAccess.Write)
             {
@@ -111,8 +120,18 @@ namespace LiteDB
                 this.Flush();
                 _buffer?.Dispose();
             }
+            else if (disposing)
+            {
+                this.DisposeCurrentChunkOwner();
+            }
 
             _disposed = true;
+        }
+
+        private void DisposeCurrentChunkOwner()
+        {
+            _currentChunkOwner?.Dispose();
+            _currentChunkOwner = null;
         }
 
         #endregion

--- a/LiteDB/Document/BsonBinaryData.cs
+++ b/LiteDB/Document/BsonBinaryData.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+namespace LiteDB
+{
+    internal sealed class BsonBinaryData : IDisposable
+    {
+        private IMemoryOwner<byte> _owner;
+        private ReadOnlyMemory<byte> _memory;
+        private byte[] _arrayCache;
+        private readonly int _length;
+
+        public BsonBinaryData(byte[] bytes)
+        {
+            _arrayCache = bytes ?? Array.Empty<byte>();
+            _length = _arrayCache.Length;
+            _memory = _arrayCache;
+        }
+
+        public BsonBinaryData(IMemoryOwner<byte> owner, int length)
+        {
+            if (owner == null) throw new ArgumentNullException(nameof(owner));
+            if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
+
+            _owner = owner;
+            _memory = owner.Memory.Slice(0, length);
+            _length = length;
+        }
+
+        public ReadOnlyMemory<byte> Memory => _arrayCache != null ? new ReadOnlyMemory<byte>(_arrayCache, 0, _length) : _memory;
+
+        public ReadOnlySpan<byte> Span => _arrayCache != null ? new ReadOnlySpan<byte>(_arrayCache, 0, _length) : _memory.Span;
+
+        public int Length => _length;
+
+        public bool HasOwner => _owner != null;
+
+        public byte[] GetBuffer()
+        {
+            if (_arrayCache != null)
+            {
+                if (_arrayCache.Length != _length)
+                {
+                    var resized = new byte[_length];
+                    Array.Copy(_arrayCache, 0, resized, 0, Math.Min(_arrayCache.Length, _length));
+                    _arrayCache = resized;
+                }
+
+                return _arrayCache;
+            }
+
+            var array = new byte[_length];
+            _memory.Span.Slice(0, _length).CopyTo(array);
+            _arrayCache = array;
+            DisposeOwner();
+            _memory = array;
+            return array;
+        }
+
+        public IMemoryOwner<byte> DetachOwner()
+        {
+            var owner = _owner;
+            _owner = null;
+            return owner;
+        }
+
+        private void DisposeOwner()
+        {
+            _owner?.Dispose();
+            _owner = null;
+        }
+
+        public void Dispose()
+        {
+            DisposeOwner();
+        }
+    }
+}

--- a/LiteDB/Document/BsonValue.cs
+++ b/LiteDB/Document/BsonValue.cs
@@ -1,5 +1,6 @@
 ﻿using LiteDB.Engine;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -86,7 +87,21 @@ namespace LiteDB
         public BsonValue(Byte[] value)
         {
             this.Type = value == null ? BsonType.Null : BsonType.Binary;
-            this.RawValue = value;
+            this.RawValue = value == null ? null : new BsonBinaryData(value);
+        }
+
+        public BsonValue(IMemoryOwner<byte> owner, int length)
+        {
+            if (owner == null)
+            {
+                this.Type = BsonType.Null;
+                this.RawValue = null;
+            }
+            else
+            {
+                this.Type = BsonType.Binary;
+                this.RawValue = new BsonBinaryData(owner, length);
+            }
         }
 
         public BsonValue(ObjectId value)
@@ -127,62 +142,114 @@ namespace LiteDB
 
         public BsonValue(object value)
         {
-            this.RawValue = value;
-
-            if (value == null) this.Type = BsonType.Null;
-            else if (value is Int32) this.Type = BsonType.Int32;
-            else if (value is Int64) this.Type = BsonType.Int64;
-            else if (value is Double) this.Type = BsonType.Double;
-            else if (value is Decimal) this.Type = BsonType.Decimal;
-            else if (value is String) this.Type = BsonType.String;
-            else if (value is IDictionary<string, BsonValue>) this.Type = BsonType.Document;
-            else if (value is IList<BsonValue>) this.Type = BsonType.Array;
-            else if (value is Byte[]) this.Type = BsonType.Binary;
-            else if (value is ObjectId) this.Type = BsonType.ObjectId;
-            else if (value is Guid) this.Type = BsonType.Guid;
-            else if (value is Boolean) this.Type = BsonType.Boolean;
-            else if (value is float[]) this.Type = BsonType.Vector;
-            else if (value is DateTime)
+            if (value == null)
+            {
+                this.Type = BsonType.Null;
+                this.RawValue = null;
+            }
+            else if (value is Int32 i32)
+            {
+                this.Type = BsonType.Int32;
+                this.RawValue = i32;
+            }
+            else if (value is Int64 i64)
+            {
+                this.Type = BsonType.Int64;
+                this.RawValue = i64;
+            }
+            else if (value is Double dbl)
+            {
+                this.Type = BsonType.Double;
+                this.RawValue = dbl;
+            }
+            else if (value is Decimal dec)
+            {
+                this.Type = BsonType.Decimal;
+                this.RawValue = dec;
+            }
+            else if (value is String str)
+            {
+                this.Type = BsonType.String;
+                this.RawValue = str;
+            }
+            else if (value is IDictionary<string, BsonValue> dict)
+            {
+                this.Type = BsonType.Document;
+                this.RawValue = dict;
+            }
+            else if (value is IList<BsonValue> list)
+            {
+                this.Type = BsonType.Array;
+                this.RawValue = list;
+            }
+            else if (value is Byte[] bytes)
+            {
+                this.Type = BsonType.Binary;
+                this.RawValue = new BsonBinaryData(bytes);
+            }
+            else if (value is IMemoryOwner<byte> owner)
+            {
+                this.Type = BsonType.Binary;
+                this.RawValue = new BsonBinaryData(owner, owner.Memory.Length);
+            }
+            else if (value is ObjectId objectId)
+            {
+                this.Type = objectId == null ? BsonType.Null : BsonType.ObjectId;
+                this.RawValue = objectId;
+            }
+            else if (value is Guid guid)
+            {
+                this.Type = BsonType.Guid;
+                this.RawValue = guid;
+            }
+            else if (value is Boolean boolean)
+            {
+                this.Type = BsonType.Boolean;
+                this.RawValue = boolean;
+            }
+            else if (value is float[] vector)
+            {
+                this.Type = BsonType.Vector;
+                this.RawValue = vector;
+            }
+            else if (value is DateTime dateTime)
             {
                 this.Type = BsonType.DateTime;
-                this.RawValue = ((DateTime)value).Truncate();
+                this.RawValue = dateTime.Truncate();
             }
-            else if (value is BsonValue)
+            else if (value is BsonValue bsonValue)
             {
-                var v = (BsonValue)value;
-                this.Type = v.Type;
-                this.RawValue = v.RawValue;
+                this.Type = bsonValue.Type;
+                this.RawValue = bsonValue.RawValue;
             }
             else
             {
-                // test for array or dictionary (document)
                 var enumerable = value as System.Collections.IEnumerable;
                 var dictionary = value as System.Collections.IDictionary;
 
-                // test first for dictionary (because IDictionary implements IEnumerable)
                 if (dictionary != null)
                 {
-                    var dict = new Dictionary<string, BsonValue>();
+                    var converted = new Dictionary<string, BsonValue>();
 
                     foreach (var key in dictionary.Keys)
                     {
-                        dict.Add(key.ToString(), new BsonValue(dictionary[key]));
+                        converted.Add(key.ToString(), new BsonValue(dictionary[key]));
                     }
 
                     this.Type = BsonType.Document;
-                    this.RawValue = dict;
+                    this.RawValue = converted;
                 }
                 else if (enumerable != null)
                 {
-                    var list = new List<BsonValue>();
+                    var converted = new List<BsonValue>();
 
-                    foreach (var x in enumerable)
+                    foreach (var item in enumerable)
                     {
-                        list.Add(new BsonValue(x));
+                        converted.Add(new BsonValue(item));
                     }
 
                     this.Type = BsonType.Array;
-                    this.RawValue = list;
+                    this.RawValue = converted;
                 }
                 else
                 {
@@ -224,7 +291,50 @@ namespace LiteDB
         public BsonDocument AsDocument => this as BsonDocument;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        public Byte[] AsBinary => this.RawValue as Byte[];
+        public Byte[] AsBinary
+        {
+            get
+            {
+                if (this.RawValue is BsonBinaryData binary)
+                {
+                    return binary.GetBuffer();
+                }
+
+                return this.RawValue as Byte[];
+            }
+        }
+
+        public ReadOnlyMemory<byte> AsBinaryMemory
+        {
+            get
+            {
+                if (this.RawValue is BsonBinaryData binary)
+                {
+                    return binary.Memory;
+                }
+
+                return this.RawValue is byte[] bytes ? (ReadOnlyMemory<byte>)bytes : ReadOnlyMemory<byte>.Empty;
+            }
+        }
+
+        public ReadOnlySpan<byte> AsBinarySpan => this.AsBinaryMemory.Span;
+
+        public int BinaryLength
+        {
+            get
+            {
+                if (this.RawValue is BsonBinaryData binary)
+                {
+                    return binary.Length;
+                }
+
+                return this.RawValue is byte[] bytes ? bytes.Length : 0;
+            }
+        }
+
+        public IMemoryOwner<byte> DetachBinaryOwner() => (this.RawValue as BsonBinaryData)?.DetachOwner();
+
+        public void DisposeBinaryOwner() => (this.RawValue as BsonBinaryData)?.Dispose();
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public bool AsBoolean => (bool)this.RawValue;
@@ -588,7 +698,7 @@ namespace LiteDB
                 case BsonType.Document: return this.AsDocument.CompareTo(other);
                 case BsonType.Array: return this.AsArray.CompareTo(other);
 
-                case BsonType.Binary: return this.AsBinary.BinaryCompareTo(other.AsBinary);
+                case BsonType.Binary: return this.AsBinarySpan.BinaryCompareTo(other.AsBinarySpan);
                 case BsonType.ObjectId: return this.AsObjectId.CompareTo(other.AsObjectId);
                 case BsonType.Guid: return this.AsGuid.CompareTo(other.AsGuid);
 
@@ -706,7 +816,7 @@ namespace LiteDB
 
                 case BsonType.String: return StringEncoding.UTF8.GetByteCount(this.AsString);
 
-                case BsonType.Binary: return this.AsBinary.Length;
+                case BsonType.Binary: return this.BinaryLength;
                 case BsonType.ObjectId: return 12;
                 case BsonType.Guid: return 16;
 

--- a/LiteDB/Document/Expression/Methods/Misc.cs
+++ b/LiteDB/Document/Expression/Methods/Misc.cs
@@ -161,7 +161,7 @@ namespace LiteDB
         public static BsonValue LENGTH(BsonValue value)
         {
             if (value.IsString) return value.AsString.Length;
-            else if (value.IsBinary) return value.AsBinary.Length;
+            else if (value.IsBinary) return value.BinaryLength;
             else if (value.IsArray) return value.AsArray.Count;
             else if (value.IsDocument) return value.AsDocument.Keys.Count;
             else if (value.IsNull) return 0;

--- a/LiteDB/Engine/Disk/Serializer/BufferReader.cs
+++ b/LiteDB/Engine/Disk/Serializer/BufferReader.cs
@@ -124,6 +124,31 @@ namespace LiteDB.Engine
             return bufferPosition;
         }
 
+        public void Read(Span<byte> destination)
+        {
+            var bufferPosition = 0;
+
+            while (bufferPosition < destination.Length)
+            {
+                var bytesLeft = _current.Count - _currentPosition;
+                var bytesToCopy = Math.Min(destination.Length - bufferPosition, bytesLeft);
+
+                if (bytesToCopy > 0)
+                {
+                    new ReadOnlySpan<byte>(_current.Array, _current.Offset + _currentPosition, bytesToCopy)
+                        .CopyTo(destination.Slice(bufferPosition, bytesToCopy));
+                }
+
+                bufferPosition += bytesToCopy;
+
+                this.MoveForward(bytesToCopy);
+
+                if (_isEOF) break;
+            }
+
+            ENSURE(destination.Length == bufferPosition, "current value must fit inside defined buffer");
+        }
+
         /// <summary>
         /// Skip bytes (same as Read but with no array copy)
         /// </summary>
@@ -331,6 +356,28 @@ namespace LiteDB.Engine
             return buffer;
         }
 
+        private BsonValue ReadBinaryValue(int count)
+        {
+            if (count == 0)
+            {
+                return new BsonValue(Array.Empty<byte>());
+            }
+
+            var owner = MemoryPool<byte>.Shared.Rent(count);
+
+            try
+            {
+                var span = owner.Memory.Span.Slice(0, count);
+                this.Read(span);
+                return new BsonValue(owner, count);
+            }
+            catch
+            {
+                owner.Dispose();
+                throw;
+            }
+        }
+
         /// <summary>
         /// Read single IndexKey (BsonValue) from buffer. Use +1 length only for string/binary
         /// </summary>
@@ -495,12 +542,17 @@ namespace LiteDB.Engine
             {
                 var length = this.ReadInt32();
                 var subType = this.ReadByte();
+                if (subType == 0x00)
+                {
+                    return this.ReadBinaryValue(length);
+                }
+
                 var bytes = this.ReadBytes(length);
 
                 switch (subType)
                 {
-                    case 0x00: return bytes;
                     case 0x04: return new Guid(bytes);
+                    default: return bytes;
                 }
             }
             else if (type == 0x07) // ObjectId

--- a/LiteDB/Engine/Disk/Serializer/BufferWriter.cs
+++ b/LiteDB/Engine/Disk/Serializer/BufferWriter.cs
@@ -120,6 +120,32 @@ namespace LiteDB.Engine
             return bufferPosition;
         }
 
+        public int Write(ReadOnlySpan<byte> source)
+        {
+            var written = 0;
+
+            while (written < source.Length)
+            {
+                var bytesLeft = _current.Count - _currentPosition;
+                var bytesToCopy = Math.Min(source.Length - written, bytesLeft);
+
+                if (bytesToCopy > 0)
+                {
+                    source.Slice(written, bytesToCopy).CopyTo(new Span<byte>(_current.Array, _current.Offset + _currentPosition, bytesToCopy));
+                }
+
+                written += bytesToCopy;
+
+                this.MoveForward(bytesToCopy);
+
+                if (_isEOF) break;
+            }
+
+            ENSURE(source.Length == written, "current value must fit inside defined buffer");
+
+            return written;
+        }
+
         /// <summary>
         /// Write bytes from buffer into segmentsr. Return how many bytes was write
         /// </summary>
@@ -359,10 +385,10 @@ namespace LiteDB.Engine
                 case BsonType.Binary:
                     this.Write((byte)0x05);
                     this.WriteCString(key);
-                    var bytes = value.AsBinary;
-                    this.Write(bytes.Length);
+                    var binary = value.AsBinarySpan;
+                    this.Write(binary.Length);
                     this.Write((byte)0x00); // subtype 00 - Generic binary subtype
-                    this.Write(bytes, 0, bytes.Length);
+                    this.Write(binary);
                     break;
 
                 case BsonType.Guid:

--- a/LiteDB/Utils/Extensions/BufferExtensions.cs
+++ b/LiteDB/Utils/Extensions/BufferExtensions.cs
@@ -8,21 +8,21 @@ namespace LiteDB
     internal static class BufferExtensions
     {
         // https://code.google.com/p/freshbooks-api/source/browse/depend/NClassify.Generator/content/ByteArray.cs?r=bbb6c13ec7a01eae082796550f1ddc05f61694b8
+        public static int BinaryCompareTo(this ReadOnlySpan<byte> lh, ReadOnlySpan<byte> rh)
+        {
+            var result = lh.SequenceCompareTo(rh);
+
+            if (result == 0) return 0;
+
+            return result < 0 ? -1 : 1;
+        }
+
         public static int BinaryCompareTo(this byte[] lh, byte[] rh)
         {
             if (lh == null) return rh == null ? 0 : -1;
             if (rh == null) return 1;
 
-            var result = 0;
-            var i = 0;
-            var stop = Math.Min(lh.Length, rh.Length);
-
-            for (; 0 == result && i < stop; i++)
-                result = lh[i].CompareTo(rh[i]);
-
-            if (result != 0) return result < 0 ? -1 : 1;
-            if (i == lh.Length) return i == rh.Length ? 0 : -1;
-            return 1;
+            return new ReadOnlySpan<byte>(lh).BinaryCompareTo(new ReadOnlySpan<byte>(rh));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- rework LiteFileStream write path to reuse pooled chunk buffers and delay partial chunk flushes
- update LiteFileStream read path and BSON infrastructure to support pooled binary ownership with new BsonBinaryData helper
- extend BufferReader/Writer to operate on spans and add targeted storage tests covering chunking and seeking

## Testing
- dotnet test LiteDB.Tests -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68e6c93749988326a98c5898dd726a86