### PR TITLE
Implement Morton encoder, metadata store, and backfill utilities

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
@@ -1,0 +1,124 @@
+extern alias litedbmain;
+
+using System;
+using System.IO;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+using LiteDatabase = litedbmain::LiteDB.LiteDatabase;
+using LiteDbBsonDocument = litedbmain::LiteDB.BsonDocument;
+using LiteDbBsonValue = litedbmain::LiteDB.BsonValue;
+using SpatialGeoPoint = LiteDB.Spatial.GeoPoint;
+using SpatialGeoPoint3D = LiteDB.Spatial.GeoPoint3D;
+
+namespace LiteDB.Spatial.Core.Tests.Backfill;
+
+public class SpatialBackfillTests
+{
+    [Fact]
+    public void Run_ShouldPopulateMissingFields()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("points");
+        var doc = new LiteDbBsonDocument
+        {
+            ["_id"] = 1,
+            ["lon"] = 0.25,
+            ["lat"] = 0.75
+        };
+
+        collection.Insert(doc);
+
+        var metadata = new SpatialCollectionMetadata("points", "stub", 2, new SpatialIndexOptions(precisionBits: 8));
+        var descriptor = new SpatialCollectionDescriptor(metadata, new TestMapper(dimensions: 2), d => new SpatialGeoPoint(d["lon"].AsDouble, d["lat"].AsDouble), null);
+
+        var result = SpatialBackfill.Run(collection, descriptor, batchSize: 16);
+
+        result.Processed.Should().Be(1);
+        result.Updated.Should().Be(1);
+        result.Errors.Should().BeEmpty();
+
+        var stored = collection.FindById(new LiteDbBsonValue(1));
+        ((object)stored).Should().NotBeNull();
+        var storedDocument = stored!;
+        storedDocument["_idx"].IsDecimal.Should().BeTrue();
+        storedDocument["_mbb"].AsArray.Count.Should().Be(4);
+    }
+
+    [Fact]
+    public void Run_ShouldSkipAlreadyIndexedDocuments()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("points");
+        var mapper = new TestMapper(dimensions: 2);
+
+        var doc = new LiteDbBsonDocument
+        {
+            ["_id"] = 1,
+            ["lon"] = 0.1,
+            ["lat"] = 0.2
+        };
+
+        collection.Insert(doc);
+
+        var metadata = new SpatialCollectionMetadata("points", "stub", 2, new SpatialIndexOptions(precisionBits: 6));
+        var descriptor = new SpatialCollectionDescriptor(metadata, mapper, d => new SpatialGeoPoint(d["lon"].AsDouble, d["lat"].AsDouble), null);
+
+        SpatialBackfill.Run(collection, descriptor, batchSize: 16);
+        var rerun = SpatialBackfill.Run(collection, descriptor, batchSize: 16);
+
+        rerun.Processed.Should().Be(1);
+        rerun.Updated.Should().Be(0);
+        rerun.Skipped.Should().Be(1);
+        rerun.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Run_ShouldCollectErrorsForDocumentsMissingGeometry()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("points");
+
+        collection.Insert(new LiteDbBsonDocument { ["_id"] = 1 });
+
+        var metadata = new SpatialCollectionMetadata("points", "stub", 2, new SpatialIndexOptions(precisionBits: 6));
+        var descriptor = new SpatialCollectionDescriptor(metadata, new TestMapper(dimensions: 2), d => null, null);
+
+        var result = SpatialBackfill.Run(collection, descriptor, batchSize: 8);
+
+        result.Processed.Should().Be(1);
+        result.Updated.Should().Be(0);
+        result.Errors.Should().HaveCount(1);
+        result.Errors[0].Message.Should().Contain("geometry");
+    }
+
+    private sealed class TestMapper : ISpatialMapper
+    {
+        private readonly MortonIndexEncoder _encoder;
+
+        public TestMapper(int dimensions)
+        {
+            _encoder = new MortonIndexEncoder(dimensions, precisionBits: 8);
+        }
+
+        public BoundingBox GetBoundingBox(SpatialGeoPoint point)
+        {
+            return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+        }
+
+        public BoundingBox GetBoundingBox(SpatialGeoPoint3D point)
+        {
+            return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+        }
+
+        public ulong Encode(SpatialGeoPoint point)
+        {
+            return _encoder.Encode(new[] { point.Longitude, point.Latitude });
+        }
+
+        public ulong Encode(SpatialGeoPoint3D point)
+        {
+            return _encoder.Encode(new[] { point.X, point.Y, point.Z });
+        }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
@@ -1,0 +1,57 @@
+using System;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public class SpatialIndexOptionsTests
+{
+    [Fact]
+    public void SpatialIndexOptions_ShouldUseSensibleDefaults()
+    {
+        var options = new SpatialIndexOptions();
+
+        options.PrecisionBits.Should().Be(32);
+        options.MaxCoveringCells.Should().Be(64);
+        options.DistanceTolerance.Should().Be(0.001);
+        options.IndexFieldName.Should().Be(SpatialIndexOptions.DefaultIndexFieldName);
+        options.BoundingBoxFieldName.Should().Be(SpatialIndexOptions.DefaultBoundingBoxFieldName);
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_ShouldAllowCustomization()
+    {
+        var options = new SpatialIndexOptions(40, 128, 0.25, "_custom_idx", "_custom_mbb");
+
+        options.PrecisionBits.Should().Be(40);
+        options.MaxCoveringCells.Should().Be(128);
+        options.DistanceTolerance.Should().Be(0.25);
+        options.IndexFieldName.Should().Be("_custom_idx");
+        options.BoundingBoxFieldName.Should().Be("_custom_mbb");
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_With_ShouldCreateNewInstance()
+    {
+        var options = new SpatialIndexOptions();
+        var updated = options.With(distanceTolerance: 0.01);
+
+        updated.Should().NotBeSameAs(options);
+        updated.DistanceTolerance.Should().Be(0.01);
+        updated.IndexFieldName.Should().Be(options.IndexFieldName);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 0, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, -0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, 0.1, "", "_mbb")]
+    [InlineData(32, 1, 0.1, "_idx", " ")]
+    public void SpatialIndexOptions_ShouldValidateInputs(int precisionBits, int maxCells, double tolerance, string indexField, string mbbField)
+    {
+        Action act = () => new SpatialIndexOptions(precisionBits, maxCells, tolerance, indexField, mbbField);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class BoundingBoxTests
+{
+    [Fact]
+    public void BoundingBox_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(BoundingBox);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BoundingBox2D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From2D(-10, -5, 20, 15);
+
+        box.Dimensions.Should().Be(2);
+        box.Is3D.Should().BeFalse();
+        box.MinX.Should().Be(-10);
+        box.MinY.Should().Be(-5);
+        box.MaxX.Should().Be(20);
+        box.MaxY.Should().Be(15);
+        box.GetValues().ToArray().Should().Equal(-10, -5, 20, 15);
+    }
+
+    [Fact]
+    public void BoundingBox3D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From3D(-1, -2, -3, 4, 5, 6);
+
+        box.Dimensions.Should().Be(3);
+        box.Is3D.Should().BeTrue();
+        box.MinX.Should().Be(-1);
+        box.MinY.Should().Be(-2);
+        box.MinZ.Should().Be(-3);
+        box.MaxX.Should().Be(4);
+        box.MaxY.Should().Be(5);
+        box.MaxZ.Should().Be(6);
+        box.GetValues().ToArray().Should().Equal(-1, -2, -3, 4, 5, 6);
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidAxisOrdering()
+    {
+        Action twoD = () => BoundingBox.From2D(5, 0, 4, 1);
+        Action threeD = () => BoundingBox.From3D(0, 0, 0, -1, 2, 3);
+
+        twoD.Should().Throw<ArgumentException>();
+        threeD.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidValueCount()
+    {
+        Action act = () => BoundingBox.Create(new[] { 1.0, 2.0, 3.0 });
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPoint3DTests
+{
+    [Fact]
+    public void GeoPoint3D_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint3D);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint3D_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint3D(1, 2, 3);
+
+        point.X.Should().Be(1);
+        point.Y.Should().Be(2);
+        point.Z.Should().Be(3);
+        point.ToString().Should().Be("(1, 2, 3)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0, 0)]
+    [InlineData(0, double.NaN, 0)]
+    [InlineData(0, 0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0, 0)]
+    [InlineData(0, double.NegativeInfinity, 0)]
+    [InlineData(0, 0, double.PositiveInfinity)]
+    public void GeoPoint3D_ShouldRejectNonFiniteValues(double x, double y, double z)
+    {
+        Action act = () => new GeoPoint3D(x, y, z);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPointTests
+{
+    [Fact]
+    public void GeoPoint_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint(12.5, -23.4);
+
+        point.Longitude.Should().Be(12.5);
+        point.Latitude.Should().Be(-23.4);
+        point.ToString().Should().Be("(12.5, -23.4)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0)]
+    [InlineData(0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0)]
+    [InlineData(0, double.NegativeInfinity)]
+    public void GeoPoint_ShouldRejectNonFiniteValues(double longitude, double latitude)
+    {
+        Action act = () => new GeoPoint(longitude, latitude);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Indexing;
+
+public class MortonIndexEncoderTests
+{
+    [Fact]
+    public void Encode2D_ShouldProduceExpectedOrderingForBinaryGrid()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 1);
+
+        encoder.Encode(new[] { 0d, 0d }).Should().Be(0);
+        encoder.Encode(new[] { 1d, 0d }).Should().Be(1);
+        encoder.Encode(new[] { 0d, 1d }).Should().Be(2);
+        encoder.Encode(new[] { 1d, 1d }).Should().Be(3);
+    }
+
+    [Fact]
+    public void Encode3D_ShouldInterleaveBitsAcrossAllAxes()
+    {
+        var encoder = new MortonIndexEncoder(3, precisionBits: 1);
+
+        encoder.Encode(new[] { 0d, 0d, 0d }).Should().Be(0);
+        encoder.Encode(new[] { 1d, 0d, 0d }).Should().Be(1);
+        encoder.Encode(new[] { 0d, 1d, 0d }).Should().Be(2);
+        encoder.Encode(new[] { 0d, 0d, 1d }).Should().Be(4);
+        encoder.Encode(new[] { 1d, 1d, 1d }).Should().Be(7);
+    }
+
+    [Fact]
+    public void Encode_ShouldRejectNaNCoordinates()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 4);
+
+        Action act = () => encoder.Encode(new[] { double.NaN, 0.5 });
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Encode_ShouldClampValuesOutsideNormalizedRange()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 4);
+
+        var min = encoder.Encode(new[] { -10d, -5d });
+        var max = encoder.Encode(new[] { 10d, 20d });
+
+        min.Should().Be(0);
+        max.Should().Be((1UL << 8) - 1UL);
+    }
+
+    [Fact]
+    public void Cover_ShouldRespectMaxCells()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 5);
+        var bounds = BoundingBox.From2D(0d, 0d, 0.5, 0.5);
+
+        var ranges = encoder.Cover(bounds, maxCells: 4);
+
+        ranges.Should().NotBeEmpty();
+        ranges.Count.Should().BeLessOrEqualTo(4);
+        ranges.Should().BeInAscendingOrder(range => range.Start);
+    }
+
+    [Fact]
+    public void CoalesceRanges_ShouldMergeOverlappingSegments()
+    {
+        var input = new[]
+        {
+            new SpatialIndexRange(0, 10),
+            new SpatialIndexRange(11, 20),
+            new SpatialIndexRange(30, 40)
+        };
+
+        var merged = MortonIndexEncoder.CoalesceRanges(input);
+
+        merged.Should().HaveCount(2);
+        merged[0].Should().Be(new SpatialIndexRange(0, 20));
+        merged[1].Should().Be(new SpatialIndexRange(30, 40));
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial.Core.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj" Aliases="litedbmain" />
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
@@ -1,0 +1,88 @@
+extern alias litedbmain;
+
+using System;
+using System.IO;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+using LiteDatabase = litedbmain::LiteDB.LiteDatabase;
+using LiteDbBsonDocument = litedbmain::LiteDB.BsonDocument;
+
+namespace LiteDB.Spatial.Core.Tests.Metadata;
+
+public class SpatialMetadataStoreTests
+{
+    [Fact]
+    public void SaveAndRetrieve_ShouldRoundTripMetadata()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var store = new SpatialMetadataStore(database);
+        var options = new SpatialIndexOptions(precisionBits: 12, maxCoveringCells: 8, distanceTolerance: 0.5, indexFieldName: "idx", boundingBoxFieldName: "box");
+        var metadata = new SpatialCollectionMetadata("places", "geographic", 2, options);
+
+        store.Save(metadata);
+
+        var loaded = store.GetOrThrow("places", "UseGeographic(…)");
+
+        loaded.Should().NotBeNull();
+        loaded.EngineName.Should().Be("geographic");
+        loaded.Dimensions.Should().Be(2);
+        loaded.Options.IndexFieldName.Should().Be("idx");
+        loaded.Options.BoundingBoxFieldName.Should().Be("box");
+    }
+
+    [Fact]
+    public void TryGet_ShouldReturnFalseWhenDescriptorMissing()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var store = new SpatialMetadataStore(database);
+
+        store.TryGet("places", out var metadata).Should().BeFalse();
+        metadata.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetOrThrow_ShouldRaiseHelpfulMessageWhenMissing()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var store = new SpatialMetadataStore(database);
+
+        Action act = () => store.GetOrThrow("places", "Spatial.UseGeographic(collection, …)");
+
+        act.Should().Throw<SpatialMetadataException>()
+            .Which.Message.Should().Contain("UseGeographic");
+    }
+
+    [Fact]
+    public void InvalidBoundingBoxLength_ShouldTriggerGuard()
+    {
+        using var database = new LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("_spatial_meta");
+
+        var document = new LiteDbBsonDocument
+        {
+            ["_id"] = "places",
+            ["collection"] = "places",
+            ["engine"] = "cartesian3d",
+            ["dimensions"] = 3,
+            ["bboxElements"] = 4,
+            ["options"] = new LiteDbBsonDocument
+            {
+                ["precisionBits"] = 12,
+                ["maxCoveringCells"] = 8,
+                ["distanceTolerance"] = 0.1,
+                ["indexField"] = "_idx",
+                ["boundingBoxField"] = "_mbb"
+            }
+        };
+
+        collection.Insert(document);
+
+        var store = new SpatialMetadataStore(database);
+
+        Action act = () => store.TryGet("places", out _);
+
+        act.Should().Throw<SpatialMetadataException>()
+            .Which.Message.Should().Contain("bounding box");
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
@@ -1,0 +1,186 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides utilities for enriching existing documents with spatial index metadata.
+/// </summary>
+public static class SpatialBackfill
+{
+    /// <summary>
+    /// Populates the configured spatial fields for documents in the provided collection.
+    /// </summary>
+    /// <param name="collection">The collection containing documents to enrich.</param>
+    /// <param name="descriptor">The descriptor describing how to extract spatial values.</param>
+    /// <param name="batchSize">The maximum number of documents processed per batch.</param>
+    /// <returns>A summary of the operation.</returns>
+    public static SpatialBackfillResult Run(ILiteCollection<BsonDocument> collection, SpatialCollectionDescriptor descriptor, int batchSize = 256)
+    {
+        if (collection is null)
+        {
+            throw new ArgumentNullException(nameof(collection));
+        }
+
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (batchSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(batchSize), "Batch size must be a positive number.");
+        }
+
+        var errors = new List<SpatialBackfillError>();
+        var processed = 0;
+        var updated = 0;
+        var skipped = 0;
+
+        var skip = 0;
+        var query = Query.All();
+
+        while (true)
+        {
+            var batch = collection.Find(query, skip, batchSize).ToList();
+
+            if (batch.Count == 0)
+            {
+                break;
+            }
+
+            foreach (var document in batch)
+            {
+                processed++;
+                ProcessDocument(collection, descriptor, document, errors, ref updated, ref skipped);
+            }
+
+            skip += batch.Count;
+        }
+
+        return new SpatialBackfillResult(processed, updated, skipped, errors);
+    }
+
+    private static void ProcessDocument(
+        ILiteCollection<BsonDocument> collection,
+        SpatialCollectionDescriptor descriptor,
+        BsonDocument document,
+        List<SpatialBackfillError> errors,
+        ref int updated,
+        ref int skipped)
+    {
+        var options = descriptor.Metadata.Options;
+        var documentId = document["_id"];
+
+        try
+        {
+            if (documentId.IsNull)
+            {
+                throw new SpatialBackfillException("Document does not contain an _id field.");
+            }
+
+            var hasIndex = HasValidIndex(document, options.IndexFieldName);
+            var hasBoundingBox = HasValidBoundingBox(document, options.BoundingBoxFieldName, descriptor.BoundingBoxElementCount);
+
+            if (hasIndex && hasBoundingBox)
+            {
+                skipped++;
+                return;
+            }
+
+            BoundingBox boundingBox;
+            ulong indexValue;
+
+            if (descriptor.Metadata.Dimensions == 2)
+            {
+                var point = descriptor.PointAccessor?.Invoke(document);
+
+                if (point is null)
+                {
+                    throw new SpatialBackfillException($"Document missing 2D geometry for engine \"{descriptor.Metadata.EngineName}\".");
+                }
+
+                boundingBox = descriptor.Mapper.GetBoundingBox(point.Value);
+                indexValue = descriptor.Mapper.Encode(point.Value);
+            }
+            else
+            {
+                var point = descriptor.Point3DAccessor?.Invoke(document);
+
+                if (point is null)
+                {
+                    throw new SpatialBackfillException($"Document missing 3D geometry for engine \"{descriptor.Metadata.EngineName}\".");
+                }
+
+                boundingBox = descriptor.Mapper.GetBoundingBox(point.Value);
+                indexValue = descriptor.Mapper.Encode(point.Value);
+            }
+
+            document[options.IndexFieldName] = new BsonValue((decimal)indexValue);
+            document[options.BoundingBoxFieldName] = ToBsonArray(boundingBox);
+
+            if (!collection.Update(documentId, document))
+            {
+                throw new SpatialBackfillException("Failed to persist spatial metadata for the document.");
+            }
+
+            updated++;
+        }
+        catch (Exception ex)
+        {
+            errors.Add(new SpatialBackfillError(documentId, ex.Message, ex));
+        }
+    }
+
+    private static bool HasValidIndex(BsonDocument document, string fieldName)
+    {
+        if (!document.TryGetValue(fieldName, out var value))
+        {
+            return false;
+        }
+
+        return value.IsNumber;
+    }
+
+    private static bool HasValidBoundingBox(BsonDocument document, string fieldName, int expectedElements)
+    {
+        if (!document.TryGetValue(fieldName, out var value) || !value.IsArray)
+        {
+            return false;
+        }
+
+        var array = value.AsArray;
+
+        if (array.Count != expectedElements)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < array.Count; i++)
+        {
+            if (!array[i].IsNumber)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static BsonArray ToBsonArray(BoundingBox boundingBox)
+    {
+        var result = new BsonArray();
+        var values = boundingBox.ToArray();
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            result.Add(new BsonValue(values[i]));
+        }
+
+        return result;
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfillError.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfillError.cs
@@ -1,0 +1,37 @@
+#nullable enable
+
+using System;
+using LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a failure encountered while attempting to enrich a document with spatial index fields.
+/// </summary>
+public sealed class SpatialBackfillError
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialBackfillError"/> class.
+    /// </summary>
+    public SpatialBackfillError(BsonValue documentId, string message, Exception exception)
+    {
+        DocumentId = documentId ?? throw new ArgumentNullException(nameof(documentId));
+        Message = message ?? throw new ArgumentNullException(nameof(message));
+        Exception = exception;
+    }
+
+    /// <summary>
+    /// Gets the identifier of the document that failed to backfill.
+    /// </summary>
+    public BsonValue DocumentId { get; }
+
+    /// <summary>
+    /// Gets a human friendly error message describing the failure.
+    /// </summary>
+    public string Message { get; }
+
+    /// <summary>
+    /// Gets the exception raised during processing. May be <c>null</c> when the error is synthesized.
+    /// </summary>
+    public Exception? Exception { get; }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfillException.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfillException.cs
@@ -1,0 +1,27 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a recoverable error encountered while backfilling spatial metadata.
+/// </summary>
+public sealed class SpatialBackfillException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialBackfillException"/> class.
+    /// </summary>
+    public SpatialBackfillException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialBackfillException"/> class with an inner exception.
+    /// </summary>
+    public SpatialBackfillException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
@@ -1,0 +1,42 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Summarizes the outcome of a spatial backfill operation.
+/// </summary>
+public sealed class SpatialBackfillResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialBackfillResult"/> class.
+    /// </summary>
+    public SpatialBackfillResult(int processed, int updated, int skipped, IReadOnlyList<SpatialBackfillError> errors)
+    {
+        Processed = processed;
+        Updated = updated;
+        Skipped = skipped;
+        Errors = errors;
+    }
+
+    /// <summary>
+    /// Gets the total number of documents inspected during the backfill.
+    /// </summary>
+    public int Processed { get; }
+
+    /// <summary>
+    /// Gets the number of documents that were updated with new spatial fields.
+    /// </summary>
+    public int Updated { get; }
+
+    /// <summary>
+    /// Gets the number of documents that already contained up-to-date spatial metadata.
+    /// </summary>
+    public int Skipped { get; }
+
+    /// <summary>
+    /// Gets the collection of errors raised while processing documents.
+    /// </summary>
+    public IReadOnlyList<SpatialBackfillError> Errors { get; }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialCollectionDescriptor.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialCollectionDescriptor.cs
@@ -1,0 +1,62 @@
+#nullable enable
+
+using System;
+using LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents the runtime configuration required to populate spatial index fields for a collection.
+/// </summary>
+public sealed class SpatialCollectionDescriptor
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialCollectionDescriptor"/> class.
+    /// </summary>
+    public SpatialCollectionDescriptor(
+        SpatialCollectionMetadata metadata,
+        ISpatialMapper mapper,
+        Func<BsonDocument, GeoPoint?>? pointAccessor,
+        Func<BsonDocument, GeoPoint3D?>? point3DAccessor)
+    {
+        Metadata = metadata ?? throw new ArgumentNullException(nameof(metadata));
+        Mapper = mapper ?? throw new ArgumentNullException(nameof(mapper));
+        PointAccessor = pointAccessor;
+        Point3DAccessor = point3DAccessor;
+
+        if (metadata.Dimensions == 2 && pointAccessor is null)
+        {
+            throw new ArgumentException("A two-dimensional collection descriptor requires a GeoPoint accessor.", nameof(pointAccessor));
+        }
+
+        if (metadata.Dimensions == 3 && point3DAccessor is null)
+        {
+            throw new ArgumentException("A three-dimensional collection descriptor requires a GeoPoint3D accessor.", nameof(point3DAccessor));
+        }
+    }
+
+    /// <summary>
+    /// Gets the persisted metadata for the collection.
+    /// </summary>
+    public SpatialCollectionMetadata Metadata { get; }
+
+    /// <summary>
+    /// Gets the mapper responsible for computing index encodings and bounding boxes.
+    /// </summary>
+    public ISpatialMapper Mapper { get; }
+
+    /// <summary>
+    /// Gets the delegate used to retrieve a two-dimensional point from a document when <see cref="SpatialCollectionMetadata.Dimensions"/> equals two.
+    /// </summary>
+    public Func<BsonDocument, GeoPoint?>? PointAccessor { get; }
+
+    /// <summary>
+    /// Gets the delegate used to retrieve a three-dimensional point from a document when <see cref="SpatialCollectionMetadata.Dimensions"/> equals three.
+    /// </summary>
+    public Func<BsonDocument, GeoPoint3D?>? Point3DAccessor { get; }
+
+    /// <summary>
+    /// Gets the number of values expected within the bounding box field.
+    /// </summary>
+    public int BoundingBoxElementCount => Metadata.BoundingBoxElementCount;
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
@@ -1,0 +1,17 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes distances between spatial points for exact filtering.
+/// </summary>
+public interface ISpatialDistance
+{
+    /// <summary>
+    /// Computes the distance between two geographic points expressed in meters.
+    /// </summary>
+    double Distance(GeoPoint left, GeoPoint right);
+
+    /// <summary>
+    /// Computes the distance between two Cartesian points expressed in user-defined units.
+    /// </summary>
+    double Distance(GeoPoint3D left, GeoPoint3D right);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
@@ -1,0 +1,52 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a spatial engine capable of producing index-aware query plans and mapping values.
+/// </summary>
+public interface ISpatialEngine
+{
+    /// <summary>
+    /// Gets the human-readable engine name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the engine.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the options associated with the engine.
+    /// </summary>
+    SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Gets the encoder used to map coordinates into index keys.
+    /// </summary>
+    ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <summary>
+    /// Gets the component responsible for mapping values to index fields.
+    /// </summary>
+    ISpatialMapper Mapper { get; }
+
+    /// <summary>
+    /// Gets the distance calculator used for exact filtering.
+    /// </summary>
+    ISpatialDistance Distance { get; }
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(GeoPoint center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided bounding box.
+    /// </summary>
+    ISpatialQueryPlan PlanWithin(BoundingBox bounds);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
@@ -1,0 +1,27 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Projects application-level spatial values into indexable representations.
+/// </summary>
+public interface ISpatialMapper
+{
+    /// <summary>
+    /// Computes the bounding box for the provided two-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(GeoPoint point);
+
+    /// <summary>
+    /// Computes the bounding box for the provided three-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(GeoPoint3D point);
+
+    /// <summary>
+    /// Encodes a two-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(GeoPoint point);
+
+    /// <summary>
+    /// Encodes a three-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(GeoPoint3D point);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes the pieces required to execute a spatial query using index ranges and precise filters.
+/// </summary>
+public interface ISpatialQueryPlan
+{
+    /// <summary>
+    /// Gets the dimensionality of the underlying spatial index.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the coarse bounding region evaluated before exact predicates. May be <c>null</c> when not applicable.
+    /// </summary>
+    BoundingBox? CoveringBounds { get; }
+
+    /// <summary>
+    /// Gets the ordered set of index ranges that should be scanned.
+    /// </summary>
+    IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <summary>
+    /// Gets a human readable description of the exact predicate applied after index filtering.
+    /// </summary>
+    string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
@@ -1,0 +1,152 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents configuration options that govern how spatial indexes are generated and queried.
+/// </summary>
+public sealed class SpatialIndexOptions : IEquatable<SpatialIndexOptions>
+{
+    /// <summary>
+    /// The default name for the numeric index field stored on documents.
+    /// </summary>
+    public const string DefaultIndexFieldName = "_idx";
+
+    /// <summary>
+    /// The default name for the bounding box field stored on documents.
+    /// </summary>
+    public const string DefaultBoundingBoxFieldName = "_mbb";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexOptions"/> class.
+    /// </summary>
+    /// <param name="precisionBits">Number of bits used by the index encoder to represent each axis.</param>
+    /// <param name="maxCoveringCells">The maximum number of index ranges allowed when covering a shape.</param>
+    /// <param name="distanceTolerance">Additional expansion applied to distance queries to accommodate floating-point error.</param>
+    /// <param name="indexFieldName">The field used to store the encoded index value on documents.</param>
+    /// <param name="boundingBoxFieldName">The field used to store the bounding box on documents.</param>
+    public SpatialIndexOptions(
+        int precisionBits = 32,
+        int maxCoveringCells = 64,
+        double distanceTolerance = 0.001,
+        string indexFieldName = DefaultIndexFieldName,
+        string boundingBoxFieldName = DefaultBoundingBoxFieldName)
+    {
+        if (precisionBits <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be a positive number of bits.");
+        }
+
+        if (maxCoveringCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCoveringCells), "The maximum number of covering cells must be positive.");
+        }
+
+        if (distanceTolerance < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(distanceTolerance), "Distance tolerance cannot be negative.");
+        }
+
+        if (string.IsNullOrWhiteSpace(indexFieldName))
+        {
+            throw new ArgumentException("Index field name cannot be null or whitespace.", nameof(indexFieldName));
+        }
+
+        if (string.IsNullOrWhiteSpace(boundingBoxFieldName))
+        {
+            throw new ArgumentException("Bounding box field name cannot be null or whitespace.", nameof(boundingBoxFieldName));
+        }
+
+        PrecisionBits = precisionBits;
+        MaxCoveringCells = maxCoveringCells;
+        DistanceTolerance = distanceTolerance;
+        IndexFieldName = indexFieldName;
+        BoundingBoxFieldName = boundingBoxFieldName;
+    }
+
+    /// <summary>
+    /// Gets the number of bits allocated to represent each coordinate axis.
+    /// </summary>
+    public int PrecisionBits { get; }
+
+    /// <summary>
+    /// Gets the maximum number of index cells that planners may request when approximating shapes.
+    /// </summary>
+    public int MaxCoveringCells { get; }
+
+    /// <summary>
+    /// Gets the amount of tolerance applied to distance-based operations.
+    /// </summary>
+    public double DistanceTolerance { get; }
+
+    /// <summary>
+    /// Gets the document field used to store encoded index values.
+    /// </summary>
+    public string IndexFieldName { get; }
+
+    /// <summary>
+    /// Gets the document field used to store bounding boxes.
+    /// </summary>
+    public string BoundingBoxFieldName { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="SpatialIndexOptions"/> instance using the existing values as defaults.
+    /// </summary>
+    public SpatialIndexOptions With(
+        int? precisionBits = null,
+        int? maxCoveringCells = null,
+        double? distanceTolerance = null,
+        string? indexFieldName = null,
+        string? boundingBoxFieldName = null)
+    {
+        return new SpatialIndexOptions(
+            precisionBits ?? PrecisionBits,
+            maxCoveringCells ?? MaxCoveringCells,
+            distanceTolerance ?? DistanceTolerance,
+            indexFieldName ?? IndexFieldName,
+            boundingBoxFieldName ?? BoundingBoxFieldName);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexOptions? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return PrecisionBits == other.PrecisionBits
+            && MaxCoveringCells == other.MaxCoveringCells
+            && DistanceTolerance.Equals(other.DistanceTolerance)
+            && string.Equals(IndexFieldName, other.IndexFieldName, StringComparison.Ordinal)
+            && string.Equals(BoundingBoxFieldName, other.BoundingBoxFieldName, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexOptions options && Equals(options);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = PrecisionBits;
+            hash = (hash * 397) ^ MaxCoveringCells;
+            hash = (hash * 397) ^ DistanceTolerance.GetHashCode();
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(IndexFieldName);
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(BoundingBoxFieldName);
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Precision={PrecisionBits}, Cells={MaxCoveringCells}, Tolerance={DistanceTolerance}, IndexField=\"{IndexFieldName}\", BoundingField=\"{BoundingBoxFieldName}\"";
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
+++ b/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
@@ -1,0 +1,234 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents an axis-aligned bounding box in two or three dimensions.
+/// </summary>
+public readonly struct BoundingBox : IEquatable<BoundingBox>
+{
+    private readonly double[] _values;
+
+    private BoundingBox(double[] values)
+    {
+        _values = values;
+    }
+
+    /// <summary>
+    /// Creates a bounding box from raw coordinate values.
+    /// </summary>
+    /// <param name="values">
+    /// The coordinates describing the box. Two-dimensional boxes require four values
+    /// (<c>minX</c>, <c>minY</c>, <c>maxX</c>, <c>maxY</c>). Three-dimensional boxes require
+    /// six values (<c>minX</c>, <c>minY</c>, <c>minZ</c>, <c>maxX</c>, <c>maxY</c>, <c>maxZ</c>).
+    /// </param>
+    /// <returns>A new <see cref="BoundingBox"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when the number of values is invalid or any value is non-finite.</exception>
+    public static BoundingBox Create(ReadOnlySpan<double> values)
+    {
+        if (values.Length != 4 && values.Length != 6)
+        {
+            throw new ArgumentException("Bounding boxes must be described by four (2D) or six (3D) values.", nameof(values));
+        }
+
+        var copy = new double[values.Length];
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var value = values[i];
+
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                throw new ArgumentException("Bounding box coordinates must be finite numbers.", nameof(values));
+            }
+
+            copy[i] = value;
+        }
+
+        ValidateExtents(copy);
+
+        return new BoundingBox(copy);
+    }
+
+    /// <summary>
+    /// Creates a two-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From2D(double minX, double minY, double maxX, double maxY)
+    {
+        return Create(new[] { minX, minY, maxX, maxY });
+    }
+
+    /// <summary>
+    /// Creates a three-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From3D(double minX, double minY, double minZ, double maxX, double maxY, double maxZ)
+    {
+        return Create(new[] { minX, minY, minZ, maxX, maxY, maxZ });
+    }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions represented by the box.
+    /// </summary>
+    public int Dimensions => _values.Length / 2;
+
+    /// <summary>
+    /// Gets a value indicating whether the bounding box captures three dimensions.
+    /// </summary>
+    public bool Is3D => Dimensions == 3;
+
+    /// <summary>
+    /// Gets the minimum X value.
+    /// </summary>
+    public double MinX => _values[0];
+
+    /// <summary>
+    /// Gets the minimum Y value.
+    /// </summary>
+    public double MinY => _values[1];
+
+    /// <summary>
+    /// Gets the minimum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MinZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[2];
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum X value.
+    /// </summary>
+    public double MaxX => _values[Dimensions == 2 ? 2 : 3];
+
+    /// <summary>
+    /// Gets the maximum Y value.
+    /// </summary>
+    public double MaxY => _values[Dimensions == 2 ? 3 : 4];
+
+    /// <summary>
+    /// Gets the maximum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MaxZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[5];
+        }
+    }
+
+    /// <summary>
+    /// Returns the raw coordinate values that describe the box.
+    /// </summary>
+    public ReadOnlySpan<double> GetValues()
+    {
+        return _values;
+    }
+
+    /// <summary>
+    /// Copies the coordinate values into a new array.
+    /// </summary>
+    public double[] ToArray()
+    {
+        var copy = new double[_values.Length];
+        Array.Copy(_values, copy, _values.Length);
+        return copy;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(BoundingBox other)
+    {
+        if (Dimensions != other.Dimensions)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _values.Length; i++)
+        {
+            if (!_values[i].Equals(other._values[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is BoundingBox box && Equals(box);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Dimensions;
+
+            for (var i = 0; i < _values.Length; i++)
+            {
+                hash = (hash * 397) ^ _values[i].GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{string.Join(", ", _values.Select(value => value.ToString(CultureInfo.InvariantCulture)))}]";
+    }
+
+    public static bool operator ==(BoundingBox left, BoundingBox right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(BoundingBox left, BoundingBox right)
+    {
+        return !left.Equals(right);
+    }
+
+    private static void ValidateExtents(IReadOnlyList<double> values)
+    {
+        if (values.Count == 4)
+        {
+            ValidateAxis(values[0], values[2], "X");
+            ValidateAxis(values[1], values[3], "Y");
+            return;
+        }
+
+        ValidateAxis(values[0], values[3], "X");
+        ValidateAxis(values[1], values[4], "Y");
+        ValidateAxis(values[2], values[5], "Z");
+    }
+
+    private static void ValidateAxis(double min, double max, string axis)
+    {
+        if (max < min)
+        {
+            throw new ArgumentException($"The maximum {axis} value must be greater than or equal to the minimum value.");
+        }
+    }
+
+    private void EnsureThreeDimensions()
+    {
+        if (!Is3D)
+        {
+            throw new InvalidOperationException("The bounding box does not define a Z axis.");
+        }
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a geographic coordinate using longitude and latitude expressed in decimal degrees.
+/// </summary>
+public readonly struct GeoPoint : IEquatable<GeoPoint>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint"/> struct.
+    /// </summary>
+    /// <param name="longitude">The longitude component in decimal degrees.</param>
+    /// <param name="latitude">The latitude component in decimal degrees.</param>
+    /// <exception cref="ArgumentException">Thrown when either coordinate is not a finite number.</exception>
+    public GeoPoint(double longitude, double latitude)
+    {
+        if (double.IsNaN(longitude) || double.IsInfinity(longitude))
+        {
+            throw new ArgumentException("Longitude must be a finite number.", nameof(longitude));
+        }
+
+        if (double.IsNaN(latitude) || double.IsInfinity(latitude))
+        {
+            throw new ArgumentException("Latitude must be a finite number.", nameof(latitude));
+        }
+
+        Longitude = longitude;
+        Latitude = latitude;
+    }
+
+    /// <summary>
+    /// Gets the longitude component in decimal degrees where positive values indicate east.
+    /// </summary>
+    public double Longitude { get; }
+
+    /// <summary>
+    /// Gets the latitude component in decimal degrees where positive values indicate north.
+    /// </summary>
+    public double Latitude { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint other)
+    {
+        return Longitude.Equals(other.Longitude) && Latitude.Equals(other.Latitude);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Longitude.GetHashCode();
+            hash = (hash * 397) ^ Latitude.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1})", Longitude, Latitude);
+    }
+
+    public static bool operator ==(GeoPoint left, GeoPoint right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint left, GeoPoint right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
@@ -1,0 +1,96 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a three-dimensional Cartesian coordinate.
+/// </summary>
+public readonly struct GeoPoint3D : IEquatable<GeoPoint3D>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint3D"/> struct.
+    /// </summary>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
+    /// <param name="z">The Z component.</param>
+    /// <exception cref="ArgumentException">Thrown when any component is not a finite number.</exception>
+    public GeoPoint3D(double x, double y, double z)
+    {
+        if (double.IsNaN(x) || double.IsInfinity(x))
+        {
+            throw new ArgumentException("X must be a finite number.", nameof(x));
+        }
+
+        if (double.IsNaN(y) || double.IsInfinity(y))
+        {
+            throw new ArgumentException("Y must be a finite number.", nameof(y));
+        }
+
+        if (double.IsNaN(z) || double.IsInfinity(z))
+        {
+            throw new ArgumentException("Z must be a finite number.", nameof(z));
+        }
+
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    /// <summary>
+    /// Gets the X component of the coordinate.
+    /// </summary>
+    public double X { get; }
+
+    /// <summary>
+    /// Gets the Y component of the coordinate.
+    /// </summary>
+    public double Y { get; }
+
+    /// <summary>
+    /// Gets the Z component of the coordinate.
+    /// </summary>
+    public double Z { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint3D other)
+    {
+        return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint3D point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = X.GetHashCode();
+            hash = (hash * 397) ^ Y.GetHashCode();
+            hash = (hash * 397) ^ Z.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1}, {2})", X, Y, Z);
+    }
+
+    public static bool operator ==(GeoPoint3D left, GeoPoint3D right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint3D left, GeoPoint3D right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides the ability to encode coordinates into spatial index values and derive coarse coverings.
+/// </summary>
+public interface ISpatialIndexEncoder
+{
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the encoder.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the number of precision bits allocated per axis.
+    /// </summary>
+    int PrecisionBits { get; }
+
+    /// <summary>
+    /// Encodes the provided coordinate tuple into a sortable spatial index value.
+    /// </summary>
+    /// <param name="coordinates">The coordinate tuple. The span length must match <see cref="Dimensions"/>.</param>
+    /// <returns>The encoded index value.</returns>
+    ulong Encode(ReadOnlySpan<double> coordinates);
+
+    /// <summary>
+    /// Produces a set of index ranges that cover the provided bounding box.
+    /// </summary>
+    /// <param name="bounds">The bounding box to cover.</param>
+    /// <param name="maxCells">The maximum number of ranges the caller is willing to accept.</param>
+    /// <returns>A collection of closed index ranges ordered from lowest to highest.</returns>
+    IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells);
+}

--- a/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
@@ -1,0 +1,314 @@
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides Morton (Z-order) encoding for two or three dimensional coordinates.
+/// </summary>
+public sealed class MortonIndexEncoder : ISpatialIndexEncoder
+{
+    private readonly ulong _maxCoordinateValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MortonIndexEncoder"/> class.
+    /// </summary>
+    /// <param name="dimensions">The spatial dimensionality supported by the encoder. Only 2D and 3D encoders are currently supported.</param>
+    /// <param name="precisionBits">The number of bits assigned to each coordinate axis.</param>
+    public MortonIndexEncoder(int dimensions, int precisionBits)
+    {
+        if (dimensions != 2 && dimensions != 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Morton encoding currently supports only two or three dimensions.");
+        }
+
+        if (precisionBits <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be a positive number of bits.");
+        }
+
+        if ((long)dimensions * precisionBits > 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "The product of dimensions and precision cannot exceed 64 bits when encoding into a UInt64.");
+        }
+
+        Dimensions = dimensions;
+        PrecisionBits = precisionBits;
+        _maxCoordinateValue = (1UL << precisionBits) - 1UL;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public int PrecisionBits { get; }
+
+    /// <inheritdoc />
+    public ulong Encode(ReadOnlySpan<double> coordinates)
+    {
+        if (coordinates.Length != Dimensions)
+        {
+            throw new ArgumentException("Coordinate count must match the encoder dimensionality.", nameof(coordinates));
+        }
+
+        Span<ulong> quantized = stackalloc ulong[Dimensions];
+
+        for (var i = 0; i < Dimensions; i++)
+        {
+            quantized[i] = Quantize(coordinates[i]);
+        }
+
+        return Interleave(quantized);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells)
+    {
+        if (bounds.Dimensions != Dimensions)
+        {
+            throw new ArgumentException("Bounding box dimensionality must match the encoder dimensionality.", nameof(bounds));
+        }
+
+        if (maxCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCells), "Maximum covering cells must be positive.");
+        }
+
+        Span<ulong> minIndices = stackalloc ulong[Dimensions];
+        Span<ulong> maxIndices = stackalloc ulong[Dimensions];
+
+        PopulateAxisIndices(bounds, minIndices, maxIndices);
+
+        var ranges = ComputeCoveringRanges(minIndices, maxIndices, maxCells);
+
+        return ranges.Count switch
+        {
+            0 => Array.Empty<SpatialIndexRange>(),
+            1 => ranges,
+            _ => CoalesceRanges(ranges)
+        };
+    }
+
+    /// <summary>
+    /// Combines overlapping or adjacent index ranges into the minimal equivalent covering.
+    /// </summary>
+    /// <param name="ranges">The ranges to coalesce.</param>
+    /// <returns>A new list containing the merged ranges ordered by start value.</returns>
+    public static IReadOnlyList<SpatialIndexRange> CoalesceRanges(IEnumerable<SpatialIndexRange> ranges)
+    {
+        if (ranges is null)
+        {
+            throw new ArgumentNullException(nameof(ranges));
+        }
+
+        var ordered = ranges.ToList();
+
+        if (ordered.Count == 0)
+        {
+            return Array.Empty<SpatialIndexRange>();
+        }
+
+        ordered.Sort((a, b) => a.Start.CompareTo(b.Start));
+
+        var result = new List<SpatialIndexRange>(ordered.Count);
+        var current = ordered[0];
+
+        for (var i = 1; i < ordered.Count; i++)
+        {
+            var candidate = ordered[i];
+
+            if (candidate.Start <= current.End + 1)
+            {
+                var mergedEnd = candidate.End > current.End ? candidate.End : current.End;
+                current = new SpatialIndexRange(current.Start, mergedEnd);
+            }
+            else
+            {
+                result.Add(current);
+                current = candidate;
+            }
+        }
+
+        result.Add(current);
+        return result;
+    }
+
+    private ulong Quantize(double coordinate)
+    {
+        if (double.IsNaN(coordinate) || double.IsInfinity(coordinate))
+        {
+            throw new ArgumentException("Coordinates must be finite numbers.", nameof(coordinate));
+        }
+
+        var clamped = coordinate;
+
+        if (clamped < 0d)
+        {
+            clamped = 0d;
+        }
+        else if (clamped > 1d)
+        {
+            clamped = 1d;
+        }
+
+        var scaled = Math.Round(clamped * _maxCoordinateValue, MidpointRounding.AwayFromZero);
+        var quantized = (ulong)scaled;
+
+        if (quantized > _maxCoordinateValue)
+        {
+            quantized = _maxCoordinateValue;
+        }
+
+        return quantized;
+    }
+
+    private void PopulateAxisIndices(BoundingBox bounds, Span<ulong> minIndices, Span<ulong> maxIndices)
+    {
+        minIndices[0] = Quantize(bounds.MinX);
+        maxIndices[0] = Quantize(bounds.MaxX);
+        minIndices[1] = Quantize(bounds.MinY);
+        maxIndices[1] = Quantize(bounds.MaxY);
+
+        if (Dimensions == 3)
+        {
+            minIndices[2] = Quantize(bounds.MinZ);
+            maxIndices[2] = Quantize(bounds.MaxZ);
+        }
+    }
+
+    private List<SpatialIndexRange> ComputeCoveringRanges(ReadOnlySpan<ulong> minIndices, ReadOnlySpan<ulong> maxIndices, int maxCells)
+    {
+        var ranges = new List<SpatialIndexRange>();
+
+        var shift = DetermineCoverShift(minIndices, maxIndices, maxCells);
+        var cellSize = 1UL << shift;
+
+        Span<ulong> axisStart = stackalloc ulong[Dimensions];
+        Span<ulong> axisEnd = stackalloc ulong[Dimensions];
+        Span<ulong> cellIndices = stackalloc ulong[Dimensions];
+        Span<ulong> baseIndices = stackalloc ulong[Dimensions];
+
+        for (var dimension = 0; dimension < Dimensions; dimension++)
+        {
+            axisStart[dimension] = minIndices[dimension] >> shift;
+            axisEnd[dimension] = maxIndices[dimension] >> shift;
+            cellIndices[dimension] = axisStart[dimension];
+        }
+
+        while (true)
+        {
+            for (var dimension = 0; dimension < Dimensions; dimension++)
+            {
+                baseIndices[dimension] = cellIndices[dimension] << shift;
+            }
+
+            var start = Interleave(baseIndices);
+            var trailingBits = Dimensions * shift;
+            ulong mask;
+
+            if (trailingBits >= 64)
+            {
+                mask = ulong.MaxValue;
+            }
+            else if (shift == 0)
+            {
+                mask = 0UL;
+            }
+            else
+            {
+                mask = (1UL << trailingBits) - 1UL;
+            }
+
+            var end = start | mask;
+            ranges.Add(new SpatialIndexRange(start, end));
+
+            var advanced = false;
+
+            for (var dimension = 0; dimension < Dimensions; dimension++)
+            {
+                if (cellIndices[dimension] < axisEnd[dimension])
+                {
+                    cellIndices[dimension]++;
+
+                    for (var reset = 0; reset < dimension; reset++)
+                    {
+                        cellIndices[reset] = axisStart[reset];
+                    }
+
+                    advanced = true;
+                    break;
+                }
+            }
+
+            if (!advanced)
+            {
+                break;
+            }
+        }
+
+        return ranges;
+    }
+
+    private int DetermineCoverShift(ReadOnlySpan<ulong> minIndices, ReadOnlySpan<ulong> maxIndices, int maxCells)
+    {
+        var maxAllowedCells = Math.Max(1, maxCells);
+
+        for (var shift = 0; shift <= PrecisionBits; shift++)
+        {
+            var cellSize = 1UL << shift;
+            long totalCells = 1;
+            var withinLimit = true;
+
+            for (var dimension = 0; dimension < Dimensions; dimension++)
+            {
+                var span = maxIndices[dimension] - minIndices[dimension] + 1UL;
+                var axisCells = (span + cellSize - 1UL) / cellSize;
+
+                try
+                {
+                    totalCells = checked(totalCells * (long)axisCells);
+                }
+                catch (OverflowException)
+                {
+                    withinLimit = false;
+                    break;
+                }
+
+                if (totalCells > maxAllowedCells)
+                {
+                    withinLimit = false;
+                    break;
+                }
+            }
+
+            if (withinLimit)
+            {
+                return shift;
+            }
+        }
+
+        return PrecisionBits;
+    }
+
+    private ulong Interleave(ReadOnlySpan<ulong> coordinates)
+    {
+        ulong result = 0UL;
+
+        for (var bit = 0; bit < PrecisionBits; bit++)
+        {
+            var baseShift = bit * Dimensions;
+
+            for (var dimension = 0; dimension < Dimensions; dimension++)
+            {
+                var bitValue = (coordinates[dimension] >> bit) & 1UL;
+                result |= bitValue << (baseShift + dimension);
+            }
+        }
+
+        return result;
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
+++ b/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
@@ -1,0 +1,76 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a closed range of spatial index values.
+/// </summary>
+public readonly struct SpatialIndexRange : IEquatable<SpatialIndexRange>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexRange"/> struct.
+    /// </summary>
+    /// <param name="start">The inclusive start of the range.</param>
+    /// <param name="end">The inclusive end of the range.</param>
+    public SpatialIndexRange(ulong start, ulong end)
+    {
+        if (end < start)
+        {
+            throw new ArgumentOutOfRangeException(nameof(end), "The end of the range must be greater than or equal to the start.");
+        }
+
+        Start = start;
+        End = end;
+    }
+
+    /// <summary>
+    /// Gets the inclusive start of the range.
+    /// </summary>
+    public ulong Start { get; }
+
+    /// <summary>
+    /// Gets the inclusive end of the range.
+    /// </summary>
+    public ulong End { get; }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexRange other)
+    {
+        return Start == other.Start && End == other.End;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexRange range && Equals(range);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Start.GetHashCode();
+            hash = (hash * 397) ^ End.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{Start}, {End}]";
+    }
+
+    public static bool operator ==(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides LINQ-friendly spatial helpers. These methods are intended to be used within expression trees
+/// and will be translated by <see cref="SpatialResolver"/> into engine-specific query plans.
+/// </summary>
+public static class SpatialExpressions
+{
+    /// <summary>
+    /// Placeholder for a query that selects points near a geographic center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint candidate, GeoPoint center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points near a three-dimensional center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint3D candidate, GeoPoint3D center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects three-dimensional points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint3D candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    private static InvalidOperationException CreateUsageException()
+    {
+        return new InvalidOperationException("SpatialExpressions are intended for use within LINQ expressions and should not be executed directly.");
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System.Linq.Expressions;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Translates method calls that originate from <see cref="SpatialExpressions"/> into spatial query plans.
+/// </summary>
+public sealed class SpatialResolver
+{
+    /// <summary>
+    /// Attempts to translate the provided method call expression into a spatial query plan.
+    /// </summary>
+    /// <param name="expression">The method call expression extracted from a LINQ query.</param>
+    /// <param name="plan">When this method returns, contains the resulting query plan if translation succeeded.</param>
+    /// <returns><c>true</c> when translation succeeded; otherwise, <c>false</c>.</returns>
+    public bool TryResolve(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        plan = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
+++ b/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Core</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618;0436</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Core.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core/Metadata/SpatialCollectionMetadata.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialCollectionMetadata.cs
@@ -1,0 +1,105 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes the spatial configuration associated with a LiteDB collection.
+/// </summary>
+public sealed class SpatialCollectionMetadata : IEquatable<SpatialCollectionMetadata>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialCollectionMetadata"/> class.
+    /// </summary>
+    /// <param name="collectionName">The owning collection name.</param>
+    /// <param name="engineName">The spatial engine identifier.</param>
+    /// <param name="dimensions">The number of spatial dimensions supported by the engine.</param>
+    /// <param name="options">The index options associated with the collection.</param>
+    public SpatialCollectionMetadata(string collectionName, string engineName, int dimensions, SpatialIndexOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name cannot be null or empty.", nameof(collectionName));
+        }
+
+        if (string.IsNullOrWhiteSpace(engineName))
+        {
+            throw new ArgumentException("Engine name cannot be null or empty.", nameof(engineName));
+        }
+
+        if (dimensions != 2 && dimensions != 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial metadata currently supports only two or three dimensions.");
+        }
+
+        CollectionName = collectionName;
+        EngineName = engineName;
+        Dimensions = dimensions;
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>
+    /// Gets the name of the collection that owns this metadata entry.
+    /// </summary>
+    public string CollectionName { get; }
+
+    /// <summary>
+    /// Gets the identifier of the spatial engine responsible for the collection.
+    /// </summary>
+    public string EngineName { get; }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions tracked for the collection.
+    /// </summary>
+    public int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the index options used for encoding spatial data.
+    /// </summary>
+    public SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Gets the expected number of elements in the stored bounding box arrays.
+    /// </summary>
+    public int BoundingBoxElementCount => Dimensions * 2;
+
+    /// <inheritdoc />
+    public bool Equals(SpatialCollectionMetadata? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return string.Equals(CollectionName, other.CollectionName, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(EngineName, other.EngineName, StringComparison.Ordinal)
+            && Dimensions == other.Dimensions
+            && Options.Equals(other.Options);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialCollectionMetadata metadata && Equals(metadata);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = StringComparer.OrdinalIgnoreCase.GetHashCode(CollectionName);
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(EngineName);
+            hash = (hash * 397) ^ Dimensions;
+            hash = (hash * 397) ^ Options.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Collection={CollectionName}, Engine={EngineName}, Dimensions={Dimensions}, Options=[{Options}]";
+    }
+}

--- a/LiteDB.Spatial.Core/Metadata/SpatialMetadataException.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialMetadataException.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents errors encountered while reading or writing spatial metadata.
+/// </summary>
+public sealed class SpatialMetadataException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialMetadataException"/> class.
+    /// </summary>
+    public SpatialMetadataException(string collectionName, string message)
+        : base(message)
+    {
+        CollectionName = collectionName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialMetadataException"/> class with an inner exception.
+    /// </summary>
+    public SpatialMetadataException(string collectionName, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        CollectionName = collectionName;
+    }
+
+    /// <summary>
+    /// Gets the collection name associated with the metadata failure.
+    /// </summary>
+    public string CollectionName { get; }
+
+    /// <summary>
+    /// Creates an exception describing a missing metadata descriptor.
+    /// </summary>
+    public static SpatialMetadataException Missing(string collectionName, string engineHint)
+    {
+        var message = $"Spatial metadata for collection \"{collectionName}\" was not found. Configure the collection via {engineHint} before issuing spatial queries.";
+        return new SpatialMetadataException(collectionName, message);
+    }
+
+    /// <summary>
+    /// Creates an exception describing an invalid or inconsistent metadata document.
+    /// </summary>
+    public static SpatialMetadataException Invalid(string collectionName, string reason)
+    {
+        var message = $"Spatial metadata for collection \"{collectionName}\" is invalid: {reason}";
+        return new SpatialMetadataException(collectionName, message);
+    }
+}

--- a/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
@@ -1,0 +1,178 @@
+#nullable enable
+
+using System;
+using LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides persistence for spatial metadata descriptors inside the database.
+/// </summary>
+public sealed class SpatialMetadataStore
+{
+    private const string DefaultMetadataCollection = "_spatial_meta";
+    private const string EngineField = "engine";
+    private const string DimensionsField = "dimensions";
+    private const string BoundingBoxField = "bboxElements";
+    private const string OptionsField = "options";
+    private const string UpdatedField = "updatedUtc";
+
+    private readonly ILiteCollection<BsonDocument> _collection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialMetadataStore"/> class.
+    /// </summary>
+    /// <param name="database">The database used to persist metadata.</param>
+    /// <param name="collectionName">Optional metadata collection name. Defaults to <c>_spatial_meta</c>.</param>
+    public SpatialMetadataStore(ILiteDatabase database, string? collectionName = null)
+    {
+        if (database is null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        var name = string.IsNullOrWhiteSpace(collectionName) ? DefaultMetadataCollection : collectionName;
+        _collection = database.GetCollection(name, BsonAutoId.Int32);
+        _collection.EnsureIndex("collection", unique: true);
+    }
+
+    /// <summary>
+    /// Stores or updates the metadata associated with the provided collection.
+    /// </summary>
+    /// <param name="metadata">The descriptor to persist.</param>
+    public void Save(SpatialCollectionMetadata metadata)
+    {
+        if (metadata is null)
+        {
+            throw new ArgumentNullException(nameof(metadata));
+        }
+
+        var document = Serialize(metadata);
+        _collection.Upsert(metadata.CollectionName, document);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the metadata for the specified collection.
+    /// </summary>
+    public bool TryGet(string collectionName, out SpatialCollectionMetadata? metadata)
+    {
+        var document = _collection.FindById(collectionName);
+
+        if (document is null)
+        {
+            metadata = null;
+            return false;
+        }
+
+        metadata = Deserialize(collectionName, document);
+        return true;
+    }
+
+    /// <summary>
+    /// Retrieves the metadata for the specified collection or throws a descriptive exception if it is missing.
+    /// </summary>
+    public SpatialCollectionMetadata GetOrThrow(string collectionName, string engineHint)
+    {
+        if (!TryGet(collectionName, out var metadata) || metadata is null)
+        {
+            throw SpatialMetadataException.Missing(collectionName, engineHint);
+        }
+
+        return metadata;
+    }
+
+    private static BsonDocument Serialize(SpatialCollectionMetadata metadata)
+    {
+        var document = new BsonDocument
+        {
+            ["_id"] = metadata.CollectionName,
+            ["collection"] = metadata.CollectionName,
+            [EngineField] = metadata.EngineName,
+            [DimensionsField] = metadata.Dimensions,
+            [BoundingBoxField] = metadata.BoundingBoxElementCount,
+            [UpdatedField] = DateTime.UtcNow
+        };
+
+        document[OptionsField] = SerializeOptions(metadata.Options);
+        return document;
+    }
+
+    private static BsonDocument SerializeOptions(SpatialIndexOptions options)
+    {
+        return new BsonDocument
+        {
+            ["precisionBits"] = options.PrecisionBits,
+            ["maxCoveringCells"] = options.MaxCoveringCells,
+            ["distanceTolerance"] = options.DistanceTolerance,
+            ["indexField"] = options.IndexFieldName,
+            ["boundingBoxField"] = options.BoundingBoxFieldName
+        };
+    }
+
+    private static SpatialCollectionMetadata Deserialize(string collectionName, BsonDocument document)
+    {
+        if (!document.TryGetValue(EngineField, out var engineValue) || engineValue.IsNull || !engineValue.IsString)
+        {
+            throw SpatialMetadataException.Invalid(collectionName, "Missing engine identifier.");
+        }
+
+        if (!document.TryGetValue(DimensionsField, out var dimensionsValue) || !dimensionsValue.IsInt32)
+        {
+            throw SpatialMetadataException.Invalid(collectionName, "Missing or invalid dimension count.");
+        }
+
+        var dimensions = dimensionsValue.AsInt32;
+
+        if (dimensions != 2 && dimensions != 3)
+        {
+            throw SpatialMetadataException.Invalid(collectionName, $"Unsupported dimension count {dimensions}.");
+        }
+
+        if (!document.TryGetValue(BoundingBoxField, out var bboxValue) || !bboxValue.IsInt32)
+        {
+            throw SpatialMetadataException.Invalid(collectionName, "Missing bounding box element count.");
+        }
+
+        var expectedBoundingElements = dimensions * 2;
+        var actualBoundingElements = bboxValue.AsInt32;
+
+        if (actualBoundingElements != expectedBoundingElements)
+        {
+            throw SpatialMetadataException.Invalid(collectionName, $"Expected {expectedBoundingElements} bounding box elements but found {actualBoundingElements}.");
+        }
+
+        var options = DeserializeOptions(document[OptionsField] as BsonDocument, new SpatialIndexOptions());
+
+        return new SpatialCollectionMetadata(collectionName, engineValue.AsString, dimensions, options);
+    }
+
+    private static SpatialIndexOptions DeserializeOptions(BsonDocument? optionsDocument, SpatialIndexOptions fallback)
+    {
+        if (optionsDocument is null)
+        {
+            return fallback;
+        }
+
+        var precisionBits = optionsDocument.TryGetValue("precisionBits", out var precisionValue) && precisionValue.IsInt32
+            ? precisionValue.AsInt32
+            : fallback.PrecisionBits;
+
+        var maxCoveringCells = optionsDocument.TryGetValue("maxCoveringCells", out var cellsValue) && cellsValue.IsInt32
+            ? cellsValue.AsInt32
+            : fallback.MaxCoveringCells;
+
+        var tolerance = optionsDocument.TryGetValue("distanceTolerance", out var toleranceValue) && toleranceValue.IsNumber
+            ? toleranceValue.AsDouble
+            : fallback.DistanceTolerance;
+
+        var indexField = optionsDocument.TryGetValue("indexField", out var indexFieldValue) && indexFieldValue.IsString
+            ? indexFieldValue.AsString
+            : fallback.IndexFieldName;
+
+        var boundingField = optionsDocument.TryGetValue("boundingBoxField", out var boundingFieldValue) && boundingFieldValue.IsString
+            ? boundingFieldValue.AsString
+            : fallback.BoundingBoxFieldName;
+
+        return new SpatialIndexOptions(precisionBits, maxCoveringCells, tolerance, indexField, boundingField);
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -40,6 +40,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.ReproRunner.Shared",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedMutexHarness", "LiteDB.Tests.SharedMutexHarness\SharedMutexHarness.csproj", "{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core", "LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj", "{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core.Tests", "LiteDB.Spatial.Core.Tests\LiteDB.Spatial.Core.Tests.csproj", "{99F2946D-65FB-4FC8-827D-C3241FB5EF93}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +162,30 @@ Global
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x64.Build.0 = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.ActiveCfg = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -1,0 +1,284 @@
+# Epic: Modular Spatial Revamp (2D Geographic, 2D Cartesian, 3D Cartesian)
+
+## Goals (scope)
+
+- Extract an engine-agnostic core (`LiteDB.Spatial.Core`).
+- Add engines:
+  - `LiteDB.Spatial.Geographic` (2D, WGS84, meters).
+  - `LiteDB.Spatial.Cartesian2D` (flat 2D).
+  - `LiteDB.Spatial.Cartesian3D` (flat 3D points).
+- Standardize internal fields:
+  - `_idx` — numeric index key (Morton/Hilbert later).
+  - `_mbb` — bounding box (4 or 6 values).
+- Keep LINQ-friendly API with index-aware query plans.
+- Provide backfill + deterministic metadata per collection.
+- Ship diagnostics ("explain") and a minimum GeoJSON I/O.
+- Preserve backward compatibility as much as possible.
+
+## Non-Goals (for now)
+
+- 3D meshes/polyhedra predicates.
+- Advanced projections/CRS transforms beyond WGS84.
+- Alternate encoders beyond Morton (scaffold only).
+
+---
+
+## Architecture overview (target)
+
+```
+LiteDB.Spatial.Core
+  Geometry, Engine contracts, LINQ resolver, Metadata, Backfill
+
+LiteDB.Spatial.Indexing
+  MortonIndexEncoder (2D/3D), Hilbert (stub)
+
+LiteDB.Spatial.Geographic
+  GeographicEngine (2D), Haversine/Vincenty, wrap/polar helpers, facade
+
+LiteDB.Spatial.Cartesian2D
+  Cartesian2DEngine, Euclidean2D, facade
+
+LiteDB.Spatial.Cartesian3D
+  Cartesian3DEngine, Euclidean3D, facade
+
+LiteDB.Spatial.Diagnostics
+  Explain(plan) utilities
+
+LiteDB.Spatial.GeoJson
+  Basic GeoJSON serializer
+
+LiteDB.Spatial
+  Top-level facade (dispatch by collection metadata)
+```
+
+---
+
+## Stories & Acceptance Criteria
+
+### S1 — Core contracts & geometry (engine-agnostic)
+
+- [x] Add `GeoPoint`, `GeoPoint3D`, `BoundingBox` (2D: 4 elems; 3D: 6 elems).
+- [x] Define interfaces: `ISpatialEngine`, `ISpatialIndexEncoder`, `ISpatialDistance`, `ISpatialMapper`, `ISpatialQueryPlan`.
+- [x] Core options: `SpatialIndexOptions` (precision, max cells, tolerance, field names).
+- [x] LINQ surface: `SpatialExpressions` (Near/InBox overloads for 2D/3D).
+- [x] Stub `SpatialResolver` for expression translation.
+
+### S2 — Indexing: Morton encoder (2D/3D)
+
+- [x] Implement `MortonIndexEncoder(int dimensions)` with bit-interleaving and helpers.
+- [x] Provide helper to union adjacent ranges for nicer covers.
+
+> Implemented a reusable Morton encoder that normalises/clamps inputs, interleaves two- and three-dimensional coordinates into `ulong` keys, and exposes range covering with automatic cell coalescing.
+
+### S3 — Metadata store & schema conventions
+
+- [x] `SpatialMetadataStore` persists per-collection descriptor `{ engine, dimensions, options }` in `"_spatial_meta"`.
+- [x] Internal field names customizable via options but default to `_idx` and `_mbb`.
+- [x] Guard mismatches and surface friendly errors.
+
+> Added metadata persistence with round-trip of `SpatialIndexOptions`, bounding-box length validation, and missing-descriptor guidance that points developers toward the appropriate `Spatial.Use...` helper.
+
+### S4 — Backfill utility
+
+- [x] `SpatialBackfill.Run<T>(collection, descriptor, batchSize)` populates `_idx`/`_mbb`.
+- [x] Ensure idempotent behavior with detailed counters and error reporting.
+
+> Introduced a spatial backfill runner that batches through `BsonDocument` collections, invokes mapper delegates to compute `_idx`/`_mbb`, tracks updated/skipped/error counts, and records per-document failures without halting the sweep.
+
+### S5 — Geographic engine (2D)
+
+- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+
+### S6 — Cartesian 2D engine
+
+- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+
+### S7 — Cartesian 3D engine (points)
+
+- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+
+### S8 — LINQ resolver
+
+- [ ] Translate `SpatialExpressions` into query plans based on metadata.
+
+### S9 — Diagnostics ("Explain")
+
+- [ ] Produce printable `SpatialExplainResult` summaries for query plans.
+
+### S10 — GeoJSON I/O (minimal)
+
+- [ ] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
+
+### S11 — Top-level facade & dispatch
+
+- [ ] `LiteDB.Spatial.Spatial` entry point manages engine configuration and dispatch.
+
+### S12 — Migration & docs
+
+- [ ] Author upgrade/guide/diagnostics documentation with samples.
+
+### S13 — Benchmarks & regression guardrails
+
+- [ ] Capture performance baselines and add regression guardrails.
+
+---
+
+## Backward Compatibility & Risk Mitigation
+
+- **Internal field rename**: standardize on `_idx` (previously `_gh`). Keep `_gh` reading optional if present (migration path), but **do not** write new `_gh`. Provide backfill to `_idx`.
+- **Engine selection**: no global singletons; bind per collection via metadata to avoid cross-collection leakage.
+- **Precision in 3D**: document that 3D needs higher `PrecisionBits` for similar spatial locality; default +4 vs 2D.
+- **Range explosion**: cap by `MaxCoveringCells`; if exceeded, coarsen ranges and rely on exact filters (documented behavior).
+
+---
+
+## Public API sketch (stable surface)
+
+```csharp
+// Top-level
+Spatial.UseGeographic(col, new GeographicOptions { PrecisionBits = 32 });
+Spatial.EnsurePointIndex(col, x => x.Location); // GeoPoint
+var near = Spatial.Near(col, x => x.Location, new GeoPoint(lon, lat), radius: 1500).ToList();
+
+Spatial.UseCartesian2D(col2, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col2, x => x.Pos2D); // GeoPoint
+var inBox = Spatial.WithinBoundingBox(col2, x => x.Pos2D, BoundingBox.From2D(0,0,10,10)).ToList();
+
+Spatial.UseCartesian3D(col3, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col3, x => x.Pos3D); // GeoPoint3D
+var hits = Spatial.Near(col3, x => x.Pos3D, new GeoPoint3D(1,2,3), radius: 5).ToList();
+```
+
+---
+
+## Test Matrix (minimum)
+
+- **Core**: BoundingBox dims, options defaults, metadata round-trip.
+- **Indexing**: Morton 2D/3D grids + boundaries.
+- **Geographic**: Near Berlin; anti-meridian bbox; polar bbox.
+- **Cartesian2D**: Near/InBox on grid; candidate pruning verified.
+- **Cartesian3D**: Near3D + AABB on 3D lattice; MaxCoveringCells respected.
+- **LINQ**: Expression translation picks correct engine; index predicate present.
+- **Backfill**: idempotency; mixed docs with/without fields.
+- **Diagnostics**: explain outputs consistent and human-readable.
+
+---
+
+## Deliverables checklist (per PR)
+
+- [ ] Code compiles, no public API breaking changes outside the new surface.
+- [ ] Unit + integration tests green.
+- [ ] Samples updated.
+- [ ] Docs updated (guide/upgrade/diagnostics).
+- [ ] Bench baseline captured.
+- [ ] Changelog entry with migration notes (`_gh` → `_idx`).
+
+---
+
+## Rollout plan
+
+1. Merge Core + Indexing + Geographic (smallest behavior delta).
+2. Introduce Cartesian2D (flat replacement for non-Earth use).
+3. Add Cartesian3D (points + AABB + Near3D).
+4. Enable LINQ resolver by default; keep a feature flag to disable if needed.
+5. Publish docs and a sample upgrade script demonstrating backfill.
+
+---
+
+## Addendum: Battle-Tested Oracles & Datasets
+
+### Reference libraries (use as **oracles**, not dependencies of runtime)
+
+- **Geometry predicates (2D):** `NetTopologySuite (NTS)` — robust predicates: `Contains`, `Intersects`, `Within`, polygon holes/edge cases.
+- **Geodesic distances (Earth):** `GeographicLib` — great-circle, inverse geodesic; use as golden values.
+- **Projections / CRS transforms (optional sanity):** `ProjNET` — to cross-check lon/lat ↔ projected calculations for small-radius approximations.
+- **3D math:** `MathNet.Spatial` — Euclidean 3D distances and vector ops for oracle checks.
+- **GeoJSON parsing (test-only):** `GeoJSON.Net` — load complex fixtures without maintaining your own parser.
+- **External systems for differential tests (CI optional):** `PostGIS`, `SQLite+RTree/SpatiaLite` for bbox/near behavior.
+
+### Public datasets & fixtures
+
+- `Turf.js` fixtures (GeoJSON): points/lines/polygons with holes; great for predicate parity.
+- `Natural Earth`: coastlines, large polygons crossing the anti-meridian (Aleutians, Russia); polar stress.
+- `OSM` extracts (tiny tiles): dense urban point clouds for performance & correctness mixes.
+- Synthetic grids & lattices: controlled point sets for Morton/Hilbert locality tests.
+- Precomputed geodesic pairs from GeographicLib samples (save as JSON with expected distances).
+
+### New Stories (append to Epic)
+
+#### T1 — Oracle Adapters
+
+- [ ] Add `LiteDB.Spatial.Testing.Oracles` project with adapters for NTS, GeographicLib, MathNet, PostGIS.
+
+#### T2 — Golden Fixtures & Tolerances
+
+- [ ] Store fixtures under `/tests/fixtures` with documented tolerances and snapshot helpers.
+
+#### T3 — Differential Correctness: Geographic 2D
+
+- [ ] Cross-check `SpatialGeographic` behavior against PostGIS and GeographicLib oracles.
+
+#### T4 — Differential Correctness: Cartesian 2D
+
+- [ ] Validate Euclidean behavior with NTS and property-based testing.
+
+#### T5 — Differential Correctness: Cartesian 3D
+
+- [ ] Ensure 3D results align with MathNet.Spatial and range caps.
+
+#### T6 — Index Locality & Stability (Morton)
+
+- [ ] Measure locality/monotonicity and compare to reference encoders.
+
+#### T7 — Query Plan Parity (LINQ)
+
+- [ ] Assert LINQ plans use indexes and match oracles.
+
+#### T8 — Performance Sanity vs External Systems (optional `perf`)
+
+- [ ] Benchmark LiteDB.Spatial vs SQLite/PostGIS and record findings.
+
+---
+
+## Concrete snippets (test-only patterns)
+
+```csharp
+// Distance parity (Geographic)
+var d1 = GeographicLibOracle.Distance(lon1, lat1, lon2, lat2);
+var d2 = SpatialGeographicDistance.Haversine(lon1, lat1, lon2, lat2);
+d2.Should().BeApproximately(d1, 1e-4 * d1 + 0.05);
+```
+
+```csharp
+// Predicate parity (2D)
+var expected = NtsOracle.Contains(poly, pt);
+var actual = SpatialExpressions.Within(/* polygon */, /* point */);
+actual.Should().Be(expected);
+```
+
+```csharp
+// 3D near parity
+var dRef = MathNetOracle3D.Distance(a, b);
+var dOur = Euclidean3D.Distance(a, b);
+dOur.Should().BeApproximately(dRef, 1e-9);
+```
+
+---
+
+## Integration guidance
+
+- Keep external libraries under `tests` only and guard with categories/env vars.
+- Persist expensive oracle outputs to JSON fixtures for reproducible CI runs.
+- Document toggles like `SPATIAL_ORACLES` and `SPATIAL_DB_TESTS` for optional suites.
+
+---
+
+## Acceptance Criteria (global)
+
+- Geographic distances match GeographicLib within tolerance on 1,000 diverse pairs.
+- 2D predicates match NTS on 100 complex polygons × 1,000 random points each.
+- 3D distances match MathNet.Spatial within floating-point tolerance on 10,000 random pairs.
+- Index usage verified by explain output in every LINQ test; no full scans when index present.
+- Fixtures pack checked into the repo; tests avoid network calls.
+


### PR DESCRIPTION
## Summary
- implement a reusable MortonIndexEncoder with range covering and coalescing helpers, plus tests for normalization and ordering
- introduce spatial metadata persistence with descriptor validation, friendly error messaging, and unit coverage
- add a spatial backfill runner with result accounting, mapper integration, and idempotency/error handling tests; mark S2–S4 complete in the roadmap doc

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e7407432f083268c81ccebffb8f4bb