### PR TITLE
Add indexing metadata and backfill infrastructure

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
@@ -1,0 +1,182 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using System.IO;
+
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using SpatialGeoPoint = LiteDB.Spatial.GeoPoint;
+using SpatialGeoPoint3D = LiteDB.Spatial.GeoPoint3D;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Backfill;
+
+public sealed class SpatialBackfillTests
+{
+    [Fact]
+    public void RunBackfillsMissingFieldsAndIsIdempotent()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("points");
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor("Stub2D", 2, new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 4));
+        var engine = new Stub2DEngine(descriptor.Options);
+
+        InsertPoint(collection, 1, 0.25, 0.75);
+        InsertPoint(collection, 2, 0.5, 0.5);
+
+        var first = LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, engine);
+
+        first.Processed.Should().Be(2);
+        first.Updated.Should().Be(2);
+        first.Skipped.Should().Be(0);
+        first.Errors.Should().BeEmpty();
+
+        var stored = collection.FindById(1);
+        ((object?)stored).Should().NotBeNull();
+        stored![descriptor.Options.IndexFieldName].Type.Should().Be(BaseLiteDB.BsonType.Decimal);
+        stored[descriptor.Options.BoundingBoxFieldName].AsArray.Count.Should().Be(4);
+
+        var second = LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, engine);
+        second.Processed.Should().Be(2);
+        second.Updated.Should().Be(0);
+        second.Skipped.Should().Be(2);
+    }
+
+    [Fact]
+    public void RunRecordsErrorsWithoutInterruptingOtherDocuments()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("points");
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor("Stub2D", 2, new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 4));
+        var engine = new Stub2DEngine(descriptor.Options);
+
+        InsertPoint(collection, 1, 0.1, 0.1);
+        collection.Insert(new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 2,
+            ["name"] = "missing-location"
+        });
+        InsertPoint(collection, 3, 0.9, 0.9);
+
+        var result = LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, engine);
+
+        result.Processed.Should().Be(3);
+        result.Updated.Should().Be(2);
+        result.Errors.Should().HaveCount(1);
+        result.Errors[0].DocumentId.Should().Be(new BaseLiteDB.BsonValue(2));
+    }
+
+    [Fact]
+    public void RunHonorsCheckpoint()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("points");
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor("Stub2D", 2, new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 4));
+        var engine = new Stub2DEngine(descriptor.Options);
+
+        InsertPoint(collection, 1, 0.0, 0.0);
+        InsertPoint(collection, 2, 0.25, 0.25);
+        InsertPoint(collection, 3, 0.5, 0.5);
+
+        var result = LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, engine, batchSize: 1, checkpoint: new BaseLiteDB.BsonValue(1));
+
+        result.Processed.Should().Be(2);
+        result.LastCheckpoint.Should().Be(new BaseLiteDB.BsonValue(3));
+        collection.FindById(1)!.ContainsKey(descriptor.Options.IndexFieldName).Should().BeFalse();
+        collection.FindById(2)![descriptor.Options.IndexFieldName].Type.Should().NotBe(BaseLiteDB.BsonType.Null);
+    }
+
+    private static void InsertPoint(BaseLiteDB.ILiteCollection<BaseLiteDB.BsonDocument> collection, int id, double x, double y)
+    {
+        collection.Insert(new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = id,
+            ["location"] = new BaseLiteDB.BsonDocument
+            {
+                ["x"] = x,
+                ["y"] = y
+            }
+        });
+    }
+
+    private sealed class Stub2DEngine : LiteDB.Spatial.ISpatialEngine
+    {
+        public Stub2DEngine(LiteDB.Spatial.SpatialIndexOptions options)
+        {
+            Options = options;
+            IndexEncoder = new LiteDB.Spatial.MortonIndexEncoder(2, options.PrecisionBits);
+            Mapper = new Stub2DMapper(IndexEncoder);
+            Distance = new StubDistance();
+        }
+
+        public string Name => "Stub2D";
+        public int Dimensions => 2;
+        public LiteDB.Spatial.SpatialIndexOptions Options { get; }
+        public LiteDB.Spatial.ISpatialIndexEncoder IndexEncoder { get; }
+        public LiteDB.Spatial.ISpatialMapper Mapper { get; }
+        public LiteDB.Spatial.ISpatialDistance Distance { get; }
+
+        public LiteDB.Spatial.ISpatialQueryPlan PlanNear(SpatialGeoPoint center, double radius) => throw new NotSupportedException();
+        public LiteDB.Spatial.ISpatialQueryPlan PlanNear(SpatialGeoPoint3D center, double radius) => throw new NotSupportedException();
+        public LiteDB.Spatial.ISpatialQueryPlan PlanWithin(LiteDB.Spatial.BoundingBox bounds) => throw new NotSupportedException();
+    }
+
+    private sealed class Stub2DMapper : LiteDB.Spatial.ISpatialMapper
+    {
+        private readonly LiteDB.Spatial.ISpatialIndexEncoder _encoder;
+        public Stub2DMapper(LiteDB.Spatial.ISpatialIndexEncoder encoder)
+        {
+            _encoder = encoder;
+        }
+
+        public LiteDB.Spatial.BoundingBox GetBoundingBox(SpatialGeoPoint point)
+        {
+            return LiteDB.Spatial.BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+        }
+
+        public LiteDB.Spatial.BoundingBox GetBoundingBox(SpatialGeoPoint3D point)
+        {
+            throw new NotSupportedException();
+        }
+
+        public ulong Encode(SpatialGeoPoint point)
+        {
+            Span<double> coordinates = stackalloc double[2];
+            coordinates[0] = point.Longitude;
+            coordinates[1] = point.Latitude;
+            return _encoder.Encode(coordinates);
+        }
+
+        public ulong Encode(SpatialGeoPoint3D point)
+        {
+            throw new NotSupportedException();
+        }
+
+        public bool TryReadPoint(BaseLiteDB.BsonDocument document, out SpatialGeoPoint point)
+        {
+            if (document.TryGetValue("location", out var value) && value.IsDocument)
+            {
+                var location = value.AsDocument;
+                point = new SpatialGeoPoint(location["x"].AsDouble, location["y"].AsDouble);
+                return true;
+            }
+
+            point = default;
+            return false;
+        }
+
+        public bool TryReadPoint(BaseLiteDB.BsonDocument document, out SpatialGeoPoint3D point)
+        {
+            point = default;
+            return false;
+        }
+    }
+
+    private sealed class StubDistance : ISpatialDistance
+    {
+        public double Distance(SpatialGeoPoint left, SpatialGeoPoint right) => 0d;
+        public double Distance(SpatialGeoPoint3D left, SpatialGeoPoint3D right) => 0d;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
@@ -1,0 +1,57 @@
+using System;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public class SpatialIndexOptionsTests
+{
+    [Fact]
+    public void SpatialIndexOptions_ShouldUseSensibleDefaults()
+    {
+        var options = new SpatialIndexOptions();
+
+        options.PrecisionBits.Should().Be(32);
+        options.MaxCoveringCells.Should().Be(64);
+        options.DistanceTolerance.Should().Be(0.001);
+        options.IndexFieldName.Should().Be(SpatialIndexOptions.DefaultIndexFieldName);
+        options.BoundingBoxFieldName.Should().Be(SpatialIndexOptions.DefaultBoundingBoxFieldName);
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_ShouldAllowCustomization()
+    {
+        var options = new SpatialIndexOptions(40, 128, 0.25, "_custom_idx", "_custom_mbb");
+
+        options.PrecisionBits.Should().Be(40);
+        options.MaxCoveringCells.Should().Be(128);
+        options.DistanceTolerance.Should().Be(0.25);
+        options.IndexFieldName.Should().Be("_custom_idx");
+        options.BoundingBoxFieldName.Should().Be("_custom_mbb");
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_With_ShouldCreateNewInstance()
+    {
+        var options = new SpatialIndexOptions();
+        var updated = options.With(distanceTolerance: 0.01);
+
+        updated.Should().NotBeSameAs(options);
+        updated.DistanceTolerance.Should().Be(0.01);
+        updated.IndexFieldName.Should().Be(options.IndexFieldName);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 0, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, -0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, 0.1, "", "_mbb")]
+    [InlineData(32, 1, 0.1, "_idx", " ")]
+    public void SpatialIndexOptions_ShouldValidateInputs(int precisionBits, int maxCells, double tolerance, string indexField, string mbbField)
+    {
+        Action act = () => new SpatialIndexOptions(precisionBits, maxCells, tolerance, indexField, mbbField);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class BoundingBoxTests
+{
+    [Fact]
+    public void BoundingBox_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(BoundingBox);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BoundingBox2D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From2D(-10, -5, 20, 15);
+
+        box.Dimensions.Should().Be(2);
+        box.Is3D.Should().BeFalse();
+        box.MinX.Should().Be(-10);
+        box.MinY.Should().Be(-5);
+        box.MaxX.Should().Be(20);
+        box.MaxY.Should().Be(15);
+        box.GetValues().ToArray().Should().Equal(-10, -5, 20, 15);
+    }
+
+    [Fact]
+    public void BoundingBox3D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From3D(-1, -2, -3, 4, 5, 6);
+
+        box.Dimensions.Should().Be(3);
+        box.Is3D.Should().BeTrue();
+        box.MinX.Should().Be(-1);
+        box.MinY.Should().Be(-2);
+        box.MinZ.Should().Be(-3);
+        box.MaxX.Should().Be(4);
+        box.MaxY.Should().Be(5);
+        box.MaxZ.Should().Be(6);
+        box.GetValues().ToArray().Should().Equal(-1, -2, -3, 4, 5, 6);
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidAxisOrdering()
+    {
+        Action twoD = () => BoundingBox.From2D(5, 0, 4, 1);
+        Action threeD = () => BoundingBox.From3D(0, 0, 0, -1, 2, 3);
+
+        twoD.Should().Throw<ArgumentException>();
+        threeD.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidValueCount()
+    {
+        Action act = () => BoundingBox.Create(new[] { 1.0, 2.0, 3.0 });
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPoint3DTests
+{
+    [Fact]
+    public void GeoPoint3D_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint3D);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint3D_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint3D(1, 2, 3);
+
+        point.X.Should().Be(1);
+        point.Y.Should().Be(2);
+        point.Z.Should().Be(3);
+        point.ToString().Should().Be("(1, 2, 3)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0, 0)]
+    [InlineData(0, double.NaN, 0)]
+    [InlineData(0, 0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0, 0)]
+    [InlineData(0, double.NegativeInfinity, 0)]
+    [InlineData(0, 0, double.PositiveInfinity)]
+    public void GeoPoint3D_ShouldRejectNonFiniteValues(double x, double y, double z)
+    {
+        Action act = () => new GeoPoint3D(x, y, z);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPointTests
+{
+    [Fact]
+    public void GeoPoint_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint(12.5, -23.4);
+
+        point.Longitude.Should().Be(12.5);
+        point.Latitude.Should().Be(-23.4);
+        point.ToString().Should().Be("(12.5, -23.4)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0)]
+    [InlineData(0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0)]
+    [InlineData(0, double.NegativeInfinity)]
+    public void GeoPoint_ShouldRejectNonFiniteValues(double longitude, double latitude)
+    {
+        Action act = () => new GeoPoint(longitude, latitude);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Indexing;
+
+public sealed class MortonIndexEncoderTests
+{
+    [Fact]
+    public void Encode2DProducesExpectedMortonCodes()
+    {
+        var encoder = new LiteDB.Spatial.MortonIndexEncoder(2, precisionBits: 2);
+
+        encoder.Encode(stackalloc double[] { 0d, 0d }).Should().Be(0UL);
+        encoder.Encode(stackalloc double[] { 1d, 0d }).Should().Be(5UL);
+        encoder.Encode(stackalloc double[] { 0d, 1d }).Should().Be(10UL);
+        encoder.Encode(stackalloc double[] { 1d, 1d }).Should().Be(15UL);
+    }
+
+    [Fact]
+    public void Encode3DProducesExpectedMortonCodes()
+    {
+        var encoder = new LiteDB.Spatial.MortonIndexEncoder(3, precisionBits: 1);
+
+        encoder.Encode(stackalloc double[] { 0d, 0d, 0d }).Should().Be(0UL);
+        encoder.Encode(stackalloc double[] { 1d, 0d, 0d }).Should().Be(1UL);
+        encoder.Encode(stackalloc double[] { 0d, 1d, 0d }).Should().Be(2UL);
+        encoder.Encode(stackalloc double[] { 0d, 0d, 1d }).Should().Be(4UL);
+        encoder.Encode(stackalloc double[] { 1d, 1d, 1d }).Should().Be(7UL);
+    }
+
+    [Fact]
+    public void EncodeRejectsNaN()
+    {
+        var encoder = new LiteDB.Spatial.MortonIndexEncoder(2, precisionBits: 4);
+
+        var action = () => encoder.Encode(stackalloc double[] { double.NaN, 0d });
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void CoverEnumeratesCellsWithinBounds()
+    {
+        var encoder = new LiteDB.Spatial.MortonIndexEncoder(2, precisionBits: 3);
+        var bounds = LiteDB.Spatial.BoundingBox.From2D(0.25, 0.25, 0.5, 0.5);
+
+        var ranges = encoder.Cover(bounds, maxCells: 16);
+        ranges.Should().NotBeEmpty();
+
+        var codes = ranges.SelectMany(range => Enumerable.Range(0, (int)(range.End - range.Start + 1)).Select(offset => range.Start + (ulong)offset));
+        var lowerBound = encoder.Encode(stackalloc double[] { 0.25, 0.25 });
+        var upperBound = encoder.Encode(stackalloc double[] { 0.5, 0.5 });
+
+        foreach (var code in codes)
+        {
+            code.Should().BeGreaterOrEqualTo(lowerBound);
+            code.Should().BeLessOrEqualTo(upperBound);
+        }
+    }
+
+    [Fact]
+    public void UnionAdjacentRangesMergesOverlaps()
+    {
+        var input = new[]
+        {
+            new LiteDB.Spatial.SpatialIndexRange(1, 3),
+            new LiteDB.Spatial.SpatialIndexRange(4, 6),
+            new LiteDB.Spatial.SpatialIndexRange(10, 12)
+        };
+
+        var merged = LiteDB.Spatial.MortonIndexEncoder.UnionAdjacentRanges(input);
+        merged.Should().HaveCount(2);
+        merged[0].Should().Be(new LiteDB.Spatial.SpatialIndexRange(1, 6));
+        merged[1].Should().Be(new LiteDB.Spatial.SpatialIndexRange(10, 12));
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial.Core.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
@@ -1,0 +1,55 @@
+extern alias LiteDbBase;
+
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Metadata;
+
+public sealed class SpatialMetadataStoreTests
+{
+    [Fact]
+    public void SaveAndLoadDescriptorRoundTrips()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var store = new LiteDB.Spatial.SpatialMetadataStore(database);
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor("Geographic", 2, new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 12));
+
+        store.SaveDescriptor("places", descriptor);
+
+        var loaded = store.GetRequiredDescriptor("places");
+        loaded.Should().Be(descriptor);
+    }
+
+    [Fact]
+    public void ValidateDocumentThrowsWhenBoundingBoxDoesNotMatchDimensions()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var store = new LiteDB.Spatial.SpatialMetadataStore(database);
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor("Cartesian3D", 3, new LiteDB.Spatial.SpatialIndexOptions());
+
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 1,
+            [descriptor.Options.BoundingBoxFieldName] = new BaseLiteDB.BsonArray(new[] { new BaseLiteDB.BsonValue(0), new BaseLiteDB.BsonValue(0), new BaseLiteDB.BsonValue(1), new BaseLiteDB.BsonValue(1) })
+        };
+
+        store.SaveDescriptor("points", descriptor);
+
+        var action = () => store.ValidateDocument(document, descriptor);
+        action.Should().Throw<LiteDB.Spatial.SpatialMetadataException>()
+            .WithMessage("*contains 4 values*");
+    }
+
+    [Fact]
+    public void GetRequiredDescriptorProvidesFriendlyMessageWhenMissing()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var store = new LiteDB.Spatial.SpatialMetadataStore(database);
+
+        var action = () => store.GetRequiredDescriptor("missing", "Call Spatial.UseGeographic(collection) first.");
+        action.Should().Throw<LiteDB.Spatial.SpatialMetadataException>()
+            .WithMessage("*Spatial.UseGeographic*");
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
@@ -1,0 +1,268 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides utilities to backfill spatial index fields on existing documents.
+/// </summary>
+public static class SpatialBackfill
+{
+    /// <summary>
+    /// Enriches documents with spatial index fields using the provided engine.
+    /// </summary>
+    /// <param name="collection">The target collection.</param>
+    /// <param name="descriptor">The descriptor describing the expected schema.</param>
+    /// <param name="engine">The engine responsible for computing the index values.</param>
+    /// <param name="batchSize">The number of documents processed per batch.</param>
+    /// <param name="checkpoint">Optional checkpoint representing the last processed identifier.</param>
+    /// <returns>A <see cref="SpatialBackfillResult"/> describing the outcome of the operation.</returns>
+    public static SpatialBackfillResult Run(
+        BaseLiteDB.ILiteCollection<BaseLiteDB.BsonDocument> collection,
+        SpatialCollectionDescriptor descriptor,
+        ISpatialEngine engine,
+        int batchSize = 256,
+        BaseLiteDB.BsonValue? checkpoint = null)
+    {
+        if (collection == null)
+        {
+            throw new ArgumentNullException(nameof(collection));
+        }
+
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        if (engine.Dimensions != descriptor.Dimensions)
+        {
+            throw new SpatialMetadataException($"Engine '{engine.Name}' produces {engine.Dimensions}D output but collection is configured for {descriptor.Dimensions}D.");
+        }
+
+        if (engine.Mapper == null)
+        {
+            throw new InvalidOperationException("The spatial engine does not expose a mapper capable of reading documents.");
+        }
+
+        if (batchSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(batchSize), "Batch size must be positive.");
+        }
+
+        var mapper = engine.Mapper;
+        var options = descriptor.Options;
+        var result = new SpatialBackfillResult();
+        var lastCheckpoint = checkpoint;
+
+        while (true)
+        {
+            var query = collection.Query()
+                .OrderBy(BaseLiteDB.BsonExpression.Create("_id"), BaseLiteDB.Query.Ascending);
+
+            if (lastCheckpoint != null)
+            {
+                query = query.Where(BaseLiteDB.Query.GT("_id", lastCheckpoint));
+            }
+
+            var documents = query
+                .Limit(batchSize)
+                .ToDocuments()
+                .ToList();
+
+            if (documents.Count == 0)
+            {
+                break;
+            }
+
+            foreach (var document in documents)
+            {
+                if (!document.TryGetValue("_id", out var idValue))
+                {
+                    result.AddError(BaseLiteDB.BsonValue.Null, "Document is missing an _id field.");
+                    continue;
+                }
+
+                lastCheckpoint = idValue;
+                result.MarkProcessed(idValue);
+
+                try
+                {
+                    if (!TryExtractPoint(document, mapper, descriptor.Dimensions, out var point2D, out var point3D))
+                    {
+                        result.AddError(idValue, "Unable to extract a spatial point from the document.");
+                        continue;
+                    }
+
+                    ulong index;
+                    BoundingBox boundingBox;
+
+                    if (descriptor.Dimensions == 2)
+                    {
+                        index = mapper.Encode(point2D);
+                        boundingBox = mapper.GetBoundingBox(point2D);
+                    }
+                    else
+                    {
+                        index = mapper.Encode(point3D);
+                        boundingBox = mapper.GetBoundingBox(point3D);
+                    }
+
+                    descriptor.EnsureCompatible(boundingBox);
+
+                    var needsUpdate = EnsureIndex(document, options.IndexFieldName, index);
+                    needsUpdate |= EnsureBoundingBox(document, options.BoundingBoxFieldName, boundingBox);
+
+                    if (needsUpdate)
+                    {
+                        if (!collection.Update(idValue, document))
+                        {
+                            result.AddError(idValue, "Failed to update the document with spatial data.");
+                            continue;
+                        }
+
+                        result.MarkUpdated();
+                    }
+                    else
+                    {
+                        result.MarkSkipped();
+                    }
+                }
+                catch (Exception ex) when (!(ex is SpatialMetadataException))
+                {
+                    result.AddError(idValue, ex.Message);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static bool TryExtractPoint(
+        BaseLiteDB.BsonDocument document,
+        ISpatialMapper mapper,
+        int dimensions,
+        out GeoPoint point2D,
+        out GeoPoint3D point3D)
+    {
+        point2D = default;
+        point3D = default;
+
+        return dimensions switch
+        {
+            2 when mapper.TryReadPoint(document, out point2D) => true,
+            3 when mapper.TryReadPoint(document, out point3D) => true,
+            _ => false
+        };
+    }
+
+    private static bool EnsureIndex(BaseLiteDB.BsonDocument document, string fieldName, ulong index)
+    {
+        var existingMatches = document.TryGetValue(fieldName, out var existing)
+            && TryConvertIndex(existing, out var existingIndex)
+            && existingIndex == index;
+
+        if (existingMatches)
+        {
+            return false;
+        }
+
+        document[fieldName] = new BaseLiteDB.BsonValue((decimal)index);
+        return true;
+    }
+
+    private static bool EnsureBoundingBox(BaseLiteDB.BsonDocument document, string fieldName, BoundingBox box)
+    {
+        var values = box.GetValues();
+        var expected = new List<BaseLiteDB.BsonValue>(values.Length);
+        for (var i = 0; i < values.Length; i++)
+        {
+            expected.Add(new BaseLiteDB.BsonValue(values[i]));
+        }
+
+        if (document.TryGetValue(fieldName, out var existing) && existing.IsArray)
+        {
+            var array = existing.AsArray;
+            if (array.Count == expected.Count)
+            {
+                var matches = true;
+                for (var i = 0; i < array.Count; i++)
+                {
+                    if (!array[i].AsDouble.Equals(expected[i].AsDouble))
+                    {
+                        matches = false;
+                        break;
+                    }
+                }
+
+                if (matches)
+                {
+                    return false;
+                }
+            }
+        }
+
+        document[fieldName] = new BaseLiteDB.BsonArray(expected);
+        return true;
+    }
+
+    private static bool TryConvertIndex(BaseLiteDB.BsonValue value, out ulong index)
+    {
+        switch (value.Type)
+        {
+            case BaseLiteDB.BsonType.Int32:
+                var intValue = value.AsInt32;
+                if (intValue < 0)
+                {
+                    index = 0;
+                    return false;
+                }
+
+                index = (ulong)intValue;
+                return true;
+            case BaseLiteDB.BsonType.Int64:
+                var longValue = value.AsInt64;
+                if (longValue < 0)
+                {
+                    index = 0;
+                    return false;
+                }
+
+                index = (ulong)longValue;
+                return true;
+            case BaseLiteDB.BsonType.Decimal:
+                var decimalValue = value.AsDecimal;
+                if (decimalValue < 0 || decimalValue > ulong.MaxValue)
+                {
+                    index = 0;
+                    return false;
+                }
+
+                index = (ulong)decimalValue;
+                return decimalValue == (decimal)index;
+            case BaseLiteDB.BsonType.Double:
+                var doubleValue = value.AsDouble;
+                if (doubleValue < 0 || doubleValue > ulong.MaxValue)
+                {
+                    index = 0;
+                    return false;
+                }
+
+                index = (ulong)doubleValue;
+                return Math.Abs(doubleValue - index) < 0.5d;
+            default:
+                index = 0;
+                return false;
+        }
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfillError.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfillError.cs
@@ -1,0 +1,32 @@
+extern alias LiteDbBase;
+
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes a failure encountered while enriching a document with spatial metadata.
+/// </summary>
+public sealed class SpatialBackfillError
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialBackfillError"/> class.
+    /// </summary>
+    public SpatialBackfillError(BaseLiteDB.BsonValue documentId, string message)
+    {
+        DocumentId = documentId;
+        Message = message;
+    }
+
+    /// <summary>
+    /// Gets the identifier of the document that caused the error.
+    /// </summary>
+    public BaseLiteDB.BsonValue DocumentId { get; }
+
+    /// <summary>
+    /// Gets a human-readable description of the failure.
+    /// </summary>
+    public string Message { get; }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
@@ -1,0 +1,66 @@
+extern alias LiteDbBase;
+
+using System.Collections.Generic;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents the outcome of a spatial backfill operation.
+/// </summary>
+public sealed class SpatialBackfillResult
+{
+    private readonly List<SpatialBackfillError> _errors = new();
+
+    internal SpatialBackfillResult()
+    {
+    }
+
+    /// <summary>
+    /// Gets the number of documents processed during the operation.
+    /// </summary>
+    public int Processed { get; private set; }
+
+    /// <summary>
+    /// Gets the number of documents updated with spatial data.
+    /// </summary>
+    public int Updated { get; private set; }
+
+    /// <summary>
+    /// Gets the number of documents that already contained the expected spatial data.
+    /// </summary>
+    public int Skipped { get; private set; }
+
+    /// <summary>
+    /// Gets the collection of errors observed during the backfill.
+    /// </summary>
+    public IReadOnlyList<SpatialBackfillError> Errors => _errors;
+
+    /// <summary>
+    /// Gets the identifier of the last processed document, which can be used as a checkpoint.
+    /// </summary>
+    public BaseLiteDB.BsonValue? LastCheckpoint { get; private set; }
+
+    internal void MarkProcessed(BaseLiteDB.BsonValue checkpoint)
+    {
+        Processed++;
+        LastCheckpoint = checkpoint;
+    }
+
+    internal void MarkUpdated()
+    {
+        Updated++;
+    }
+
+    internal void MarkSkipped()
+    {
+        Skipped++;
+    }
+
+    internal void AddError(BaseLiteDB.BsonValue id, string message)
+    {
+        _errors.Add(new SpatialBackfillError(id, message));
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
@@ -1,0 +1,17 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes distances between spatial points for exact filtering.
+/// </summary>
+public interface ISpatialDistance
+{
+    /// <summary>
+    /// Computes the distance between two geographic points expressed in meters.
+    /// </summary>
+    double Distance(GeoPoint left, GeoPoint right);
+
+    /// <summary>
+    /// Computes the distance between two Cartesian points expressed in user-defined units.
+    /// </summary>
+    double Distance(GeoPoint3D left, GeoPoint3D right);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
@@ -1,0 +1,52 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a spatial engine capable of producing index-aware query plans and mapping values.
+/// </summary>
+public interface ISpatialEngine
+{
+    /// <summary>
+    /// Gets the human-readable engine name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the engine.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the options associated with the engine.
+    /// </summary>
+    SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Gets the encoder used to map coordinates into index keys.
+    /// </summary>
+    ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <summary>
+    /// Gets the component responsible for mapping values to index fields.
+    /// </summary>
+    ISpatialMapper Mapper { get; }
+
+    /// <summary>
+    /// Gets the distance calculator used for exact filtering.
+    /// </summary>
+    ISpatialDistance Distance { get; }
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(GeoPoint center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided bounding box.
+    /// </summary>
+    ISpatialQueryPlan PlanWithin(BoundingBox bounds);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
@@ -1,0 +1,47 @@
+extern alias LiteDbBase;
+
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Projects application-level spatial values into indexable representations.
+/// </summary>
+public interface ISpatialMapper
+{
+    /// <summary>
+    /// Computes the bounding box for the provided two-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(GeoPoint point);
+
+    /// <summary>
+    /// Computes the bounding box for the provided three-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(GeoPoint3D point);
+
+    /// <summary>
+    /// Encodes a two-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(GeoPoint point);
+
+    /// <summary>
+    /// Encodes a three-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(GeoPoint3D point);
+
+    /// <summary>
+    /// Attempts to extract a two-dimensional point from the provided document for indexing purposes.
+    /// </summary>
+    /// <param name="document">The source document.</param>
+    /// <param name="point">When this method returns, contains the extracted point if available.</param>
+    /// <returns><c>true</c> when a point could be extracted; otherwise, <c>false</c>.</returns>
+    bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point);
+
+    /// <summary>
+    /// Attempts to extract a three-dimensional point from the provided document for indexing purposes.
+    /// </summary>
+    /// <param name="document">The source document.</param>
+    /// <param name="point">When this method returns, contains the extracted point if available.</param>
+    /// <returns><c>true</c> when a point could be extracted; otherwise, <c>false</c>.</returns>
+    bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes the pieces required to execute a spatial query using index ranges and precise filters.
+/// </summary>
+public interface ISpatialQueryPlan
+{
+    /// <summary>
+    /// Gets the dimensionality of the underlying spatial index.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the coarse bounding region evaluated before exact predicates. May be <c>null</c> when not applicable.
+    /// </summary>
+    BoundingBox? CoveringBounds { get; }
+
+    /// <summary>
+    /// Gets the ordered set of index ranges that should be scanned.
+    /// </summary>
+    IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <summary>
+    /// Gets a human readable description of the exact predicate applied after index filtering.
+    /// </summary>
+    string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
@@ -1,0 +1,152 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents configuration options that govern how spatial indexes are generated and queried.
+/// </summary>
+public sealed class SpatialIndexOptions : IEquatable<SpatialIndexOptions>
+{
+    /// <summary>
+    /// The default name for the numeric index field stored on documents.
+    /// </summary>
+    public const string DefaultIndexFieldName = "_idx";
+
+    /// <summary>
+    /// The default name for the bounding box field stored on documents.
+    /// </summary>
+    public const string DefaultBoundingBoxFieldName = "_mbb";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexOptions"/> class.
+    /// </summary>
+    /// <param name="precisionBits">Number of bits used by the index encoder to represent each axis.</param>
+    /// <param name="maxCoveringCells">The maximum number of index ranges allowed when covering a shape.</param>
+    /// <param name="distanceTolerance">Additional expansion applied to distance queries to accommodate floating-point error.</param>
+    /// <param name="indexFieldName">The field used to store the encoded index value on documents.</param>
+    /// <param name="boundingBoxFieldName">The field used to store the bounding box on documents.</param>
+    public SpatialIndexOptions(
+        int precisionBits = 32,
+        int maxCoveringCells = 64,
+        double distanceTolerance = 0.001,
+        string indexFieldName = DefaultIndexFieldName,
+        string boundingBoxFieldName = DefaultBoundingBoxFieldName)
+    {
+        if (precisionBits <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be a positive number of bits.");
+        }
+
+        if (maxCoveringCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCoveringCells), "The maximum number of covering cells must be positive.");
+        }
+
+        if (distanceTolerance < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(distanceTolerance), "Distance tolerance cannot be negative.");
+        }
+
+        if (string.IsNullOrWhiteSpace(indexFieldName))
+        {
+            throw new ArgumentException("Index field name cannot be null or whitespace.", nameof(indexFieldName));
+        }
+
+        if (string.IsNullOrWhiteSpace(boundingBoxFieldName))
+        {
+            throw new ArgumentException("Bounding box field name cannot be null or whitespace.", nameof(boundingBoxFieldName));
+        }
+
+        PrecisionBits = precisionBits;
+        MaxCoveringCells = maxCoveringCells;
+        DistanceTolerance = distanceTolerance;
+        IndexFieldName = indexFieldName;
+        BoundingBoxFieldName = boundingBoxFieldName;
+    }
+
+    /// <summary>
+    /// Gets the number of bits allocated to represent each coordinate axis.
+    /// </summary>
+    public int PrecisionBits { get; }
+
+    /// <summary>
+    /// Gets the maximum number of index cells that planners may request when approximating shapes.
+    /// </summary>
+    public int MaxCoveringCells { get; }
+
+    /// <summary>
+    /// Gets the amount of tolerance applied to distance-based operations.
+    /// </summary>
+    public double DistanceTolerance { get; }
+
+    /// <summary>
+    /// Gets the document field used to store encoded index values.
+    /// </summary>
+    public string IndexFieldName { get; }
+
+    /// <summary>
+    /// Gets the document field used to store bounding boxes.
+    /// </summary>
+    public string BoundingBoxFieldName { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="SpatialIndexOptions"/> instance using the existing values as defaults.
+    /// </summary>
+    public SpatialIndexOptions With(
+        int? precisionBits = null,
+        int? maxCoveringCells = null,
+        double? distanceTolerance = null,
+        string? indexFieldName = null,
+        string? boundingBoxFieldName = null)
+    {
+        return new SpatialIndexOptions(
+            precisionBits ?? PrecisionBits,
+            maxCoveringCells ?? MaxCoveringCells,
+            distanceTolerance ?? DistanceTolerance,
+            indexFieldName ?? IndexFieldName,
+            boundingBoxFieldName ?? BoundingBoxFieldName);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexOptions? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return PrecisionBits == other.PrecisionBits
+            && MaxCoveringCells == other.MaxCoveringCells
+            && DistanceTolerance.Equals(other.DistanceTolerance)
+            && string.Equals(IndexFieldName, other.IndexFieldName, StringComparison.Ordinal)
+            && string.Equals(BoundingBoxFieldName, other.BoundingBoxFieldName, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexOptions options && Equals(options);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = PrecisionBits;
+            hash = (hash * 397) ^ MaxCoveringCells;
+            hash = (hash * 397) ^ DistanceTolerance.GetHashCode();
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(IndexFieldName);
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(BoundingBoxFieldName);
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Precision={PrecisionBits}, Cells={MaxCoveringCells}, Tolerance={DistanceTolerance}, IndexField=\"{IndexFieldName}\", BoundingField=\"{BoundingBoxFieldName}\"";
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
+++ b/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
@@ -1,0 +1,234 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents an axis-aligned bounding box in two or three dimensions.
+/// </summary>
+public readonly struct BoundingBox : IEquatable<BoundingBox>
+{
+    private readonly double[] _values;
+
+    private BoundingBox(double[] values)
+    {
+        _values = values;
+    }
+
+    /// <summary>
+    /// Creates a bounding box from raw coordinate values.
+    /// </summary>
+    /// <param name="values">
+    /// The coordinates describing the box. Two-dimensional boxes require four values
+    /// (<c>minX</c>, <c>minY</c>, <c>maxX</c>, <c>maxY</c>). Three-dimensional boxes require
+    /// six values (<c>minX</c>, <c>minY</c>, <c>minZ</c>, <c>maxX</c>, <c>maxY</c>, <c>maxZ</c>).
+    /// </param>
+    /// <returns>A new <see cref="BoundingBox"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when the number of values is invalid or any value is non-finite.</exception>
+    public static BoundingBox Create(ReadOnlySpan<double> values)
+    {
+        if (values.Length != 4 && values.Length != 6)
+        {
+            throw new ArgumentException("Bounding boxes must be described by four (2D) or six (3D) values.", nameof(values));
+        }
+
+        var copy = new double[values.Length];
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var value = values[i];
+
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                throw new ArgumentException("Bounding box coordinates must be finite numbers.", nameof(values));
+            }
+
+            copy[i] = value;
+        }
+
+        ValidateExtents(copy);
+
+        return new BoundingBox(copy);
+    }
+
+    /// <summary>
+    /// Creates a two-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From2D(double minX, double minY, double maxX, double maxY)
+    {
+        return Create(new[] { minX, minY, maxX, maxY });
+    }
+
+    /// <summary>
+    /// Creates a three-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From3D(double minX, double minY, double minZ, double maxX, double maxY, double maxZ)
+    {
+        return Create(new[] { minX, minY, minZ, maxX, maxY, maxZ });
+    }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions represented by the box.
+    /// </summary>
+    public int Dimensions => _values.Length / 2;
+
+    /// <summary>
+    /// Gets a value indicating whether the bounding box captures three dimensions.
+    /// </summary>
+    public bool Is3D => Dimensions == 3;
+
+    /// <summary>
+    /// Gets the minimum X value.
+    /// </summary>
+    public double MinX => _values[0];
+
+    /// <summary>
+    /// Gets the minimum Y value.
+    /// </summary>
+    public double MinY => _values[1];
+
+    /// <summary>
+    /// Gets the minimum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MinZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[2];
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum X value.
+    /// </summary>
+    public double MaxX => _values[Dimensions == 2 ? 2 : 3];
+
+    /// <summary>
+    /// Gets the maximum Y value.
+    /// </summary>
+    public double MaxY => _values[Dimensions == 2 ? 3 : 4];
+
+    /// <summary>
+    /// Gets the maximum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MaxZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[5];
+        }
+    }
+
+    /// <summary>
+    /// Returns the raw coordinate values that describe the box.
+    /// </summary>
+    public ReadOnlySpan<double> GetValues()
+    {
+        return _values;
+    }
+
+    /// <summary>
+    /// Copies the coordinate values into a new array.
+    /// </summary>
+    public double[] ToArray()
+    {
+        var copy = new double[_values.Length];
+        Array.Copy(_values, copy, _values.Length);
+        return copy;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(BoundingBox other)
+    {
+        if (Dimensions != other.Dimensions)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _values.Length; i++)
+        {
+            if (!_values[i].Equals(other._values[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is BoundingBox box && Equals(box);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Dimensions;
+
+            for (var i = 0; i < _values.Length; i++)
+            {
+                hash = (hash * 397) ^ _values[i].GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{string.Join(", ", _values.Select(value => value.ToString(CultureInfo.InvariantCulture)))}]";
+    }
+
+    public static bool operator ==(BoundingBox left, BoundingBox right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(BoundingBox left, BoundingBox right)
+    {
+        return !left.Equals(right);
+    }
+
+    private static void ValidateExtents(IReadOnlyList<double> values)
+    {
+        if (values.Count == 4)
+        {
+            ValidateAxis(values[0], values[2], "X");
+            ValidateAxis(values[1], values[3], "Y");
+            return;
+        }
+
+        ValidateAxis(values[0], values[3], "X");
+        ValidateAxis(values[1], values[4], "Y");
+        ValidateAxis(values[2], values[5], "Z");
+    }
+
+    private static void ValidateAxis(double min, double max, string axis)
+    {
+        if (max < min)
+        {
+            throw new ArgumentException($"The maximum {axis} value must be greater than or equal to the minimum value.");
+        }
+    }
+
+    private void EnsureThreeDimensions()
+    {
+        if (!Is3D)
+        {
+            throw new InvalidOperationException("The bounding box does not define a Z axis.");
+        }
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a geographic coordinate using longitude and latitude expressed in decimal degrees.
+/// </summary>
+public readonly struct GeoPoint : IEquatable<GeoPoint>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint"/> struct.
+    /// </summary>
+    /// <param name="longitude">The longitude component in decimal degrees.</param>
+    /// <param name="latitude">The latitude component in decimal degrees.</param>
+    /// <exception cref="ArgumentException">Thrown when either coordinate is not a finite number.</exception>
+    public GeoPoint(double longitude, double latitude)
+    {
+        if (double.IsNaN(longitude) || double.IsInfinity(longitude))
+        {
+            throw new ArgumentException("Longitude must be a finite number.", nameof(longitude));
+        }
+
+        if (double.IsNaN(latitude) || double.IsInfinity(latitude))
+        {
+            throw new ArgumentException("Latitude must be a finite number.", nameof(latitude));
+        }
+
+        Longitude = longitude;
+        Latitude = latitude;
+    }
+
+    /// <summary>
+    /// Gets the longitude component in decimal degrees where positive values indicate east.
+    /// </summary>
+    public double Longitude { get; }
+
+    /// <summary>
+    /// Gets the latitude component in decimal degrees where positive values indicate north.
+    /// </summary>
+    public double Latitude { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint other)
+    {
+        return Longitude.Equals(other.Longitude) && Latitude.Equals(other.Latitude);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Longitude.GetHashCode();
+            hash = (hash * 397) ^ Latitude.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1})", Longitude, Latitude);
+    }
+
+    public static bool operator ==(GeoPoint left, GeoPoint right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint left, GeoPoint right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
@@ -1,0 +1,96 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a three-dimensional Cartesian coordinate.
+/// </summary>
+public readonly struct GeoPoint3D : IEquatable<GeoPoint3D>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint3D"/> struct.
+    /// </summary>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
+    /// <param name="z">The Z component.</param>
+    /// <exception cref="ArgumentException">Thrown when any component is not a finite number.</exception>
+    public GeoPoint3D(double x, double y, double z)
+    {
+        if (double.IsNaN(x) || double.IsInfinity(x))
+        {
+            throw new ArgumentException("X must be a finite number.", nameof(x));
+        }
+
+        if (double.IsNaN(y) || double.IsInfinity(y))
+        {
+            throw new ArgumentException("Y must be a finite number.", nameof(y));
+        }
+
+        if (double.IsNaN(z) || double.IsInfinity(z))
+        {
+            throw new ArgumentException("Z must be a finite number.", nameof(z));
+        }
+
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    /// <summary>
+    /// Gets the X component of the coordinate.
+    /// </summary>
+    public double X { get; }
+
+    /// <summary>
+    /// Gets the Y component of the coordinate.
+    /// </summary>
+    public double Y { get; }
+
+    /// <summary>
+    /// Gets the Z component of the coordinate.
+    /// </summary>
+    public double Z { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint3D other)
+    {
+        return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint3D point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = X.GetHashCode();
+            hash = (hash * 397) ^ Y.GetHashCode();
+            hash = (hash * 397) ^ Z.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1}, {2})", X, Y, Z);
+    }
+
+    public static bool operator ==(GeoPoint3D left, GeoPoint3D right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint3D left, GeoPoint3D right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides the ability to encode coordinates into spatial index values and derive coarse coverings.
+/// </summary>
+public interface ISpatialIndexEncoder
+{
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the encoder.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the number of precision bits allocated per axis.
+    /// </summary>
+    int PrecisionBits { get; }
+
+    /// <summary>
+    /// Encodes the provided coordinate tuple into a sortable spatial index value.
+    /// </summary>
+    /// <param name="coordinates">The coordinate tuple. The span length must match <see cref="Dimensions"/>.</param>
+    /// <returns>The encoded index value.</returns>
+    ulong Encode(ReadOnlySpan<double> coordinates);
+
+    /// <summary>
+    /// Produces a set of index ranges that cover the provided bounding box.
+    /// </summary>
+    /// <param name="bounds">The bounding box to cover.</param>
+    /// <param name="maxCells">The maximum number of ranges the caller is willing to accept.</param>
+    /// <returns>A collection of closed index ranges ordered from lowest to highest.</returns>
+    IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells);
+}

--- a/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Implements a Morton (Z-order) index encoder for two- and three-dimensional coordinates.
+/// </summary>
+public sealed class MortonIndexEncoder : ISpatialIndexEncoder
+{
+    private readonly ulong _maxValue;
+    private readonly ulong _enumerationThreshold;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MortonIndexEncoder"/> class.
+    /// </summary>
+    /// <param name="dimensions">The dimensionality supported by the encoder. Only 2D and 3D are supported.</param>
+    /// <param name="precisionBits">The number of bits allocated to each coordinate axis.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="dimensions"/> or <paramref name="precisionBits"/> are out of range.</exception>
+    public MortonIndexEncoder(int dimensions, int precisionBits)
+    {
+        if (dimensions != 2 && dimensions != 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Morton encoding currently supports only two or three dimensions.");
+        }
+
+        if (precisionBits <= 0 || precisionBits > 32)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision bits must be between 1 and 32.");
+        }
+
+        Dimensions = dimensions;
+        PrecisionBits = precisionBits;
+        _maxValue = (1UL << precisionBits) - 1UL;
+        _enumerationThreshold = Math.Max(1UL, (ulong)precisionBits * 32UL);
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public int PrecisionBits { get; }
+
+    /// <inheritdoc />
+    public ulong Encode(ReadOnlySpan<double> coordinates)
+    {
+        if (coordinates.Length != Dimensions)
+        {
+            throw new ArgumentException($"Expected {Dimensions} coordinates but received {coordinates.Length}.", nameof(coordinates));
+        }
+
+        Span<ulong> quantized = stackalloc ulong[Dimensions];
+
+        for (var axis = 0; axis < Dimensions; axis++)
+        {
+            quantized[axis] = Quantize(coordinates[axis]);
+        }
+
+        return InterleaveBits(quantized);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells)
+    {
+        if (bounds.Dimensions != Dimensions)
+        {
+            throw new ArgumentException($"Expected a {Dimensions}D bounding box but received {bounds.Dimensions}D.", nameof(bounds));
+        }
+
+        if (maxCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCells), "The maximum number of covering cells must be positive.");
+        }
+
+        var minimum = QuantizeBounds(bounds, isMax: false);
+        var maximum = QuantizeBounds(bounds, isMax: true);
+
+        var totalCells = EstimateCellCount(minimum, maximum);
+
+        if (totalCells == 0)
+        {
+            return Array.Empty<SpatialIndexRange>();
+        }
+
+        if (totalCells > _enumerationThreshold)
+        {
+            var start = InterleaveBits(minimum);
+            var end = InterleaveBits(maximum);
+            if (start > end)
+            {
+                (start, end) = (end, start);
+            }
+
+            return new[] { new SpatialIndexRange(start, end) };
+        }
+
+        var buffer = new List<ulong>((int)Math.Min(totalCells, int.MaxValue));
+        EnumerateCodes(minimum, maximum, buffer, new ulong[Dimensions], 0);
+        buffer.Sort();
+
+        var ranges = BuildRanges(buffer);
+        return ReduceRangeCount(ranges, maxCells);
+    }
+
+    /// <summary>
+    /// Merges adjacent and overlapping ranges to create a simplified covering.
+    /// </summary>
+    /// <param name="ranges">The ranges to simplify.</param>
+    /// <returns>A collection of merged ranges ordered by their starting value.</returns>
+    public static IReadOnlyList<SpatialIndexRange> UnionAdjacentRanges(IEnumerable<SpatialIndexRange> ranges)
+    {
+        if (ranges == null)
+        {
+            throw new ArgumentNullException(nameof(ranges));
+        }
+
+        var ordered = ranges.OrderBy(r => r.Start).ThenBy(r => r.End).ToList();
+        if (ordered.Count == 0)
+        {
+            return ordered;
+        }
+
+        var result = new List<SpatialIndexRange>(ordered.Count);
+        var current = ordered[0];
+
+        for (var i = 1; i < ordered.Count; i++)
+        {
+            var candidate = ordered[i];
+            if (candidate.Start <= current.End + 1)
+            {
+                current = new SpatialIndexRange(current.Start, Math.Max(current.End, candidate.End));
+            }
+            else
+            {
+                result.Add(current);
+                current = candidate;
+            }
+        }
+
+        result.Add(current);
+        return result;
+    }
+
+    private ulong Quantize(double coordinate)
+    {
+        if (double.IsNaN(coordinate) || double.IsInfinity(coordinate))
+        {
+            throw new ArgumentException("Coordinates must be finite values.");
+        }
+
+        var clamped = Math.Clamp(coordinate, 0d, 1d);
+        var scaled = clamped * _maxValue;
+        var quantized = (ulong)Math.Round(scaled, MidpointRounding.AwayFromZero);
+        return quantized > _maxValue ? _maxValue : quantized;
+    }
+
+    private ulong[] QuantizeBounds(BoundingBox bounds, bool isMax)
+    {
+        var values = bounds.GetValues();
+        var buffer = new ulong[Dimensions];
+        for (var axis = 0; axis < Dimensions; axis++)
+        {
+            var offset = isMax ? axis + Dimensions : axis;
+            buffer[axis] = Quantize(values[offset]);
+        }
+
+        return buffer;
+    }
+
+    private static ulong EstimateCellCount(IReadOnlyList<ulong> min, IReadOnlyList<ulong> max)
+    {
+        try
+        {
+            ulong total = 1;
+            for (var i = 0; i < min.Count; i++)
+            {
+                total = checked(total * (max[i] - min[i] + 1));
+            }
+
+            return total;
+        }
+        catch (OverflowException)
+        {
+            return ulong.MaxValue;
+        }
+    }
+
+    private void EnumerateCodes(ulong[] minimum, ulong[] maximum, List<ulong> buffer, ulong[] current, int axis)
+    {
+        if (axis == Dimensions)
+        {
+            buffer.Add(InterleaveBits(current));
+            return;
+        }
+
+        for (var value = minimum[axis]; value <= maximum[axis]; value++)
+        {
+            current[axis] = value;
+            EnumerateCodes(minimum, maximum, buffer, current, axis + 1);
+        }
+    }
+
+    private IReadOnlyList<SpatialIndexRange> ReduceRangeCount(List<SpatialIndexRange> ranges, int maxCells)
+    {
+        if (ranges.Count <= maxCells)
+        {
+            return ranges;
+        }
+
+        ranges.Sort((left, right) => left.Start.CompareTo(right.Start));
+
+        while (ranges.Count > maxCells && ranges.Count > 1)
+        {
+            var bestIndex = 0;
+            ulong bestCost = ulong.MaxValue;
+
+            for (var i = 0; i < ranges.Count - 1; i++)
+            {
+                var current = ranges[i];
+                var next = ranges[i + 1];
+                var cost = next.End - current.Start;
+                if (cost < bestCost)
+                {
+                    bestCost = cost;
+                    bestIndex = i;
+                }
+            }
+
+            var merged = new SpatialIndexRange(ranges[bestIndex].Start, ranges[bestIndex + 1].End);
+            ranges[bestIndex] = merged;
+            ranges.RemoveAt(bestIndex + 1);
+        }
+
+        return ranges;
+    }
+
+    private static List<SpatialIndexRange> BuildRanges(List<ulong> codes)
+    {
+        if (codes.Count == 0)
+        {
+            return new List<SpatialIndexRange>();
+        }
+
+        var ranges = new List<SpatialIndexRange>();
+        ulong start = codes[0];
+        ulong previous = start;
+
+        for (var i = 1; i < codes.Count; i++)
+        {
+            var value = codes[i];
+            if (value == previous + 1)
+            {
+                previous = value;
+                continue;
+            }
+
+            ranges.Add(new SpatialIndexRange(start, previous));
+            start = previous = value;
+        }
+
+        ranges.Add(new SpatialIndexRange(start, previous));
+        return ranges;
+    }
+
+    private ulong InterleaveBits(ReadOnlySpan<ulong> values)
+    {
+        ulong result = 0;
+        var bitPosition = 0;
+
+        for (var bit = 0; bit < PrecisionBits; bit++)
+        {
+            for (var axis = 0; axis < Dimensions; axis++)
+            {
+                var bitValue = (values[axis] >> bit) & 1UL;
+                result |= bitValue << bitPosition;
+                bitPosition++;
+            }
+        }
+
+        return result;
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
+++ b/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
@@ -1,0 +1,76 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a closed range of spatial index values.
+/// </summary>
+public readonly struct SpatialIndexRange : IEquatable<SpatialIndexRange>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexRange"/> struct.
+    /// </summary>
+    /// <param name="start">The inclusive start of the range.</param>
+    /// <param name="end">The inclusive end of the range.</param>
+    public SpatialIndexRange(ulong start, ulong end)
+    {
+        if (end < start)
+        {
+            throw new ArgumentOutOfRangeException(nameof(end), "The end of the range must be greater than or equal to the start.");
+        }
+
+        Start = start;
+        End = end;
+    }
+
+    /// <summary>
+    /// Gets the inclusive start of the range.
+    /// </summary>
+    public ulong Start { get; }
+
+    /// <summary>
+    /// Gets the inclusive end of the range.
+    /// </summary>
+    public ulong End { get; }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexRange other)
+    {
+        return Start == other.Start && End == other.End;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexRange range && Equals(range);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Start.GetHashCode();
+            hash = (hash * 397) ^ End.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{Start}, {End}]";
+    }
+
+    public static bool operator ==(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides LINQ-friendly spatial helpers. These methods are intended to be used within expression trees
+/// and will be translated by <see cref="SpatialResolver"/> into engine-specific query plans.
+/// </summary>
+public static class SpatialExpressions
+{
+    /// <summary>
+    /// Placeholder for a query that selects points near a geographic center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint candidate, GeoPoint center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points near a three-dimensional center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint3D candidate, GeoPoint3D center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects three-dimensional points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint3D candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    private static InvalidOperationException CreateUsageException()
+    {
+        return new InvalidOperationException("SpatialExpressions are intended for use within LINQ expressions and should not be executed directly.");
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System.Linq.Expressions;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Translates method calls that originate from <see cref="SpatialExpressions"/> into spatial query plans.
+/// </summary>
+public sealed class SpatialResolver
+{
+    /// <summary>
+    /// Attempts to translate the provided method call expression into a spatial query plan.
+    /// </summary>
+    /// <param name="expression">The method call expression extracted from a LINQ query.</param>
+    /// <param name="plan">When this method returns, contains the resulting query plan if translation succeeded.</param>
+    /// <returns><c>true</c> when translation succeeded; otherwise, <c>false</c>.</returns>
+    public bool TryResolve(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        plan = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
+++ b/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Core</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Core.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core/Metadata/SpatialCollectionDescriptor.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialCollectionDescriptor.cs
@@ -1,0 +1,111 @@
+using System;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes how a collection is configured for spatial indexing.
+/// </summary>
+public sealed class SpatialCollectionDescriptor : IEquatable<SpatialCollectionDescriptor>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialCollectionDescriptor"/> class.
+    /// </summary>
+    /// <param name="engine">The engine name responsible for indexing the collection.</param>
+    /// <param name="dimensions">The spatial dimensionality supported by the engine.</param>
+    /// <param name="options">The index options associated with the collection.</param>
+    public SpatialCollectionDescriptor(string engine, int dimensions, SpatialIndexOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(engine))
+        {
+            throw new ArgumentException("Engine name must be provided.", nameof(engine));
+        }
+
+        if (dimensions != 2 && dimensions != 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial collections must be either two- or three-dimensional.");
+        }
+
+        Engine = engine;
+        Dimensions = dimensions;
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+    }
+
+    /// <summary>
+    /// Gets the engine name used to service spatial queries for the collection.
+    /// </summary>
+    public string Engine { get; }
+
+    /// <summary>
+    /// Gets the spatial dimensionality supported by the collection.
+    /// </summary>
+    public int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the index options associated with the collection.
+    /// </summary>
+    public SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Ensures that the provided bounding box matches the descriptor dimensionality.
+    /// </summary>
+    /// <param name="box">The bounding box to validate.</param>
+    public void EnsureCompatible(BoundingBox box)
+    {
+        if (box.Dimensions != Dimensions)
+        {
+            throw new SpatialMetadataException($"Collection is configured for {Dimensions}D geometry but encountered a {box.Dimensions}D bounding box.");
+        }
+    }
+
+    /// <summary>
+    /// Ensures that a stored bounding box representation matches the descriptor dimensionality.
+    /// </summary>
+    /// <param name="valueCount">The number of serialized bounding box values.</param>
+    public void EnsureCompatible(int valueCount)
+    {
+        var expected = Dimensions == 2 ? 4 : 6;
+        if (valueCount != expected)
+        {
+            throw new SpatialMetadataException($"Collection is configured for {Dimensions}D geometry but {Options.BoundingBoxFieldName} contains {valueCount} values.");
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialCollectionDescriptor? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return Dimensions == other.Dimensions
+            && string.Equals(Engine, other.Engine, StringComparison.Ordinal)
+            && Options.Equals(other.Options);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialCollectionDescriptor descriptor && Equals(descriptor);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = StringComparer.Ordinal.GetHashCode(Engine);
+            hash = (hash * 397) ^ Dimensions.GetHashCode();
+            hash = (hash * 397) ^ Options.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Engine={Engine}, Dimensions={Dimensions}, Options=({Options})";
+    }
+}

--- a/LiteDB.Spatial.Core/Metadata/SpatialMetadataException.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialMetadataException.cs
@@ -1,0 +1,27 @@
+using System;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents configuration issues with spatial metadata.
+/// </summary>
+public sealed class SpatialMetadataException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialMetadataException"/> class.
+    /// </summary>
+    public SpatialMetadataException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialMetadataException"/> class using the specified message.
+    /// </summary>
+    /// <param name="message">The exception message.</param>
+    public SpatialMetadataException(string message)
+        : base(message)
+    {
+    }
+}

--- a/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
@@ -1,0 +1,160 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Concurrent;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Persists spatial metadata describing how a collection is indexed.
+/// </summary>
+public sealed class SpatialMetadataStore
+{
+    /// <summary>
+    /// The name of the metadata collection.
+    /// </summary>
+    public const string MetadataCollectionName = "_spatial_meta";
+
+    private readonly BaseLiteDB.ILiteDatabase _database;
+    private readonly ConcurrentDictionary<string, SpatialCollectionDescriptor> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialMetadataStore"/> class.
+    /// </summary>
+    /// <param name="database">The database that hosts the metadata collection.</param>
+    public SpatialMetadataStore(BaseLiteDB.ILiteDatabase database)
+    {
+        _database = database ?? throw new ArgumentNullException(nameof(database));
+    }
+
+    /// <summary>
+    /// Persists the provided descriptor for the specified collection.
+    /// </summary>
+    public void SaveDescriptor(string collectionName, SpatialCollectionDescriptor descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        var collection = _database.GetCollection(MetadataCollectionName);
+        var document = Serialize(collectionName, descriptor);
+        collection.Upsert(document);
+        _cache[collectionName] = descriptor;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the descriptor for the specified collection.
+    /// </summary>
+    public bool TryGetDescriptor(string collectionName, out SpatialCollectionDescriptor descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        if (_cache.TryGetValue(collectionName, out descriptor!))
+        {
+            return true;
+        }
+
+        var collection = _database.GetCollection(MetadataCollectionName);
+        var document = collection.FindById(new BaseLiteDB.BsonValue(collectionName));
+        if (document == null)
+        {
+            descriptor = null!;
+            return false;
+        }
+
+        descriptor = Deserialize(document);
+        _cache[collectionName] = descriptor;
+        return true;
+    }
+
+    /// <summary>
+    /// Retrieves the descriptor for the collection or throws a friendly exception if missing.
+    /// </summary>
+    /// <param name="collectionName">The collection name.</param>
+    /// <param name="suggestion">Optional suggestion guiding the caller to configure the collection.</param>
+    /// <returns>The persisted descriptor.</returns>
+    public SpatialCollectionDescriptor GetRequiredDescriptor(string collectionName, string? suggestion = null)
+    {
+        if (TryGetDescriptor(collectionName, out var descriptor))
+        {
+            return descriptor;
+        }
+
+        var hint = suggestion ?? "Configure the collection using the appropriate Spatial.Use* helper.";
+        throw new SpatialMetadataException($"Collection '{collectionName}' is not configured for spatial indexing. {hint}");
+    }
+
+    /// <summary>
+    /// Validates that the provided document aligns with the persisted descriptor.
+    /// </summary>
+    public void ValidateDocument(BaseLiteDB.BsonDocument document, SpatialCollectionDescriptor descriptor)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (document.TryGetValue(descriptor.Options.BoundingBoxFieldName, out var value) && value.IsArray)
+        {
+            descriptor.EnsureCompatible(value.AsArray.Count);
+        }
+    }
+
+    private static BaseLiteDB.BsonDocument Serialize(string collectionName, SpatialCollectionDescriptor descriptor)
+    {
+        var options = descriptor.Options;
+        var optionsDoc = new BaseLiteDB.BsonDocument
+        {
+            ["precisionBits"] = options.PrecisionBits,
+            ["maxCoveringCells"] = options.MaxCoveringCells,
+            ["distanceTolerance"] = options.DistanceTolerance,
+            ["indexFieldName"] = options.IndexFieldName,
+            ["boundingBoxFieldName"] = options.BoundingBoxFieldName,
+        };
+
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = collectionName,
+            ["collection"] = collectionName,
+            ["engine"] = descriptor.Engine,
+            ["dimensions"] = descriptor.Dimensions,
+            ["options"] = optionsDoc,
+            ["updatedUtc"] = DateTime.UtcNow
+        };
+
+        return document;
+    }
+
+    private static SpatialCollectionDescriptor Deserialize(BaseLiteDB.BsonDocument document)
+    {
+        var engine = document["engine"].AsString;
+        var dimensions = document["dimensions"].AsInt32;
+        var optionsDoc = document["options"].AsDocument;
+
+        var options = new SpatialIndexOptions(
+            optionsDoc["precisionBits"].AsInt32,
+            optionsDoc["maxCoveringCells"].AsInt32,
+            optionsDoc["distanceTolerance"].AsDouble,
+            optionsDoc["indexFieldName"].AsString,
+            optionsDoc["boundingBoxFieldName"].AsString);
+
+        return new SpatialCollectionDescriptor(engine, dimensions, options);
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -40,6 +40,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.ReproRunner.Shared",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedMutexHarness", "LiteDB.Tests.SharedMutexHarness\SharedMutexHarness.csproj", "{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core", "LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj", "{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core.Tests", "LiteDB.Spatial.Core.Tests\LiteDB.Spatial.Core.Tests.csproj", "{99F2946D-65FB-4FC8-827D-C3241FB5EF93}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +162,30 @@ Global
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x64.Build.0 = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.ActiveCfg = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -1,0 +1,293 @@
+# Epic: Modular Spatial Revamp (2D Geographic, 2D Cartesian, 3D Cartesian)
+
+## Goals (scope)
+
+- Extract an engine-agnostic core (`LiteDB.Spatial.Core`).
+- Add engines:
+  - `LiteDB.Spatial.Geographic` (2D, WGS84, meters).
+  - `LiteDB.Spatial.Cartesian2D` (flat 2D).
+  - `LiteDB.Spatial.Cartesian3D` (flat 3D points).
+- Standardize internal fields:
+  - `_idx` — numeric index key (Morton/Hilbert later).
+  - `_mbb` — bounding box (4 or 6 values).
+- Keep LINQ-friendly API with index-aware query plans.
+- Provide backfill + deterministic metadata per collection.
+- Ship diagnostics ("explain") and a minimum GeoJSON I/O.
+- Preserve backward compatibility as much as possible.
+
+## Non-Goals (for now)
+
+- 3D meshes/polyhedra predicates.
+- Advanced projections/CRS transforms beyond WGS84.
+- Alternate encoders beyond Morton (scaffold only).
+
+---
+
+## Architecture overview (target)
+
+```
+LiteDB.Spatial.Core
+  Geometry, Engine contracts, LINQ resolver, Metadata, Backfill
+
+LiteDB.Spatial.Indexing
+  MortonIndexEncoder (2D/3D), Hilbert (stub)
+
+LiteDB.Spatial.Geographic
+  GeographicEngine (2D), Haversine/Vincenty, wrap/polar helpers, facade
+
+LiteDB.Spatial.Cartesian2D
+  Cartesian2DEngine, Euclidean2D, facade
+
+LiteDB.Spatial.Cartesian3D
+  Cartesian3DEngine, Euclidean3D, facade
+
+LiteDB.Spatial.Diagnostics
+  Explain(plan) utilities
+
+LiteDB.Spatial.GeoJson
+  Basic GeoJSON serializer
+
+LiteDB.Spatial
+  Top-level facade (dispatch by collection metadata)
+```
+
+---
+
+## Stories & Acceptance Criteria
+
+### S1 — Core contracts & geometry (engine-agnostic)
+
+- [x] Add `GeoPoint`, `GeoPoint3D`, `BoundingBox` (2D: 4 elems; 3D: 6 elems).
+- [x] Define interfaces: `ISpatialEngine`, `ISpatialIndexEncoder`, `ISpatialDistance`, `ISpatialMapper`, `ISpatialQueryPlan`.
+- [x] Core options: `SpatialIndexOptions` (precision, max cells, tolerance, field names).
+- [x] LINQ surface: `SpatialExpressions` (Near/InBox overloads for 2D/3D).
+- [x] Stub `SpatialResolver` for expression translation.
+
+### S2 — Indexing: Morton encoder (2D/3D)
+
+- [x] Implement `MortonIndexEncoder(int dimensions)` with bit-interleaving and helpers.
+- [x] Provide helper to union adjacent ranges for nicer covers.
+
+**Notes**
+
+- Added a reusable `MortonIndexEncoder` that normalizes inputs, emits deterministic Morton codes for two and three dimensions, and can coalesce covering ranges when callers need a coarse approximation.
+- Introduced unit tests that exercise 2D/3D encodings, NaN validation, covering enumeration, and range union behaviour.
+
+### S3 — Metadata store & schema conventions
+
+- [x] `SpatialMetadataStore` persists per-collection descriptor `{ engine, dimensions, options }` in `"_spatial_meta"`.
+- [x] Internal field names customizable via options but default to `_idx` and `_mbb`.
+- [x] Guard mismatches and surface friendly errors.
+
+**Notes**
+
+- Implemented `SpatialCollectionDescriptor` equality semantics and a metadata store with caching, round-trip persistence, and friendly error messages when metadata is missing or incompatible with stored documents.
+- Added schema validation helpers to flag mismatched bounding box lengths, easing diagnosis of dimensional errors.
+
+### S4 — Backfill utility
+
+- [x] `SpatialBackfill.Run<T>(collection, descriptor, batchSize)` populates `_idx`/`_mbb`.
+- [x] Ensure idempotent behavior with detailed counters and error reporting.
+
+**Notes**
+
+- Delivered a document-oriented backfill runner that pages through collections, invokes engine mappers to compute `_idx`/`_mbb`, and reports processed/updated/skipped counts alongside per-document errors.
+- Added smoke tests with stub engines to confirm idempotency, checkpoint handling, and resilience to malformed documents.
+
+### S5 — Geographic engine (2D)
+
+- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+
+### S6 — Cartesian 2D engine
+
+- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+
+### S7 — Cartesian 3D engine (points)
+
+- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+
+### S8 — LINQ resolver
+
+- [ ] Translate `SpatialExpressions` into query plans based on metadata.
+
+### S9 — Diagnostics ("Explain")
+
+- [ ] Produce printable `SpatialExplainResult` summaries for query plans.
+
+### S10 — GeoJSON I/O (minimal)
+
+- [ ] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
+
+### S11 — Top-level facade & dispatch
+
+- [ ] `LiteDB.Spatial.Spatial` entry point manages engine configuration and dispatch.
+
+### S12 — Migration & docs
+
+- [ ] Author upgrade/guide/diagnostics documentation with samples.
+
+### S13 — Benchmarks & regression guardrails
+
+- [ ] Capture performance baselines and add regression guardrails.
+
+---
+
+## Backward Compatibility & Risk Mitigation
+
+- **Internal field rename**: standardize on `_idx` (previously `_gh`). Keep `_gh` reading optional if present (migration path), but **do not** write new `_gh`. Provide backfill to `_idx`.
+- **Engine selection**: no global singletons; bind per collection via metadata to avoid cross-collection leakage.
+- **Precision in 3D**: document that 3D needs higher `PrecisionBits` for similar spatial locality; default +4 vs 2D.
+- **Range explosion**: cap by `MaxCoveringCells`; if exceeded, coarsen ranges and rely on exact filters (documented behavior).
+
+---
+
+## Public API sketch (stable surface)
+
+```csharp
+// Top-level
+Spatial.UseGeographic(col, new GeographicOptions { PrecisionBits = 32 });
+Spatial.EnsurePointIndex(col, x => x.Location); // GeoPoint
+var near = Spatial.Near(col, x => x.Location, new GeoPoint(lon, lat), radius: 1500).ToList();
+
+Spatial.UseCartesian2D(col2, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col2, x => x.Pos2D); // GeoPoint
+var inBox = Spatial.WithinBoundingBox(col2, x => x.Pos2D, BoundingBox.From2D(0,0,10,10)).ToList();
+
+Spatial.UseCartesian3D(col3, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col3, x => x.Pos3D); // GeoPoint3D
+var hits = Spatial.Near(col3, x => x.Pos3D, new GeoPoint3D(1,2,3), radius: 5).ToList();
+```
+
+---
+
+## Test Matrix (minimum)
+
+- **Core**: BoundingBox dims, options defaults, metadata round-trip.
+- **Indexing**: Morton 2D/3D grids + boundaries.
+- **Geographic**: Near Berlin; anti-meridian bbox; polar bbox.
+- **Cartesian2D**: Near/InBox on grid; candidate pruning verified.
+- **Cartesian3D**: Near3D + AABB on 3D lattice; MaxCoveringCells respected.
+- **LINQ**: Expression translation picks correct engine; index predicate present.
+- **Backfill**: idempotency; mixed docs with/without fields.
+- **Diagnostics**: explain outputs consistent and human-readable.
+
+---
+
+## Deliverables checklist (per PR)
+
+- [ ] Code compiles, no public API breaking changes outside the new surface.
+- [ ] Unit + integration tests green.
+- [ ] Samples updated.
+- [ ] Docs updated (guide/upgrade/diagnostics).
+- [ ] Bench baseline captured.
+- [ ] Changelog entry with migration notes (`_gh` → `_idx`).
+
+---
+
+## Rollout plan
+
+1. Merge Core + Indexing + Geographic (smallest behavior delta).
+2. Introduce Cartesian2D (flat replacement for non-Earth use).
+3. Add Cartesian3D (points + AABB + Near3D).
+4. Enable LINQ resolver by default; keep a feature flag to disable if needed.
+5. Publish docs and a sample upgrade script demonstrating backfill.
+
+---
+
+## Addendum: Battle-Tested Oracles & Datasets
+
+### Reference libraries (use as **oracles**, not dependencies of runtime)
+
+- **Geometry predicates (2D):** `NetTopologySuite (NTS)` — robust predicates: `Contains`, `Intersects`, `Within`, polygon holes/edge cases.
+- **Geodesic distances (Earth):** `GeographicLib` — great-circle, inverse geodesic; use as golden values.
+- **Projections / CRS transforms (optional sanity):** `ProjNET` — to cross-check lon/lat ↔ projected calculations for small-radius approximations.
+- **3D math:** `MathNet.Spatial` — Euclidean 3D distances and vector ops for oracle checks.
+- **GeoJSON parsing (test-only):** `GeoJSON.Net` — load complex fixtures without maintaining your own parser.
+- **External systems for differential tests (CI optional):** `PostGIS`, `SQLite+RTree/SpatiaLite` for bbox/near behavior.
+
+### Public datasets & fixtures
+
+- `Turf.js` fixtures (GeoJSON): points/lines/polygons with holes; great for predicate parity.
+- `Natural Earth`: coastlines, large polygons crossing the anti-meridian (Aleutians, Russia); polar stress.
+- `OSM` extracts (tiny tiles): dense urban point clouds for performance & correctness mixes.
+- Synthetic grids & lattices: controlled point sets for Morton/Hilbert locality tests.
+- Precomputed geodesic pairs from GeographicLib samples (save as JSON with expected distances).
+
+### New Stories (append to Epic)
+
+#### T1 — Oracle Adapters
+
+- [ ] Add `LiteDB.Spatial.Testing.Oracles` project with adapters for NTS, GeographicLib, MathNet, PostGIS.
+
+#### T2 — Golden Fixtures & Tolerances
+
+- [ ] Store fixtures under `/tests/fixtures` with documented tolerances and snapshot helpers.
+
+#### T3 — Differential Correctness: Geographic 2D
+
+- [ ] Cross-check `SpatialGeographic` behavior against PostGIS and GeographicLib oracles.
+
+#### T4 — Differential Correctness: Cartesian 2D
+
+- [ ] Validate Euclidean behavior with NTS and property-based testing.
+
+#### T5 — Differential Correctness: Cartesian 3D
+
+- [ ] Ensure 3D results align with MathNet.Spatial and range caps.
+
+#### T6 — Index Locality & Stability (Morton)
+
+- [ ] Measure locality/monotonicity and compare to reference encoders.
+
+#### T7 — Query Plan Parity (LINQ)
+
+- [ ] Assert LINQ plans use indexes and match oracles.
+
+#### T8 — Performance Sanity vs External Systems (optional `perf`)
+
+- [ ] Benchmark LiteDB.Spatial vs SQLite/PostGIS and record findings.
+
+---
+
+## Concrete snippets (test-only patterns)
+
+```csharp
+// Distance parity (Geographic)
+var d1 = GeographicLibOracle.Distance(lon1, lat1, lon2, lat2);
+var d2 = SpatialGeographicDistance.Haversine(lon1, lat1, lon2, lat2);
+d2.Should().BeApproximately(d1, 1e-4 * d1 + 0.05);
+```
+
+```csharp
+// Predicate parity (2D)
+var expected = NtsOracle.Contains(poly, pt);
+var actual = SpatialExpressions.Within(/* polygon */, /* point */);
+actual.Should().Be(expected);
+```
+
+```csharp
+// 3D near parity
+var dRef = MathNetOracle3D.Distance(a, b);
+var dOur = Euclidean3D.Distance(a, b);
+dOur.Should().BeApproximately(dRef, 1e-9);
+```
+
+---
+
+## Integration guidance
+
+- Keep external libraries under `tests` only and guard with categories/env vars.
+- Persist expensive oracle outputs to JSON fixtures for reproducible CI runs.
+- Document toggles like `SPATIAL_ORACLES` and `SPATIAL_DB_TESTS` for optional suites.
+
+---
+
+## Acceptance Criteria (global)
+
+- Geographic distances match GeographicLib within tolerance on 1,000 diverse pairs.
+- 2D predicates match NTS on 100 complex polygons × 1,000 random points each.
+- 3D distances match MathNet.Spatial within floating-point tolerance on 10,000 random pairs.
+- Index usage verified by explain output in every LINQ test; no full scans when index present.
+- Fixtures pack checked into the repo; tests avoid network calls.
+


### PR DESCRIPTION
## Summary
- add a Morton-based spatial index encoder with range coalescing utilities
- persist spatial collection descriptors through a metadata store with friendly validation
- introduce a document backfill pipeline and result reporting for spatial index fields, with unit coverage and updated docs

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e7407432f083268c81ccebffb8f4bb