### PR TITLE
Implement Morton encoder, metadata store, and backfill for spatial core

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
@@ -1,0 +1,209 @@
+extern alias litedb;
+
+using System;
+using System.IO;
+using FluentAssertions;
+using litedb::LiteDB;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Backfill;
+
+public sealed class SpatialBackfillTests
+{
+    [Fact]
+    public void Run_ShouldPopulateMissingFields()
+    {
+        using var stream = new MemoryStream();
+        using var database = new LiteDatabase(stream);
+        var collection = database.GetCollection<BsonDocument>("points");
+
+        collection.Insert(new BsonDocument
+        {
+            ["_id"] = 1,
+            ["location"] = new BsonDocument { ["x"] = 0.25, ["y"] = 0.75 }
+        });
+
+        var options = new SpatialIndexOptions(precisionBits: 4, indexFieldName: "_idx", boundingBoxFieldName: "_mbb");
+        var encoder = new MortonIndexEncoder(2, options.PrecisionBits);
+        var mapper = new TestMapper(encoder);
+        var engine = new TestEngine("test", 2, options, encoder, mapper);
+        var descriptor = new SpatialCollectionDescriptor("points", "test", 2, "location", options).WithEngine(engine);
+
+        var existingIndex = unchecked((long)encoder.Encode(new[] { 0.5, 0.5 }));
+        collection.Insert(new BsonDocument
+        {
+            ["_id"] = 2,
+            ["location"] = new BsonDocument { ["x"] = 0.5, ["y"] = 0.5 },
+            ["_idx"] = existingIndex,
+            ["_mbb"] = new BsonArray { 0.5, 0.5, 0.5, 0.5 }
+        });
+
+        var result = SpatialBackfill.Run(collection, descriptor, batchSize: 1);
+
+        result.Updated.Should().Be(1);
+        result.Skipped.Should().Be(1);
+        result.Errors.Should().Be(0);
+        result.LastCheckpoint.Should().NotBeNull();
+        result.LastCheckpoint!.AsInt32.Should().Be(2);
+
+        var reloaded = collection.FindById(1);
+        reloaded["_idx"].IsInt64.Should().BeTrue();
+        reloaded["_mbb"].AsArray.Count.Should().Be(4);
+
+        var secondRun = SpatialBackfill.Run(collection, descriptor);
+        secondRun.Updated.Should().Be(0);
+        secondRun.Skipped.Should().Be(2);
+        secondRun.Errors.Should().Be(0);
+    }
+
+    [Fact]
+    public void Run_ShouldCountErrorsWithoutStopping()
+    {
+        using var stream = new MemoryStream();
+        using var database = new LiteDatabase(stream);
+        var collection = database.GetCollection<BsonDocument>("points");
+
+        collection.Insert(new BsonDocument
+        {
+            ["_id"] = 1,
+            ["location"] = new BsonDocument { ["x"] = 0.1, ["y"] = 0.2 }
+        });
+
+        collection.Insert(new BsonDocument
+        {
+            ["_id"] = 2,
+            ["location"] = new BsonDocument { ["x"] = "bad", ["y"] = 0.4 }
+        });
+
+        var options = new SpatialIndexOptions(precisionBits: 3, indexFieldName: "_idx", boundingBoxFieldName: "_mbb");
+        var encoder = new MortonIndexEncoder(2, options.PrecisionBits);
+        var mapper = new TestMapper(encoder);
+        var engine = new TestEngine("test", 2, options, encoder, mapper);
+        var descriptor = new SpatialCollectionDescriptor("points", "test", 2, "location", options).WithEngine(engine);
+
+        var result = SpatialBackfill.Run(collection, descriptor);
+
+        result.Updated.Should().Be(1);
+        result.Skipped.Should().Be(0);
+        result.Errors.Should().Be(1);
+    }
+
+    private sealed class TestMapper : ISpatialMapper
+    {
+        private readonly MortonIndexEncoder _encoder;
+
+        public TestMapper(MortonIndexEncoder encoder)
+        {
+            _encoder = encoder;
+        }
+
+        public bool TryExtractPoint(BsonValue value, out GeoPoint point)
+        {
+            if (value.Type != BsonType.Document)
+            {
+                point = default;
+                return false;
+            }
+
+            var doc = value.AsDocument;
+            if (!doc.TryGetValue("x", out var xValue) || !doc.TryGetValue("y", out var yValue))
+            {
+                point = default;
+                return false;
+            }
+
+            if (!xValue.IsNumber || !yValue.IsNumber)
+            {
+                point = default;
+                return false;
+            }
+
+            point = new GeoPoint(xValue.AsDouble, yValue.AsDouble);
+            return true;
+        }
+
+        public bool TryExtractPoint3D(BsonValue value, out GeoPoint3D point)
+        {
+            if (value.Type != BsonType.Document)
+            {
+                point = default;
+                return false;
+            }
+
+            var doc = value.AsDocument;
+            if (!doc.TryGetValue("x", out var xValue) || !doc.TryGetValue("y", out var yValue) || !doc.TryGetValue("z", out var zValue))
+            {
+                point = default;
+                return false;
+            }
+
+            if (!xValue.IsNumber || !yValue.IsNumber || !zValue.IsNumber)
+            {
+                point = default;
+                return false;
+            }
+
+            point = new GeoPoint3D(xValue.AsDouble, yValue.AsDouble, zValue.AsDouble);
+            return true;
+        }
+
+        public BoundingBox GetBoundingBox(GeoPoint point)
+        {
+            return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+        }
+
+        public BoundingBox GetBoundingBox(GeoPoint3D point)
+        {
+            return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+        }
+
+        public ulong Encode(GeoPoint point)
+        {
+            return _encoder.Encode(new[] { point.Longitude, point.Latitude });
+        }
+
+        public ulong Encode(GeoPoint3D point)
+        {
+            return _encoder.Encode(new[] { point.X, point.Y, point.Z });
+        }
+    }
+
+    private sealed class TestEngine : ISpatialEngine
+    {
+        public TestEngine(string name, int dimensions, SpatialIndexOptions options, ISpatialIndexEncoder encoder, ISpatialMapper mapper)
+        {
+            Name = name;
+            Dimensions = dimensions;
+            Options = options;
+            IndexEncoder = encoder;
+            Mapper = mapper;
+            Distance = new TestDistance();
+        }
+
+        public string Name { get; }
+
+        public int Dimensions { get; }
+
+        public SpatialIndexOptions Options { get; }
+
+        public ISpatialIndexEncoder IndexEncoder { get; }
+
+        public ISpatialMapper Mapper { get; }
+
+        public ISpatialDistance Distance { get; }
+
+        public ISpatialQueryPlan PlanNear(GeoPoint center, double radius) => throw new NotSupportedException();
+
+        public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius) => throw new NotSupportedException();
+
+        public ISpatialQueryPlan PlanWithin(BoundingBox bounds) => throw new NotSupportedException();
+    }
+
+    private sealed class TestDistance : ISpatialDistance
+    {
+        public double Distance(GeoPoint left, GeoPoint right) => 0;
+
+        public double Distance(GeoPoint3D left, GeoPoint3D right) => 0;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
@@ -1,0 +1,57 @@
+using System;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public class SpatialIndexOptionsTests
+{
+    [Fact]
+    public void SpatialIndexOptions_ShouldUseSensibleDefaults()
+    {
+        var options = new SpatialIndexOptions();
+
+        options.PrecisionBits.Should().Be(32);
+        options.MaxCoveringCells.Should().Be(64);
+        options.DistanceTolerance.Should().Be(0.001);
+        options.IndexFieldName.Should().Be(SpatialIndexOptions.DefaultIndexFieldName);
+        options.BoundingBoxFieldName.Should().Be(SpatialIndexOptions.DefaultBoundingBoxFieldName);
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_ShouldAllowCustomization()
+    {
+        var options = new SpatialIndexOptions(40, 128, 0.25, "_custom_idx", "_custom_mbb");
+
+        options.PrecisionBits.Should().Be(40);
+        options.MaxCoveringCells.Should().Be(128);
+        options.DistanceTolerance.Should().Be(0.25);
+        options.IndexFieldName.Should().Be("_custom_idx");
+        options.BoundingBoxFieldName.Should().Be("_custom_mbb");
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_With_ShouldCreateNewInstance()
+    {
+        var options = new SpatialIndexOptions();
+        var updated = options.With(distanceTolerance: 0.01);
+
+        updated.Should().NotBeSameAs(options);
+        updated.DistanceTolerance.Should().Be(0.01);
+        updated.IndexFieldName.Should().Be(options.IndexFieldName);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 0, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, -0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, 0.1, "", "_mbb")]
+    [InlineData(32, 1, 0.1, "_idx", " ")]
+    public void SpatialIndexOptions_ShouldValidateInputs(int precisionBits, int maxCells, double tolerance, string indexField, string mbbField)
+    {
+        Action act = () => new SpatialIndexOptions(precisionBits, maxCells, tolerance, indexField, mbbField);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class BoundingBoxTests
+{
+    [Fact]
+    public void BoundingBox_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(BoundingBox);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BoundingBox2D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From2D(-10, -5, 20, 15);
+
+        box.Dimensions.Should().Be(2);
+        box.Is3D.Should().BeFalse();
+        box.MinX.Should().Be(-10);
+        box.MinY.Should().Be(-5);
+        box.MaxX.Should().Be(20);
+        box.MaxY.Should().Be(15);
+        box.GetValues().ToArray().Should().Equal(-10, -5, 20, 15);
+    }
+
+    [Fact]
+    public void BoundingBox3D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From3D(-1, -2, -3, 4, 5, 6);
+
+        box.Dimensions.Should().Be(3);
+        box.Is3D.Should().BeTrue();
+        box.MinX.Should().Be(-1);
+        box.MinY.Should().Be(-2);
+        box.MinZ.Should().Be(-3);
+        box.MaxX.Should().Be(4);
+        box.MaxY.Should().Be(5);
+        box.MaxZ.Should().Be(6);
+        box.GetValues().ToArray().Should().Equal(-1, -2, -3, 4, 5, 6);
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidAxisOrdering()
+    {
+        Action twoD = () => BoundingBox.From2D(5, 0, 4, 1);
+        Action threeD = () => BoundingBox.From3D(0, 0, 0, -1, 2, 3);
+
+        twoD.Should().Throw<ArgumentException>();
+        threeD.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidValueCount()
+    {
+        Action act = () => BoundingBox.Create(new[] { 1.0, 2.0, 3.0 });
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPoint3DTests
+{
+    [Fact]
+    public void GeoPoint3D_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint3D);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint3D_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint3D(1, 2, 3);
+
+        point.X.Should().Be(1);
+        point.Y.Should().Be(2);
+        point.Z.Should().Be(3);
+        point.ToString().Should().Be("(1, 2, 3)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0, 0)]
+    [InlineData(0, double.NaN, 0)]
+    [InlineData(0, 0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0, 0)]
+    [InlineData(0, double.NegativeInfinity, 0)]
+    [InlineData(0, 0, double.PositiveInfinity)]
+    public void GeoPoint3D_ShouldRejectNonFiniteValues(double x, double y, double z)
+    {
+        Action act = () => new GeoPoint3D(x, y, z);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPointTests
+{
+    [Fact]
+    public void GeoPoint_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint(12.5, -23.4);
+
+        point.Longitude.Should().Be(12.5);
+        point.Latitude.Should().Be(-23.4);
+        point.ToString().Should().Be("(12.5, -23.4)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0)]
+    [InlineData(0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0)]
+    [InlineData(0, double.NegativeInfinity)]
+    public void GeoPoint_ShouldRejectNonFiniteValues(double longitude, double latitude)
+    {
+        Action act = () => new GeoPoint(longitude, latitude);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
@@ -1,0 +1,81 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Indexing;
+
+public sealed class MortonIndexEncoderTests
+{
+    [Fact]
+    public void Encode_ShouldInterleaveBitsFor2DCoordinates()
+    {
+        var encoder = new MortonIndexEncoder(dimensions: 2, precisionBits: 3);
+
+        encoder.Encode(new[] { 0d, 0d }).Should().Be(0);
+        encoder.Encode(new[] { 1d, 1d }).Should().Be(63);
+        encoder.Encode(new[] { 0.5, 0.5 }).Should().Be(48);
+    }
+
+    [Fact]
+    public void Encode_ShouldInterleaveBitsFor3DCoordinates()
+    {
+        var encoder = new MortonIndexEncoder(dimensions: 3, precisionBits: 2);
+
+        encoder.Encode(new[] { 0d, 0d, 0d }).Should().Be(0);
+        encoder.Encode(new[] { 1d, 1d, 1d }).Should().Be(63);
+        encoder.Encode(new[] { 0.5, 0.25, 0.75 }).Should().Be(0b101010);
+    }
+
+    [Fact]
+    public void Encode_ShouldClampAndRejectInvalidValues()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 3);
+
+        encoder.Encode(new[] { -1d, 2d }).Should().Be(0b101010);
+
+        Action action = () => encoder.Encode(new[] { double.NaN, 0d });
+        action.Should().Throw<ArgumentException>().WithMessage("*finite*");
+    }
+
+    [Fact]
+    public void Cover_ShouldRespectMaxCells()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 3);
+        var bounds = BoundingBox.From2D(0d, 0d, 1d, 1d);
+
+        var ranges = encoder.Cover(bounds, maxCells: 4);
+
+        ranges.Should().HaveCountLessOrEqualTo(4);
+        ranges.Should().BeInAscendingOrder(r => r.Start);
+        ranges.Should().OnlyContain(range => range.End >= range.Start);
+    }
+
+    [Fact]
+    public void Cover_ShouldProduceSingleRangeForPoint()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 3);
+        var bounds = BoundingBox.From2D(0.5, 0.5, 0.5, 0.5);
+
+        var ranges = encoder.Cover(bounds, maxCells: 8);
+
+        ranges.Should().HaveCount(1);
+        var encoded = encoder.Encode(new[] { 0.5, 0.5 });
+        ranges[0].Start.Should().Be(encoded);
+        ranges[0].End.Should().Be(encoded);
+    }
+
+    [Fact]
+    public void MergeAdjacentRanges_ShouldCoalesceTouchingRanges()
+    {
+        var input = new[]
+        {
+            new SpatialIndexRange(1, 2),
+            new SpatialIndexRange(3, 5),
+            new SpatialIndexRange(10, 12)
+        };
+
+        var merged = MortonIndexEncoder.MergeAdjacentRanges(input);
+
+        merged.Should().Equal(new SpatialIndexRange(1, 5), new SpatialIndexRange(10, 12));
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial.Core.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>litedb</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
@@ -1,0 +1,102 @@
+extern alias litedb;
+
+using System;
+using System.IO;
+using FluentAssertions;
+using litedb::LiteDB;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Metadata;
+
+public sealed class SpatialMetadataStoreTests
+{
+    [Fact]
+    public void RoundTrip_ShouldPersistDescriptor()
+    {
+        using var stream = new MemoryStream();
+        using var database = new LiteDatabase(stream);
+        var store = new SpatialMetadataStore(database);
+
+        var options = new SpatialIndexOptions(precisionBits: 28, maxCoveringCells: 32, distanceTolerance: 0.25, indexFieldName: "_idx", boundingBoxFieldName: "_mbb");
+        var descriptor = new SpatialCollectionDescriptor("points", "geographic", 2, "location", options);
+
+        store.UpsertDescriptor(descriptor);
+
+        var loaded = store.TryGetDescriptor("points");
+
+        loaded.Should().NotBeNull();
+        loaded.Should().Be(descriptor);
+    }
+
+    [Fact]
+    public void GetRequiredDescriptor_ShouldThrowWhenMissing()
+    {
+        using var stream = new MemoryStream();
+        using var database = new LiteDatabase(stream);
+        var store = new SpatialMetadataStore(database);
+
+        var act = () => store.GetRequiredDescriptor("missing");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*UseGeographic*");
+    }
+
+    [Fact]
+    public void ValidateDocument_ShouldDetectBoundingBoxMismatch()
+    {
+        using var stream = new MemoryStream();
+        using var database = new LiteDatabase(stream);
+        var store = new SpatialMetadataStore(database);
+        var options = new SpatialIndexOptions(indexFieldName: "_idx", boundingBoxFieldName: "_mbb");
+        var descriptor = new SpatialCollectionDescriptor("points", "cartesian3d", 3, "position", options);
+
+        var document = new BsonDocument
+        {
+            ["_id"] = 1,
+            [descriptor.Options.BoundingBoxFieldName] = new BsonArray { 0d, 0d, 1d, 1d },
+            [descriptor.Options.IndexFieldName] = 123L
+        };
+
+        var act = () => store.ValidateDocument(descriptor, document);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*declares 3 dimensions*");
+    }
+
+    [Fact]
+    public void ValidateDocument_ShouldRejectNonNumericIndex()
+    {
+        using var stream = new MemoryStream();
+        using var database = new LiteDatabase(stream);
+        var store = new SpatialMetadataStore(database);
+        var options = new SpatialIndexOptions(indexFieldName: "_idx", boundingBoxFieldName: "_mbb");
+        var descriptor = new SpatialCollectionDescriptor("points", "cartesian2d", 2, "position", options);
+
+        var document = new BsonDocument
+        {
+            ["_id"] = 1,
+            [descriptor.Options.BoundingBoxFieldName] = new BsonArray { 0d, 0d, 1d, 1d },
+            [descriptor.Options.IndexFieldName] = "abc"
+        };
+
+        var act = () => store.ValidateDocument(descriptor, document);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*64-bit integer*");
+    }
+
+    [Fact]
+    public void ValidateDocument_ShouldAllowDocumentsWithoutSpatialFields()
+    {
+        using var stream = new MemoryStream();
+        using var database = new LiteDatabase(stream);
+        var store = new SpatialMetadataStore(database);
+        var options = new SpatialIndexOptions(indexFieldName: "_idx", boundingBoxFieldName: "_mbb");
+        var descriptor = new SpatialCollectionDescriptor("points", "cartesian2d", 2, "position", options);
+
+        var document = new BsonDocument { ["_id"] = 1 };
+
+        store.Invoking(x => x.ValidateDocument(descriptor, document)).Should().NotThrow();
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
@@ -1,0 +1,186 @@
+#nullable enable
+
+extern alias litedb;
+
+using System;
+using System.Collections.Generic;
+using litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Utilities for enriching existing documents with spatial index data.
+/// </summary>
+public static class SpatialBackfill
+{
+    /// <summary>
+    /// Populates missing spatial index fields on the specified collection.
+    /// </summary>
+    /// <param name="collection">The collection to scan.</param>
+    /// <param name="descriptor">The descriptor describing the spatial configuration.</param>
+    /// <param name="batchSize">The number of documents updated per batch.</param>
+    /// <param name="checkpointField">The field used to expose the last processed checkpoint.</param>
+    /// <returns>A summary describing the backfill outcome.</returns>
+    public static SpatialBackfillResult Run(
+        ILiteCollection<BsonDocument> collection,
+        SpatialCollectionDescriptor descriptor,
+        int batchSize = 128,
+        string checkpointField = "_id")
+    {
+        if (collection is null)
+        {
+            throw new ArgumentNullException(nameof(collection));
+        }
+
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (descriptor.Engine is null)
+        {
+            throw new ArgumentException("The descriptor must include a resolved engine instance.", nameof(descriptor));
+        }
+
+        if (batchSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(batchSize), "Batch size must be greater than zero.");
+        }
+
+        if (string.IsNullOrWhiteSpace(checkpointField))
+        {
+            throw new ArgumentException("Checkpoint field cannot be null or whitespace.", nameof(checkpointField));
+        }
+
+        var mapper = descriptor.Engine.Mapper ?? throw new InvalidOperationException("The spatial engine did not expose a mapper.");
+        var options = descriptor.Options;
+
+        var updated = 0;
+        var skipped = 0;
+        var errors = 0;
+        BsonValue? lastCheckpoint = null;
+
+        var pending = new List<BsonDocument>(batchSize);
+
+        foreach (var document in collection.FindAll())
+        {
+            lastCheckpoint = document.TryGetValue(checkpointField, out var checkpoint) ? checkpoint : null;
+
+            try
+            {
+                if (!document.TryGetValue(descriptor.GeometryFieldName, out var geometryValue) || geometryValue.IsNull)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                var changed = descriptor.Dimensions switch
+                {
+                    2 => Process2D(document, mapper, geometryValue, options),
+                    3 => Process3D(document, mapper, geometryValue, options),
+                    _ => throw new InvalidOperationException($"Unsupported dimensionality {descriptor.Dimensions}.")
+                };
+
+                if (!changed)
+                {
+                    skipped++;
+                    continue;
+                }
+
+                pending.Add(document);
+                updated++;
+
+                if (pending.Count >= batchSize)
+                {
+                    collection.Update(pending);
+                    pending.Clear();
+                }
+            }
+            catch
+            {
+                errors++;
+            }
+        }
+
+        if (pending.Count > 0)
+        {
+            collection.Update(pending);
+        }
+
+        return new SpatialBackfillResult(updated, skipped, errors, lastCheckpoint);
+    }
+
+    private static bool Process2D(BsonDocument document, ISpatialMapper mapper, BsonValue geometryValue, SpatialIndexOptions options)
+    {
+        if (!mapper.TryExtractPoint(geometryValue, out var point))
+        {
+            throw new InvalidOperationException("Unable to extract a two-dimensional point from the document value.");
+        }
+
+        var index = mapper.Encode(point);
+        var boundingBox = mapper.GetBoundingBox(point);
+        return ApplySpatialFields(document, index, boundingBox, options);
+    }
+
+    private static bool Process3D(BsonDocument document, ISpatialMapper mapper, BsonValue geometryValue, SpatialIndexOptions options)
+    {
+        if (!mapper.TryExtractPoint3D(geometryValue, out var point))
+        {
+            throw new InvalidOperationException("Unable to extract a three-dimensional point from the document value.");
+        }
+
+        var index = mapper.Encode(point);
+        var boundingBox = mapper.GetBoundingBox(point);
+        return ApplySpatialFields(document, index, boundingBox, options);
+    }
+
+    private static bool ApplySpatialFields(BsonDocument document, ulong index, BoundingBox box, SpatialIndexOptions options)
+    {
+        var changed = false;
+        var indexField = options.IndexFieldName;
+        var encodedIndex = unchecked((long)index);
+
+        if (!document.TryGetValue(indexField, out var existingIndex) || existingIndex.IsNull || existingIndex.AsInt64 != encodedIndex)
+        {
+            document[indexField] = encodedIndex;
+            changed = true;
+        }
+
+        var values = box.GetValues();
+        var array = new BsonArray();
+        for (var i = 0; i < values.Length; i++)
+        {
+            array.Add(values[i]);
+        }
+
+        if (!document.TryGetValue(options.BoundingBoxFieldName, out var existingBox) || existingBox.IsNull)
+        {
+            document[options.BoundingBoxFieldName] = array;
+            return true;
+        }
+
+        if (existingBox.Type != BsonType.Array)
+        {
+            document[options.BoundingBoxFieldName] = array;
+            return true;
+        }
+
+        var current = existingBox.AsArray;
+        if (current.Count != array.Count)
+        {
+            document[options.BoundingBoxFieldName] = array;
+            return true;
+        }
+
+        for (var i = 0; i < array.Count; i++)
+        {
+            if (!current[i].AsDouble.Equals(array[i].AsDouble))
+            {
+                document[options.BoundingBoxFieldName] = array;
+                return true;
+            }
+        }
+
+        return changed;
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+extern alias litedb;
+
+using litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents the outcome of a spatial backfill run.
+/// </summary>
+public readonly struct SpatialBackfillResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialBackfillResult"/> struct.
+    /// </summary>
+    public SpatialBackfillResult(int updated, int skipped, int errors, BsonValue? lastCheckpoint)
+    {
+        Updated = updated;
+        Skipped = skipped;
+        Errors = errors;
+        LastCheckpoint = lastCheckpoint;
+    }
+
+    /// <summary>
+    /// Gets the number of documents that were enriched with spatial data.
+    /// </summary>
+    public int Updated { get; }
+
+    /// <summary>
+    /// Gets the number of documents that already had spatial fields or were skipped.
+    /// </summary>
+    public int Skipped { get; }
+
+    /// <summary>
+    /// Gets the number of documents that failed during enrichment.
+    /// </summary>
+    public int Errors { get; }
+
+    /// <summary>
+    /// Gets the last processed checkpoint value.
+    /// </summary>
+    public BsonValue? LastCheckpoint { get; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Updated={Updated}, Skipped={Skipped}, Errors={Errors}, LastCheckpoint={LastCheckpoint}";
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
@@ -1,0 +1,17 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes distances between spatial points for exact filtering.
+/// </summary>
+public interface ISpatialDistance
+{
+    /// <summary>
+    /// Computes the distance between two geographic points expressed in meters.
+    /// </summary>
+    double Distance(GeoPoint left, GeoPoint right);
+
+    /// <summary>
+    /// Computes the distance between two Cartesian points expressed in user-defined units.
+    /// </summary>
+    double Distance(GeoPoint3D left, GeoPoint3D right);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
@@ -1,0 +1,52 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a spatial engine capable of producing index-aware query plans and mapping values.
+/// </summary>
+public interface ISpatialEngine
+{
+    /// <summary>
+    /// Gets the human-readable engine name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the engine.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the options associated with the engine.
+    /// </summary>
+    SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Gets the encoder used to map coordinates into index keys.
+    /// </summary>
+    ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <summary>
+    /// Gets the component responsible for mapping values to index fields.
+    /// </summary>
+    ISpatialMapper Mapper { get; }
+
+    /// <summary>
+    /// Gets the distance calculator used for exact filtering.
+    /// </summary>
+    ISpatialDistance Distance { get; }
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(GeoPoint center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided bounding box.
+    /// </summary>
+    ISpatialQueryPlan PlanWithin(BoundingBox bounds);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
@@ -1,0 +1,41 @@
+extern alias litedb;
+
+using litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Projects application-level spatial values into indexable representations.
+/// </summary>
+public interface ISpatialMapper
+{
+    /// <summary>
+    /// Attempts to extract a two-dimensional point from a document value.
+    /// </summary>
+    bool TryExtractPoint(BsonValue value, out GeoPoint point);
+
+    /// <summary>
+    /// Attempts to extract a three-dimensional point from a document value.
+    /// </summary>
+    bool TryExtractPoint3D(BsonValue value, out GeoPoint3D point);
+
+    /// <summary>
+    /// Computes the bounding box for the provided two-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(GeoPoint point);
+
+    /// <summary>
+    /// Computes the bounding box for the provided three-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(GeoPoint3D point);
+
+    /// <summary>
+    /// Encodes a two-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(GeoPoint point);
+
+    /// <summary>
+    /// Encodes a three-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(GeoPoint3D point);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes the pieces required to execute a spatial query using index ranges and precise filters.
+/// </summary>
+public interface ISpatialQueryPlan
+{
+    /// <summary>
+    /// Gets the dimensionality of the underlying spatial index.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the coarse bounding region evaluated before exact predicates. May be <c>null</c> when not applicable.
+    /// </summary>
+    BoundingBox? CoveringBounds { get; }
+
+    /// <summary>
+    /// Gets the ordered set of index ranges that should be scanned.
+    /// </summary>
+    IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <summary>
+    /// Gets a human readable description of the exact predicate applied after index filtering.
+    /// </summary>
+    string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
@@ -1,0 +1,152 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents configuration options that govern how spatial indexes are generated and queried.
+/// </summary>
+public sealed class SpatialIndexOptions : IEquatable<SpatialIndexOptions>
+{
+    /// <summary>
+    /// The default name for the numeric index field stored on documents.
+    /// </summary>
+    public const string DefaultIndexFieldName = "_idx";
+
+    /// <summary>
+    /// The default name for the bounding box field stored on documents.
+    /// </summary>
+    public const string DefaultBoundingBoxFieldName = "_mbb";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexOptions"/> class.
+    /// </summary>
+    /// <param name="precisionBits">Number of bits used by the index encoder to represent each axis.</param>
+    /// <param name="maxCoveringCells">The maximum number of index ranges allowed when covering a shape.</param>
+    /// <param name="distanceTolerance">Additional expansion applied to distance queries to accommodate floating-point error.</param>
+    /// <param name="indexFieldName">The field used to store the encoded index value on documents.</param>
+    /// <param name="boundingBoxFieldName">The field used to store the bounding box on documents.</param>
+    public SpatialIndexOptions(
+        int precisionBits = 32,
+        int maxCoveringCells = 64,
+        double distanceTolerance = 0.001,
+        string indexFieldName = DefaultIndexFieldName,
+        string boundingBoxFieldName = DefaultBoundingBoxFieldName)
+    {
+        if (precisionBits <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be a positive number of bits.");
+        }
+
+        if (maxCoveringCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCoveringCells), "The maximum number of covering cells must be positive.");
+        }
+
+        if (distanceTolerance < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(distanceTolerance), "Distance tolerance cannot be negative.");
+        }
+
+        if (string.IsNullOrWhiteSpace(indexFieldName))
+        {
+            throw new ArgumentException("Index field name cannot be null or whitespace.", nameof(indexFieldName));
+        }
+
+        if (string.IsNullOrWhiteSpace(boundingBoxFieldName))
+        {
+            throw new ArgumentException("Bounding box field name cannot be null or whitespace.", nameof(boundingBoxFieldName));
+        }
+
+        PrecisionBits = precisionBits;
+        MaxCoveringCells = maxCoveringCells;
+        DistanceTolerance = distanceTolerance;
+        IndexFieldName = indexFieldName;
+        BoundingBoxFieldName = boundingBoxFieldName;
+    }
+
+    /// <summary>
+    /// Gets the number of bits allocated to represent each coordinate axis.
+    /// </summary>
+    public int PrecisionBits { get; }
+
+    /// <summary>
+    /// Gets the maximum number of index cells that planners may request when approximating shapes.
+    /// </summary>
+    public int MaxCoveringCells { get; }
+
+    /// <summary>
+    /// Gets the amount of tolerance applied to distance-based operations.
+    /// </summary>
+    public double DistanceTolerance { get; }
+
+    /// <summary>
+    /// Gets the document field used to store encoded index values.
+    /// </summary>
+    public string IndexFieldName { get; }
+
+    /// <summary>
+    /// Gets the document field used to store bounding boxes.
+    /// </summary>
+    public string BoundingBoxFieldName { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="SpatialIndexOptions"/> instance using the existing values as defaults.
+    /// </summary>
+    public SpatialIndexOptions With(
+        int? precisionBits = null,
+        int? maxCoveringCells = null,
+        double? distanceTolerance = null,
+        string? indexFieldName = null,
+        string? boundingBoxFieldName = null)
+    {
+        return new SpatialIndexOptions(
+            precisionBits ?? PrecisionBits,
+            maxCoveringCells ?? MaxCoveringCells,
+            distanceTolerance ?? DistanceTolerance,
+            indexFieldName ?? IndexFieldName,
+            boundingBoxFieldName ?? BoundingBoxFieldName);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexOptions? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return PrecisionBits == other.PrecisionBits
+            && MaxCoveringCells == other.MaxCoveringCells
+            && DistanceTolerance.Equals(other.DistanceTolerance)
+            && string.Equals(IndexFieldName, other.IndexFieldName, StringComparison.Ordinal)
+            && string.Equals(BoundingBoxFieldName, other.BoundingBoxFieldName, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexOptions options && Equals(options);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = PrecisionBits;
+            hash = (hash * 397) ^ MaxCoveringCells;
+            hash = (hash * 397) ^ DistanceTolerance.GetHashCode();
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(IndexFieldName);
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(BoundingBoxFieldName);
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Precision={PrecisionBits}, Cells={MaxCoveringCells}, Tolerance={DistanceTolerance}, IndexField=\"{IndexFieldName}\", BoundingField=\"{BoundingBoxFieldName}\"";
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
+++ b/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
@@ -1,0 +1,234 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents an axis-aligned bounding box in two or three dimensions.
+/// </summary>
+public readonly struct BoundingBox : IEquatable<BoundingBox>
+{
+    private readonly double[] _values;
+
+    private BoundingBox(double[] values)
+    {
+        _values = values;
+    }
+
+    /// <summary>
+    /// Creates a bounding box from raw coordinate values.
+    /// </summary>
+    /// <param name="values">
+    /// The coordinates describing the box. Two-dimensional boxes require four values
+    /// (<c>minX</c>, <c>minY</c>, <c>maxX</c>, <c>maxY</c>). Three-dimensional boxes require
+    /// six values (<c>minX</c>, <c>minY</c>, <c>minZ</c>, <c>maxX</c>, <c>maxY</c>, <c>maxZ</c>).
+    /// </param>
+    /// <returns>A new <see cref="BoundingBox"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when the number of values is invalid or any value is non-finite.</exception>
+    public static BoundingBox Create(ReadOnlySpan<double> values)
+    {
+        if (values.Length != 4 && values.Length != 6)
+        {
+            throw new ArgumentException("Bounding boxes must be described by four (2D) or six (3D) values.", nameof(values));
+        }
+
+        var copy = new double[values.Length];
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var value = values[i];
+
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                throw new ArgumentException("Bounding box coordinates must be finite numbers.", nameof(values));
+            }
+
+            copy[i] = value;
+        }
+
+        ValidateExtents(copy);
+
+        return new BoundingBox(copy);
+    }
+
+    /// <summary>
+    /// Creates a two-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From2D(double minX, double minY, double maxX, double maxY)
+    {
+        return Create(new[] { minX, minY, maxX, maxY });
+    }
+
+    /// <summary>
+    /// Creates a three-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From3D(double minX, double minY, double minZ, double maxX, double maxY, double maxZ)
+    {
+        return Create(new[] { minX, minY, minZ, maxX, maxY, maxZ });
+    }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions represented by the box.
+    /// </summary>
+    public int Dimensions => _values.Length / 2;
+
+    /// <summary>
+    /// Gets a value indicating whether the bounding box captures three dimensions.
+    /// </summary>
+    public bool Is3D => Dimensions == 3;
+
+    /// <summary>
+    /// Gets the minimum X value.
+    /// </summary>
+    public double MinX => _values[0];
+
+    /// <summary>
+    /// Gets the minimum Y value.
+    /// </summary>
+    public double MinY => _values[1];
+
+    /// <summary>
+    /// Gets the minimum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MinZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[2];
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum X value.
+    /// </summary>
+    public double MaxX => _values[Dimensions == 2 ? 2 : 3];
+
+    /// <summary>
+    /// Gets the maximum Y value.
+    /// </summary>
+    public double MaxY => _values[Dimensions == 2 ? 3 : 4];
+
+    /// <summary>
+    /// Gets the maximum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MaxZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[5];
+        }
+    }
+
+    /// <summary>
+    /// Returns the raw coordinate values that describe the box.
+    /// </summary>
+    public ReadOnlySpan<double> GetValues()
+    {
+        return _values;
+    }
+
+    /// <summary>
+    /// Copies the coordinate values into a new array.
+    /// </summary>
+    public double[] ToArray()
+    {
+        var copy = new double[_values.Length];
+        Array.Copy(_values, copy, _values.Length);
+        return copy;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(BoundingBox other)
+    {
+        if (Dimensions != other.Dimensions)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _values.Length; i++)
+        {
+            if (!_values[i].Equals(other._values[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is BoundingBox box && Equals(box);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Dimensions;
+
+            for (var i = 0; i < _values.Length; i++)
+            {
+                hash = (hash * 397) ^ _values[i].GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{string.Join(", ", _values.Select(value => value.ToString(CultureInfo.InvariantCulture)))}]";
+    }
+
+    public static bool operator ==(BoundingBox left, BoundingBox right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(BoundingBox left, BoundingBox right)
+    {
+        return !left.Equals(right);
+    }
+
+    private static void ValidateExtents(IReadOnlyList<double> values)
+    {
+        if (values.Count == 4)
+        {
+            ValidateAxis(values[0], values[2], "X");
+            ValidateAxis(values[1], values[3], "Y");
+            return;
+        }
+
+        ValidateAxis(values[0], values[3], "X");
+        ValidateAxis(values[1], values[4], "Y");
+        ValidateAxis(values[2], values[5], "Z");
+    }
+
+    private static void ValidateAxis(double min, double max, string axis)
+    {
+        if (max < min)
+        {
+            throw new ArgumentException($"The maximum {axis} value must be greater than or equal to the minimum value.");
+        }
+    }
+
+    private void EnsureThreeDimensions()
+    {
+        if (!Is3D)
+        {
+            throw new InvalidOperationException("The bounding box does not define a Z axis.");
+        }
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a geographic coordinate using longitude and latitude expressed in decimal degrees.
+/// </summary>
+public readonly struct GeoPoint : IEquatable<GeoPoint>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint"/> struct.
+    /// </summary>
+    /// <param name="longitude">The longitude component in decimal degrees.</param>
+    /// <param name="latitude">The latitude component in decimal degrees.</param>
+    /// <exception cref="ArgumentException">Thrown when either coordinate is not a finite number.</exception>
+    public GeoPoint(double longitude, double latitude)
+    {
+        if (double.IsNaN(longitude) || double.IsInfinity(longitude))
+        {
+            throw new ArgumentException("Longitude must be a finite number.", nameof(longitude));
+        }
+
+        if (double.IsNaN(latitude) || double.IsInfinity(latitude))
+        {
+            throw new ArgumentException("Latitude must be a finite number.", nameof(latitude));
+        }
+
+        Longitude = longitude;
+        Latitude = latitude;
+    }
+
+    /// <summary>
+    /// Gets the longitude component in decimal degrees where positive values indicate east.
+    /// </summary>
+    public double Longitude { get; }
+
+    /// <summary>
+    /// Gets the latitude component in decimal degrees where positive values indicate north.
+    /// </summary>
+    public double Latitude { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint other)
+    {
+        return Longitude.Equals(other.Longitude) && Latitude.Equals(other.Latitude);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Longitude.GetHashCode();
+            hash = (hash * 397) ^ Latitude.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1})", Longitude, Latitude);
+    }
+
+    public static bool operator ==(GeoPoint left, GeoPoint right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint left, GeoPoint right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
@@ -1,0 +1,96 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a three-dimensional Cartesian coordinate.
+/// </summary>
+public readonly struct GeoPoint3D : IEquatable<GeoPoint3D>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint3D"/> struct.
+    /// </summary>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
+    /// <param name="z">The Z component.</param>
+    /// <exception cref="ArgumentException">Thrown when any component is not a finite number.</exception>
+    public GeoPoint3D(double x, double y, double z)
+    {
+        if (double.IsNaN(x) || double.IsInfinity(x))
+        {
+            throw new ArgumentException("X must be a finite number.", nameof(x));
+        }
+
+        if (double.IsNaN(y) || double.IsInfinity(y))
+        {
+            throw new ArgumentException("Y must be a finite number.", nameof(y));
+        }
+
+        if (double.IsNaN(z) || double.IsInfinity(z))
+        {
+            throw new ArgumentException("Z must be a finite number.", nameof(z));
+        }
+
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    /// <summary>
+    /// Gets the X component of the coordinate.
+    /// </summary>
+    public double X { get; }
+
+    /// <summary>
+    /// Gets the Y component of the coordinate.
+    /// </summary>
+    public double Y { get; }
+
+    /// <summary>
+    /// Gets the Z component of the coordinate.
+    /// </summary>
+    public double Z { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint3D other)
+    {
+        return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint3D point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = X.GetHashCode();
+            hash = (hash * 397) ^ Y.GetHashCode();
+            hash = (hash * 397) ^ Z.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1}, {2})", X, Y, Z);
+    }
+
+    public static bool operator ==(GeoPoint3D left, GeoPoint3D right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint3D left, GeoPoint3D right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides the ability to encode coordinates into spatial index values and derive coarse coverings.
+/// </summary>
+public interface ISpatialIndexEncoder
+{
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the encoder.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the number of precision bits allocated per axis.
+    /// </summary>
+    int PrecisionBits { get; }
+
+    /// <summary>
+    /// Encodes the provided coordinate tuple into a sortable spatial index value.
+    /// </summary>
+    /// <param name="coordinates">The coordinate tuple. The span length must match <see cref="Dimensions"/>.</param>
+    /// <returns>The encoded index value.</returns>
+    ulong Encode(ReadOnlySpan<double> coordinates);
+
+    /// <summary>
+    /// Produces a set of index ranges that cover the provided bounding box.
+    /// </summary>
+    /// <param name="bounds">The bounding box to cover.</param>
+    /// <param name="maxCells">The maximum number of ranges the caller is willing to accept.</param>
+    /// <returns>A collection of closed index ranges ordered from lowest to highest.</returns>
+    IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells);
+}

--- a/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
@@ -1,0 +1,292 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Encodes normalized coordinates into Morton (Z-order) keys for use as spatial indexes.
+/// </summary>
+public sealed class MortonIndexEncoder : ISpatialIndexEncoder
+{
+    private readonly int _dimensions;
+    private readonly int _precisionBits;
+    private readonly ulong _maxCoordinateValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MortonIndexEncoder"/> class.
+    /// </summary>
+    /// <param name="dimensions">Number of spatial dimensions supported by the encoder.</param>
+    /// <param name="precisionBits">Number of bits allocated to each axis. Defaults to 32.</param>
+    public MortonIndexEncoder(int dimensions, int precisionBits = 32)
+    {
+        if (dimensions is < 1 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Morton encoding supports between one and three dimensions.");
+        }
+
+        if (precisionBits <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be a positive number of bits.");
+        }
+
+        if ((long)dimensions * precisionBits > 63)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "The chosen dimensionality and precision exceed the 64-bit Morton key capacity.");
+        }
+
+        _dimensions = dimensions;
+        _precisionBits = precisionBits;
+        _maxCoordinateValue = (1UL << precisionBits) - 1UL;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions => _dimensions;
+
+    /// <inheritdoc />
+    public int PrecisionBits => _precisionBits;
+
+    /// <inheritdoc />
+    public ulong Encode(ReadOnlySpan<double> coordinates)
+    {
+        if (coordinates.Length != _dimensions)
+        {
+            throw new ArgumentException($"Expected {_dimensions} coordinates but received {coordinates.Length}.", nameof(coordinates));
+        }
+
+        Span<ulong> quantized = stackalloc ulong[_dimensions];
+
+        for (var i = 0; i < _dimensions; i++)
+        {
+            quantized[i] = Quantize(coordinates[i]);
+        }
+
+        return EncodeQuantized(quantized);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells)
+    {
+        if (bounds.Dimensions != _dimensions)
+        {
+            throw new ArgumentException($"Bounding box dimensionality ({bounds.Dimensions}) does not match encoder dimensionality ({_dimensions}).", nameof(bounds));
+        }
+
+        if (maxCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCells), "The maximum number of covering cells must be positive.");
+        }
+
+        var values = bounds.GetValues();
+        var min = new ulong[_dimensions];
+        var max = new ulong[_dimensions];
+
+        for (var axis = 0; axis < _dimensions; axis++)
+        {
+            min[axis] = Quantize(values[axis]);
+            max[axis] = Quantize(values[axis + _dimensions]);
+
+            if (max[axis] < min[axis])
+            {
+                throw new ArgumentException("Bounding box maximum must be greater than or equal to the minimum on every axis.", nameof(bounds));
+            }
+        }
+
+        var ranges = new List<SpatialIndexRange>();
+
+        var cellSizeShift = DetermineCellShift(min.AsSpan(), max.AsSpan(), maxCells);
+        var cellSize = 1UL << cellSizeShift;
+        var upperBound = _maxCoordinateValue;
+
+        var cursor = new ulong[_dimensions];
+        var cellMax = new ulong[_dimensions];
+
+        void Enumerate(int axis)
+        {
+            if (axis == _dimensions)
+            {
+                for (var i = 0; i < _dimensions; i++)
+                {
+                    var end = cursor[i] + cellSize - 1UL;
+                    cellMax[i] = end > upperBound ? upperBound : end;
+                }
+
+                var startCode = EncodeQuantized(cursor);
+                var endCode = EncodeQuantized(cellMax);
+                ranges.Add(new SpatialIndexRange(startCode, endCode));
+                return;
+            }
+
+            var axisMin = AlignDown(min[axis], cellSize);
+            var axisMax = AlignUp(max[axis], cellSize, upperBound);
+
+            for (var value = axisMin; value <= axisMax; value += cellSize)
+            {
+                cursor[axis] = value;
+                Enumerate(axis + 1);
+            }
+        }
+
+        Enumerate(0);
+
+        return MergeAdjacentRanges(ranges);
+    }
+
+    /// <summary>
+    /// Coalesces adjacent or overlapping ranges into a minimal set of disjoint ranges.
+    /// </summary>
+    /// <param name="ranges">The input ranges, which may be unsorted.</param>
+    /// <returns>A sorted list of non-overlapping ranges.</returns>
+    public static IReadOnlyList<SpatialIndexRange> MergeAdjacentRanges(IEnumerable<SpatialIndexRange> ranges)
+    {
+        if (ranges is null)
+        {
+            throw new ArgumentNullException(nameof(ranges));
+        }
+
+        var ordered = ranges.OrderBy(static r => r.Start).ThenBy(static r => r.End).ToArray();
+
+        if (ordered.Length == 0)
+        {
+            return Array.Empty<SpatialIndexRange>();
+        }
+
+        var result = new List<SpatialIndexRange>(ordered.Length);
+        var current = ordered[0];
+
+        for (var i = 1; i < ordered.Length; i++)
+        {
+            var next = ordered[i];
+
+            if (next.Start <= current.End + 1)
+            {
+                var mergedEnd = next.End > current.End ? next.End : current.End;
+                current = new SpatialIndexRange(current.Start, mergedEnd);
+                continue;
+            }
+
+            result.Add(current);
+            current = next;
+        }
+
+        result.Add(current);
+        return result;
+    }
+
+    private int DetermineCellShift(ReadOnlySpan<ulong> min, ReadOnlySpan<ulong> max, int maxCells)
+    {
+        var shift = 0;
+
+        while (shift < _precisionBits)
+        {
+            var cells = 1UL;
+
+            for (var axis = 0; axis < _dimensions; axis++)
+            {
+                var span = AlignUp(max[axis], 1UL << shift, _maxCoordinateValue) - AlignDown(min[axis], 1UL << shift) + 1UL;
+                var axisCells = span / (1UL << shift);
+
+                if (axisCells == 0)
+                {
+                    axisCells = 1;
+                }
+
+                cells *= axisCells;
+
+                if (cells > (ulong)maxCells)
+                {
+                    break;
+                }
+            }
+
+            if (cells <= (ulong)maxCells)
+            {
+                return shift;
+            }
+
+            shift++;
+        }
+
+        return _precisionBits;
+    }
+
+    private ulong EncodeQuantized(ReadOnlySpan<ulong> coordinates)
+    {
+        ulong result = 0;
+
+        for (var bit = 0; bit < _precisionBits; bit++)
+        {
+            for (var axis = 0; axis < _dimensions; axis++)
+            {
+                var bitValue = (coordinates[axis] >> bit) & 1UL;
+                if (bitValue == 0)
+                {
+                    continue;
+                }
+
+                var shift = bit * _dimensions + axis;
+                result |= bitValue << shift;
+            }
+        }
+
+        return result;
+    }
+
+    private ulong Quantize(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Coordinate values must be finite numbers.", nameof(value));
+        }
+
+        var clamped = value;
+
+        if (clamped < 0d)
+        {
+            clamped = 0d;
+        }
+        else if (clamped > 1d)
+        {
+            clamped = 1d;
+        }
+
+        var scaled = clamped * _maxCoordinateValue;
+        var quantized = (ulong)Math.Round(scaled, MidpointRounding.AwayFromZero);
+
+        if (quantized > _maxCoordinateValue)
+        {
+            quantized = _maxCoordinateValue;
+        }
+
+        return quantized;
+    }
+
+    private static ulong AlignDown(ulong value, ulong cellSize)
+    {
+        if (cellSize <= 1)
+        {
+            return value;
+        }
+
+        return (value / cellSize) * cellSize;
+    }
+
+    private static ulong AlignUp(ulong value, ulong cellSize, ulong maximum)
+    {
+        if (cellSize <= 1)
+        {
+            return value;
+        }
+
+        var remainder = value % cellSize;
+        if (remainder == cellSize - 1)
+        {
+            return value;
+        }
+
+        var adjusted = value + (cellSize - 1 - remainder);
+        return adjusted > maximum ? maximum : adjusted;
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
+++ b/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
@@ -1,0 +1,76 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a closed range of spatial index values.
+/// </summary>
+public readonly struct SpatialIndexRange : IEquatable<SpatialIndexRange>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexRange"/> struct.
+    /// </summary>
+    /// <param name="start">The inclusive start of the range.</param>
+    /// <param name="end">The inclusive end of the range.</param>
+    public SpatialIndexRange(ulong start, ulong end)
+    {
+        if (end < start)
+        {
+            throw new ArgumentOutOfRangeException(nameof(end), "The end of the range must be greater than or equal to the start.");
+        }
+
+        Start = start;
+        End = end;
+    }
+
+    /// <summary>
+    /// Gets the inclusive start of the range.
+    /// </summary>
+    public ulong Start { get; }
+
+    /// <summary>
+    /// Gets the inclusive end of the range.
+    /// </summary>
+    public ulong End { get; }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexRange other)
+    {
+        return Start == other.Start && End == other.End;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexRange range && Equals(range);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Start.GetHashCode();
+            hash = (hash * 397) ^ End.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{Start}, {End}]";
+    }
+
+    public static bool operator ==(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides LINQ-friendly spatial helpers. These methods are intended to be used within expression trees
+/// and will be translated by <see cref="SpatialResolver"/> into engine-specific query plans.
+/// </summary>
+public static class SpatialExpressions
+{
+    /// <summary>
+    /// Placeholder for a query that selects points near a geographic center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint candidate, GeoPoint center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points near a three-dimensional center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint3D candidate, GeoPoint3D center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects three-dimensional points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint3D candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    private static InvalidOperationException CreateUsageException()
+    {
+        return new InvalidOperationException("SpatialExpressions are intended for use within LINQ expressions and should not be executed directly.");
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System.Linq.Expressions;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Translates method calls that originate from <see cref="SpatialExpressions"/> into spatial query plans.
+/// </summary>
+public sealed class SpatialResolver
+{
+    /// <summary>
+    /// Attempts to translate the provided method call expression into a spatial query plan.
+    /// </summary>
+    /// <param name="expression">The method call expression extracted from a LINQ query.</param>
+    /// <param name="plan">When this method returns, contains the resulting query plan if translation succeeded.</param>
+    /// <returns><c>true</c> when translation succeeded; otherwise, <c>false</c>.</returns>
+    public bool TryResolve(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        plan = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
+++ b/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Core</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Core.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>litedb</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core/Metadata/SpatialCollectionDescriptor.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialCollectionDescriptor.cs
@@ -1,0 +1,157 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents the spatial capabilities configured for a collection.
+/// </summary>
+public sealed class SpatialCollectionDescriptor : IEquatable<SpatialCollectionDescriptor>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialCollectionDescriptor"/> class.
+    /// </summary>
+    /// <param name="collectionName">Name of the collection the descriptor applies to.</param>
+    /// <param name="engineName">The logical engine name associated with the collection.</param>
+    /// <param name="dimensions">Number of spatial dimensions encoded by the engine.</param>
+    /// <param name="geometryFieldName">The document field that stores the spatial value.</param>
+    /// <param name="options">Options controlling index persistence and query planning.</param>
+    /// <param name="engine">Optional resolved engine instance for runtime operations.</param>
+    public SpatialCollectionDescriptor(
+        string collectionName,
+        string engineName,
+        int dimensions,
+        string geometryFieldName,
+        SpatialIndexOptions options,
+        ISpatialEngine? engine = null)
+    {
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name cannot be null or whitespace.", nameof(collectionName));
+        }
+
+        if (string.IsNullOrWhiteSpace(engineName))
+        {
+            throw new ArgumentException("Engine name cannot be null or whitespace.", nameof(engineName));
+        }
+
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial collections must be two or three dimensional.");
+        }
+
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name cannot be null or whitespace.", nameof(geometryFieldName));
+        }
+
+        CollectionName = collectionName;
+        EngineName = engineName;
+        Dimensions = dimensions;
+        GeometryFieldName = geometryFieldName;
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+        Engine = engine;
+    }
+
+    /// <summary>
+    /// Gets the collection name associated with the descriptor.
+    /// </summary>
+    public string CollectionName { get; }
+
+    /// <summary>
+    /// Gets the logical engine identifier.
+    /// </summary>
+    public string EngineName { get; }
+
+    /// <summary>
+    /// Gets the number of dimensions supported by the collection.
+    /// </summary>
+    public int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the field containing the spatial value.
+    /// </summary>
+    public string GeometryFieldName { get; }
+
+    /// <summary>
+    /// Gets the options governing index persistence.
+    /// </summary>
+    public SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Gets the runtime engine instance when resolved.
+    /// </summary>
+    public ISpatialEngine? Engine { get; }
+
+    /// <summary>
+    /// Gets the expected number of entries within the stored bounding box.
+    /// </summary>
+    public int ExpectedBoundingBoxLength => Dimensions * 2;
+
+    /// <summary>
+    /// Returns a new descriptor with the provided engine instance attached.
+    /// </summary>
+    /// <param name="engine">The resolved engine.</param>
+    /// <returns>A descriptor that references the supplied engine.</returns>
+    public SpatialCollectionDescriptor WithEngine(ISpatialEngine engine)
+    {
+        if (engine is null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        if (engine.Dimensions != Dimensions)
+        {
+            throw new ArgumentException("Engine dimensionality does not match the descriptor.", nameof(engine));
+        }
+
+        if (!string.Equals(engine.Name, EngineName, StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Engine name does not match the descriptor metadata.", nameof(engine));
+        }
+
+        return new SpatialCollectionDescriptor(CollectionName, EngineName, Dimensions, GeometryFieldName, Options, engine);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialCollectionDescriptor? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return string.Equals(CollectionName, other.CollectionName, StringComparison.Ordinal)
+            && string.Equals(EngineName, other.EngineName, StringComparison.Ordinal)
+            && Dimensions == other.Dimensions
+            && string.Equals(GeometryFieldName, other.GeometryFieldName, StringComparison.Ordinal)
+            && Options.Equals(other.Options);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialCollectionDescriptor descriptor && Equals(descriptor);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = StringComparer.Ordinal.GetHashCode(CollectionName);
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(EngineName);
+            hash = (hash * 397) ^ Dimensions;
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(GeometryFieldName);
+            hash = (hash * 397) ^ Options.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Collection=\"{CollectionName}\", Engine=\"{EngineName}\", Dimensions={Dimensions}, Field=\"{GeometryFieldName}\", Options={Options}";
+    }
+}

--- a/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
@@ -1,0 +1,161 @@
+#nullable enable
+
+extern alias litedb;
+
+using System;
+using litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Persists spatial configuration descriptors inside a dedicated metadata collection.
+/// </summary>
+public sealed class SpatialMetadataStore
+{
+    /// <summary>
+    /// Gets the name of the collection that stores spatial metadata.
+    /// </summary>
+    public const string MetadataCollectionName = "_spatial_meta";
+
+    private readonly ILiteCollection<BsonDocument> _collection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialMetadataStore"/> class.
+    /// </summary>
+    /// <param name="database">The database used to persist metadata.</param>
+    public SpatialMetadataStore(ILiteDatabase database)
+    {
+        if (database is null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        _collection = database.GetCollection<BsonDocument>(MetadataCollectionName);
+    }
+
+    /// <summary>
+    /// Persists the provided descriptor and returns the stored value.
+    /// </summary>
+    public SpatialCollectionDescriptor UpsertDescriptor(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        var document = Serialize(descriptor);
+        _collection.Upsert(document);
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Attempts to locate spatial metadata for the specified collection.
+    /// </summary>
+    public SpatialCollectionDescriptor? TryGetDescriptor(string collectionName)
+    {
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name cannot be null or whitespace.", nameof(collectionName));
+        }
+
+        var document = _collection.FindById(collectionName);
+        return document is null ? null : Deserialize(document);
+    }
+
+    /// <summary>
+    /// Retrieves the descriptor for the provided collection or throws a descriptive error.
+    /// </summary>
+    public SpatialCollectionDescriptor GetRequiredDescriptor(string collectionName)
+    {
+        var descriptor = TryGetDescriptor(collectionName);
+        if (descriptor is null)
+        {
+            throw new InvalidOperationException($"Spatial metadata for collection \"{collectionName}\" was not found. Configure an engine using Spatial.UseGeographic(...) or the appropriate helper for your engine.");
+        }
+
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Ensures that the stored metadata remains compatible with the provided document.
+    /// </summary>
+    public void ValidateDocument(SpatialCollectionDescriptor descriptor, BsonDocument document)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (document is null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(descriptor.Options.BoundingBoxFieldName, out var boundingValue) || boundingValue.IsNull)
+        {
+            return;
+        }
+
+        if (boundingValue.Type != BsonType.Array)
+        {
+            throw new InvalidOperationException($"The bounding box field \"{descriptor.Options.BoundingBoxFieldName}\" must be stored as an array.");
+        }
+
+        var array = boundingValue.AsArray;
+        if (array.Count != descriptor.ExpectedBoundingBoxLength)
+        {
+            throw new InvalidOperationException($"Spatial metadata for collection \"{descriptor.CollectionName}\" declares {descriptor.Dimensions} dimensions but found {array.Count} values within \"{descriptor.Options.BoundingBoxFieldName}\".");
+        }
+
+        if (document.TryGetValue(descriptor.Options.IndexFieldName, out var indexValue) && !indexValue.IsNull)
+        {
+            if (!indexValue.IsInt64 && !indexValue.IsInt32)
+            {
+                throw new InvalidOperationException($"The index field \"{descriptor.Options.IndexFieldName}\" must be a 64-bit integer value.");
+            }
+        }
+    }
+
+    private static BsonDocument Serialize(SpatialCollectionDescriptor descriptor)
+    {
+        return new BsonDocument
+        {
+            ["_id"] = descriptor.CollectionName,
+            ["collection"] = descriptor.CollectionName,
+            ["engine"] = descriptor.EngineName,
+            ["dimensions"] = descriptor.Dimensions,
+            ["geometryField"] = descriptor.GeometryFieldName,
+            ["options"] = SerializeOptions(descriptor.Options)
+        };
+    }
+
+    private static BsonDocument SerializeOptions(SpatialIndexOptions options)
+    {
+        return new BsonDocument
+        {
+            ["precisionBits"] = options.PrecisionBits,
+            ["maxCells"] = options.MaxCoveringCells,
+            ["tolerance"] = options.DistanceTolerance,
+            ["indexField"] = options.IndexFieldName,
+            ["boundingField"] = options.BoundingBoxFieldName
+        };
+    }
+
+    private static SpatialCollectionDescriptor Deserialize(BsonDocument document)
+    {
+        var collectionName = document["collection"].AsString;
+        var engineName = document["engine"].AsString;
+        var dimensions = document["dimensions"].AsInt32;
+        var geometryField = document["geometryField"].AsString;
+        var optionsDocument = document["options"].AsDocument;
+
+        var options = new SpatialIndexOptions(
+            precisionBits: optionsDocument["precisionBits"].AsInt32,
+            maxCoveringCells: optionsDocument["maxCells"].AsInt32,
+            distanceTolerance: optionsDocument["tolerance"].AsDouble,
+            indexFieldName: optionsDocument["indexField"].AsString,
+            boundingBoxFieldName: optionsDocument["boundingField"].AsString);
+
+        return new SpatialCollectionDescriptor(collectionName, engineName, dimensions, geometryField, options);
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -40,6 +40,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.ReproRunner.Shared",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedMutexHarness", "LiteDB.Tests.SharedMutexHarness\SharedMutexHarness.csproj", "{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core", "LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj", "{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core.Tests", "LiteDB.Spatial.Core.Tests\LiteDB.Spatial.Core.Tests.csproj", "{99F2946D-65FB-4FC8-827D-C3241FB5EF93}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +162,30 @@ Global
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x64.Build.0 = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.ActiveCfg = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -1,0 +1,284 @@
+# Epic: Modular Spatial Revamp (2D Geographic, 2D Cartesian, 3D Cartesian)
+
+## Goals (scope)
+
+- Extract an engine-agnostic core (`LiteDB.Spatial.Core`).
+- Add engines:
+  - `LiteDB.Spatial.Geographic` (2D, WGS84, meters).
+  - `LiteDB.Spatial.Cartesian2D` (flat 2D).
+  - `LiteDB.Spatial.Cartesian3D` (flat 3D points).
+- Standardize internal fields:
+  - `_idx` — numeric index key (Morton/Hilbert later).
+  - `_mbb` — bounding box (4 or 6 values).
+- Keep LINQ-friendly API with index-aware query plans.
+- Provide backfill + deterministic metadata per collection.
+- Ship diagnostics ("explain") and a minimum GeoJSON I/O.
+- Preserve backward compatibility as much as possible.
+
+## Non-Goals (for now)
+
+- 3D meshes/polyhedra predicates.
+- Advanced projections/CRS transforms beyond WGS84.
+- Alternate encoders beyond Morton (scaffold only).
+
+---
+
+## Architecture overview (target)
+
+```
+LiteDB.Spatial.Core
+  Geometry, Engine contracts, LINQ resolver, Metadata, Backfill
+
+LiteDB.Spatial.Indexing
+  MortonIndexEncoder (2D/3D), Hilbert (stub)
+
+LiteDB.Spatial.Geographic
+  GeographicEngine (2D), Haversine/Vincenty, wrap/polar helpers, facade
+
+LiteDB.Spatial.Cartesian2D
+  Cartesian2DEngine, Euclidean2D, facade
+
+LiteDB.Spatial.Cartesian3D
+  Cartesian3DEngine, Euclidean3D, facade
+
+LiteDB.Spatial.Diagnostics
+  Explain(plan) utilities
+
+LiteDB.Spatial.GeoJson
+  Basic GeoJSON serializer
+
+LiteDB.Spatial
+  Top-level facade (dispatch by collection metadata)
+```
+
+---
+
+## Stories & Acceptance Criteria
+
+### S1 — Core contracts & geometry (engine-agnostic)
+
+- [x] Add `GeoPoint`, `GeoPoint3D`, `BoundingBox` (2D: 4 elems; 3D: 6 elems).
+- [x] Define interfaces: `ISpatialEngine`, `ISpatialIndexEncoder`, `ISpatialDistance`, `ISpatialMapper`, `ISpatialQueryPlan`.
+- [x] Core options: `SpatialIndexOptions` (precision, max cells, tolerance, field names).
+- [x] LINQ surface: `SpatialExpressions` (Near/InBox overloads for 2D/3D).
+- [x] Stub `SpatialResolver` for expression translation.
+
+### S2 — Indexing: Morton encoder (2D/3D)
+
+- [x] Implement `MortonIndexEncoder(int dimensions)` with bit-interleaving and helpers.
+- [x] Provide helper to union adjacent ranges for nicer covers.
+  - Encodes normalized coordinates for 2D and 3D collections with automatic quantization limits.
+  - Adaptive covering logic coalesces Morton ranges while respecting `MaxCoveringCells`.
+
+### S3 — Metadata store & schema conventions
+
+- [x] `SpatialMetadataStore` persists per-collection descriptor `{ engine, dimensions, options }` in `"_spatial_meta"`.
+- [x] Internal field names customizable via options but default to `_idx` and `_mbb`.
+- [x] Guard mismatches and surface friendly errors.
+  - Descriptors capture engine name, dimensionality, geometry field, and materialized options.
+  - Validator checks index type and bounding-box length, hinting at misconfigured collections.
+
+### S4 — Backfill utility
+
+- [x] `SpatialBackfill.Run<T>(collection, descriptor, batchSize)` populates `_idx`/`_mbb`.
+- [x] Ensure idempotent behavior with detailed counters and error reporting.
+  - Engine-provided mappers hydrate coordinates and compute Morton keys + bounding boxes.
+  - Batched updates track updated/skipped/error counts and expose the latest checkpoint.
+
+### S5 — Geographic engine (2D)
+
+- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+
+### S6 — Cartesian 2D engine
+
+- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+
+### S7 — Cartesian 3D engine (points)
+
+- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+
+### S8 — LINQ resolver
+
+- [ ] Translate `SpatialExpressions` into query plans based on metadata.
+
+### S9 — Diagnostics ("Explain")
+
+- [ ] Produce printable `SpatialExplainResult` summaries for query plans.
+
+### S10 — GeoJSON I/O (minimal)
+
+- [ ] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
+
+### S11 — Top-level facade & dispatch
+
+- [ ] `LiteDB.Spatial.Spatial` entry point manages engine configuration and dispatch.
+
+### S12 — Migration & docs
+
+- [ ] Author upgrade/guide/diagnostics documentation with samples.
+
+### S13 — Benchmarks & regression guardrails
+
+- [ ] Capture performance baselines and add regression guardrails.
+
+---
+
+## Backward Compatibility & Risk Mitigation
+
+- **Internal field rename**: standardize on `_idx` (previously `_gh`). Keep `_gh` reading optional if present (migration path), but **do not** write new `_gh`. Provide backfill to `_idx`.
+- **Engine selection**: no global singletons; bind per collection via metadata to avoid cross-collection leakage.
+- **Precision in 3D**: document that 3D needs higher `PrecisionBits` for similar spatial locality; default +4 vs 2D.
+- **Range explosion**: cap by `MaxCoveringCells`; if exceeded, coarsen ranges and rely on exact filters (documented behavior).
+
+---
+
+## Public API sketch (stable surface)
+
+```csharp
+// Top-level
+Spatial.UseGeographic(col, new GeographicOptions { PrecisionBits = 32 });
+Spatial.EnsurePointIndex(col, x => x.Location); // GeoPoint
+var near = Spatial.Near(col, x => x.Location, new GeoPoint(lon, lat), radius: 1500).ToList();
+
+Spatial.UseCartesian2D(col2, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col2, x => x.Pos2D); // GeoPoint
+var inBox = Spatial.WithinBoundingBox(col2, x => x.Pos2D, BoundingBox.From2D(0,0,10,10)).ToList();
+
+Spatial.UseCartesian3D(col3, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col3, x => x.Pos3D); // GeoPoint3D
+var hits = Spatial.Near(col3, x => x.Pos3D, new GeoPoint3D(1,2,3), radius: 5).ToList();
+```
+
+---
+
+## Test Matrix (minimum)
+
+- **Core**: BoundingBox dims, options defaults, metadata round-trip.
+- **Indexing**: Morton 2D/3D grids + boundaries.
+- **Geographic**: Near Berlin; anti-meridian bbox; polar bbox.
+- **Cartesian2D**: Near/InBox on grid; candidate pruning verified.
+- **Cartesian3D**: Near3D + AABB on 3D lattice; MaxCoveringCells respected.
+- **LINQ**: Expression translation picks correct engine; index predicate present.
+- **Backfill**: idempotency; mixed docs with/without fields.
+- **Diagnostics**: explain outputs consistent and human-readable.
+
+---
+
+## Deliverables checklist (per PR)
+
+- [ ] Code compiles, no public API breaking changes outside the new surface.
+- [ ] Unit + integration tests green.
+- [ ] Samples updated.
+- [ ] Docs updated (guide/upgrade/diagnostics).
+- [ ] Bench baseline captured.
+- [ ] Changelog entry with migration notes (`_gh` → `_idx`).
+
+---
+
+## Rollout plan
+
+1. Merge Core + Indexing + Geographic (smallest behavior delta).
+2. Introduce Cartesian2D (flat replacement for non-Earth use).
+3. Add Cartesian3D (points + AABB + Near3D).
+4. Enable LINQ resolver by default; keep a feature flag to disable if needed.
+5. Publish docs and a sample upgrade script demonstrating backfill.
+
+---
+
+## Addendum: Battle-Tested Oracles & Datasets
+
+### Reference libraries (use as **oracles**, not dependencies of runtime)
+
+- **Geometry predicates (2D):** `NetTopologySuite (NTS)` — robust predicates: `Contains`, `Intersects`, `Within`, polygon holes/edge cases.
+- **Geodesic distances (Earth):** `GeographicLib` — great-circle, inverse geodesic; use as golden values.
+- **Projections / CRS transforms (optional sanity):** `ProjNET` — to cross-check lon/lat ↔ projected calculations for small-radius approximations.
+- **3D math:** `MathNet.Spatial` — Euclidean 3D distances and vector ops for oracle checks.
+- **GeoJSON parsing (test-only):** `GeoJSON.Net` — load complex fixtures without maintaining your own parser.
+- **External systems for differential tests (CI optional):** `PostGIS`, `SQLite+RTree/SpatiaLite` for bbox/near behavior.
+
+### Public datasets & fixtures
+
+- `Turf.js` fixtures (GeoJSON): points/lines/polygons with holes; great for predicate parity.
+- `Natural Earth`: coastlines, large polygons crossing the anti-meridian (Aleutians, Russia); polar stress.
+- `OSM` extracts (tiny tiles): dense urban point clouds for performance & correctness mixes.
+- Synthetic grids & lattices: controlled point sets for Morton/Hilbert locality tests.
+- Precomputed geodesic pairs from GeographicLib samples (save as JSON with expected distances).
+
+### New Stories (append to Epic)
+
+#### T1 — Oracle Adapters
+
+- [ ] Add `LiteDB.Spatial.Testing.Oracles` project with adapters for NTS, GeographicLib, MathNet, PostGIS.
+
+#### T2 — Golden Fixtures & Tolerances
+
+- [ ] Store fixtures under `/tests/fixtures` with documented tolerances and snapshot helpers.
+
+#### T3 — Differential Correctness: Geographic 2D
+
+- [ ] Cross-check `SpatialGeographic` behavior against PostGIS and GeographicLib oracles.
+
+#### T4 — Differential Correctness: Cartesian 2D
+
+- [ ] Validate Euclidean behavior with NTS and property-based testing.
+
+#### T5 — Differential Correctness: Cartesian 3D
+
+- [ ] Ensure 3D results align with MathNet.Spatial and range caps.
+
+#### T6 — Index Locality & Stability (Morton)
+
+- [ ] Measure locality/monotonicity and compare to reference encoders.
+
+#### T7 — Query Plan Parity (LINQ)
+
+- [ ] Assert LINQ plans use indexes and match oracles.
+
+#### T8 — Performance Sanity vs External Systems (optional `perf`)
+
+- [ ] Benchmark LiteDB.Spatial vs SQLite/PostGIS and record findings.
+
+---
+
+## Concrete snippets (test-only patterns)
+
+```csharp
+// Distance parity (Geographic)
+var d1 = GeographicLibOracle.Distance(lon1, lat1, lon2, lat2);
+var d2 = SpatialGeographicDistance.Haversine(lon1, lat1, lon2, lat2);
+d2.Should().BeApproximately(d1, 1e-4 * d1 + 0.05);
+```
+
+```csharp
+// Predicate parity (2D)
+var expected = NtsOracle.Contains(poly, pt);
+var actual = SpatialExpressions.Within(/* polygon */, /* point */);
+actual.Should().Be(expected);
+```
+
+```csharp
+// 3D near parity
+var dRef = MathNetOracle3D.Distance(a, b);
+var dOur = Euclidean3D.Distance(a, b);
+dOur.Should().BeApproximately(dRef, 1e-9);
+```
+
+---
+
+## Integration guidance
+
+- Keep external libraries under `tests` only and guard with categories/env vars.
+- Persist expensive oracle outputs to JSON fixtures for reproducible CI runs.
+- Document toggles like `SPATIAL_ORACLES` and `SPATIAL_DB_TESTS` for optional suites.
+
+---
+
+## Acceptance Criteria (global)
+
+- Geographic distances match GeographicLib within tolerance on 1,000 diverse pairs.
+- 2D predicates match NTS on 100 complex polygons × 1,000 random points each.
+- 3D distances match MathNet.Spatial within floating-point tolerance on 10,000 random pairs.
+- Index usage verified by explain output in every LINQ test; no full scans when index present.
+- Fixtures pack checked into the repo; tests avoid network calls.
+


### PR DESCRIPTION
## Summary
- implement a MortonIndexEncoder with quantization, coverage generation, and adjacent range coalescing for 2D/3D coordinates
- add spatial collection descriptors, a metadata store with validation, and alias the LiteDB reference to avoid type collisions
- introduce spatial backfill utilities plus mapper extraction APIs, new unit tests, and documentation updates for S2–S4

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e7407432f083268c81ccebffb8f4bb