### PR TITLE
Implement Morton encoder, metadata store, and backfill utilities

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Backfill/SpatialBackfillTests.cs
@@ -1,0 +1,219 @@
+extern alias litedb;
+using System;
+using System.IO;
+using FluentAssertions;
+using LiteDbRuntime = litedb::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Backfill;
+
+public class SpatialBackfillTests
+{
+    [Fact]
+    public void Run_ShouldPopulateMissingFieldsAndTrackCounters()
+    {
+        using var database = new LiteDbRuntime.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection<LiteDbRuntime.BsonDocument>("docs");
+        var engine = CreateEngine();
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor(engine.Name, engine.Dimensions, engine.Options, engine);
+
+        collection.Insert(new LiteDbRuntime.BsonDocument
+        {
+            ["_id"] = 1,
+            ["point"] = new LiteDbRuntime.BsonArray { 0.1, 0.2 }
+        });
+
+        collection.Insert(new LiteDbRuntime.BsonDocument
+        {
+            ["_id"] = 2,
+            ["point"] = new LiteDbRuntime.BsonArray { 0.3, 0.4 }
+        });
+
+        collection.Insert(new LiteDbRuntime.BsonDocument
+        {
+            ["_id"] = 3,
+            ["point"] = new LiteDbRuntime.BsonArray { 0.5, 0.6 },
+            ["_idx"] = new LiteDbRuntime.BsonValue(42),
+            ["_mbb"] = new LiteDbRuntime.BsonArray { 0.5, 0.6, 0.5, 0.6 }
+        });
+
+        collection.Insert(new LiteDbRuntime.BsonDocument
+        {
+            ["_id"] = 4,
+            ["value"] = 99
+        });
+
+        var result = LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, batchSize: 2);
+
+        result.UpdatedCount.Should().Be(2);
+        result.SkippedCount.Should().Be(1);
+        result.ErrorCount.Should().Be(1);
+        result.LastCheckpoint.Should().Be(new LiteDbRuntime.BsonValue(4));
+
+        var updated = collection.FindById(1);
+        ((object)updated).Should().NotBeNull();
+        var updatedDocument = updated!;
+        updatedDocument["_idx"].Should().NotBeNull();
+        updatedDocument["_mbb"].AsArray.Count.Should().Be(4);
+
+        var rerun = LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, batchSize: 2);
+        rerun.UpdatedCount.Should().Be(0);
+        rerun.SkippedCount.Should().Be(3);
+        rerun.ErrorCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Run_ShouldRespectResumeCheckpoint()
+    {
+        using var database = new LiteDbRuntime.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection<LiteDbRuntime.BsonDocument>("docs");
+        var engine = CreateEngine();
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor(engine.Name, engine.Dimensions, engine.Options, engine);
+
+        for (var i = 1; i <= 4; i++)
+        {
+            collection.Insert(new LiteDbRuntime.BsonDocument
+            {
+                ["_id"] = i,
+                ["point"] = new LiteDbRuntime.BsonArray { 0.1 * i, 0.1 * i }
+            });
+        }
+
+        var firstRun = LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, batchSize: 2, resumeAfter: new LiteDbRuntime.BsonValue(2));
+
+        firstRun.UpdatedCount.Should().Be(2);
+        firstRun.SkippedCount.Should().Be(0);
+        firstRun.ErrorCount.Should().Be(0);
+        firstRun.LastCheckpoint.Should().Be(new LiteDbRuntime.BsonValue(4));
+    }
+
+    [Fact]
+    public void Run_ShouldThrowWhenBoundingBoxLengthMismatch()
+    {
+        using var database = new LiteDbRuntime.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection<LiteDbRuntime.BsonDocument>("docs");
+        var engine = CreateEngine();
+        var descriptor = new LiteDB.Spatial.SpatialCollectionDescriptor(engine.Name, engine.Dimensions, engine.Options, engine);
+
+        collection.Insert(new LiteDbRuntime.BsonDocument
+        {
+            ["_id"] = 1,
+            ["point"] = new LiteDbRuntime.BsonArray { 0.1, 0.1 },
+            ["_idx"] = new LiteDbRuntime.BsonValue(1),
+            ["_mbb"] = new LiteDbRuntime.BsonArray { 0.1, 0.1, 0.1 }
+        });
+
+        Action act = () => LiteDB.Spatial.SpatialBackfill.Run(collection, descriptor, batchSize: 1);
+
+        act.Should().Throw<LiteDbRuntime.LiteException>()
+            .Which.Message.Should().Contain("Expected 4 values");
+    }
+
+    private static TestSpatialEngine CreateEngine()
+    {
+        var options = new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 8);
+        return new TestSpatialEngine(2, options);
+    }
+
+    private sealed class TestSpatialEngine : LiteDB.Spatial.ISpatialEngine
+    {
+        public TestSpatialEngine(int dimensions, LiteDB.Spatial.SpatialIndexOptions options)
+        {
+            Dimensions = dimensions;
+            Options = options;
+            Name = dimensions == 3 ? "Test3D" : "Test2D";
+            IndexEncoder = new LiteDB.Spatial.MortonIndexEncoder(dimensions, options.PrecisionBits);
+            Mapper = new TestSpatialMapper(IndexEncoder, dimensions);
+            Distance = new TestSpatialDistance();
+        }
+
+        public string Name { get; }
+
+        public int Dimensions { get; }
+
+        public LiteDB.Spatial.SpatialIndexOptions Options { get; }
+
+        public LiteDB.Spatial.ISpatialIndexEncoder IndexEncoder { get; }
+
+        public LiteDB.Spatial.ISpatialMapper Mapper { get; }
+
+        public LiteDB.Spatial.ISpatialDistance Distance { get; }
+
+        public LiteDB.Spatial.ISpatialQueryPlan PlanNear(global::LiteDB.Spatial.GeoPoint center, double radius) => throw new NotSupportedException();
+
+        public LiteDB.Spatial.ISpatialQueryPlan PlanNear(global::LiteDB.Spatial.GeoPoint3D center, double radius) => throw new NotSupportedException();
+
+        public LiteDB.Spatial.ISpatialQueryPlan PlanWithin(global::LiteDB.Spatial.BoundingBox bounds) => throw new NotSupportedException();
+    }
+
+        private sealed class TestSpatialMapper : LiteDB.Spatial.ISpatialMapper
+        {
+            private readonly LiteDB.Spatial.ISpatialIndexEncoder _encoder;
+            private readonly int _dimensions;
+
+            public TestSpatialMapper(LiteDB.Spatial.ISpatialIndexEncoder encoder, int dimensions)
+            {
+                _encoder = encoder;
+                _dimensions = dimensions;
+            }
+
+        public LiteDB.Spatial.BoundingBox GetBoundingBox(global::LiteDB.Spatial.GeoPoint point)
+        {
+            return global::LiteDB.Spatial.BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+        }
+
+        public LiteDB.Spatial.BoundingBox GetBoundingBox(global::LiteDB.Spatial.GeoPoint3D point)
+        {
+            return global::LiteDB.Spatial.BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+        }
+
+        public ulong Encode(global::LiteDB.Spatial.GeoPoint point)
+        {
+            return _encoder.Encode(new[] { point.Longitude, point.Latitude });
+        }
+
+        public ulong Encode(global::LiteDB.Spatial.GeoPoint3D point)
+        {
+            return _encoder.Encode(new[] { point.X, point.Y, point.Z });
+        }
+
+        public bool TryMapDocument(LiteDbRuntime.BsonDocument document, LiteDB.Spatial.SpatialIndexOptions options, out ulong index, out LiteDB.Spatial.BoundingBox boundingBox)
+        {
+            if (!document.TryGetValue("point", out var value) || !value.IsArray)
+            {
+                index = default;
+                boundingBox = default;
+                return false;
+            }
+
+            var array = value.AsArray;
+
+            if (_dimensions == 2 && array.Count >= 2)
+            {
+                var point = new global::LiteDB.Spatial.GeoPoint(array[0].AsDouble, array[1].AsDouble);
+                boundingBox = GetBoundingBox(point);
+                index = Encode(point);
+                return true;
+            }
+
+            if (_dimensions == 3 && array.Count >= 3)
+            {
+                var point = new global::LiteDB.Spatial.GeoPoint3D(array[0].AsDouble, array[1].AsDouble, array[2].AsDouble);
+                boundingBox = GetBoundingBox(point);
+                index = Encode(point);
+                return true;
+            }
+
+            index = default;
+            boundingBox = default;
+            return false;
+        }
+    }
+
+    private sealed class TestSpatialDistance : LiteDB.Spatial.ISpatialDistance
+    {
+        public double Distance(global::LiteDB.Spatial.GeoPoint left, global::LiteDB.Spatial.GeoPoint right) => 0d;
+
+        public double Distance(global::LiteDB.Spatial.GeoPoint3D left, global::LiteDB.Spatial.GeoPoint3D right) => 0d;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/SpatialIndexOptionsTests.cs
@@ -1,0 +1,57 @@
+using System;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public class SpatialIndexOptionsTests
+{
+    [Fact]
+    public void SpatialIndexOptions_ShouldUseSensibleDefaults()
+    {
+        var options = new SpatialIndexOptions();
+
+        options.PrecisionBits.Should().Be(32);
+        options.MaxCoveringCells.Should().Be(64);
+        options.DistanceTolerance.Should().Be(0.001);
+        options.IndexFieldName.Should().Be(SpatialIndexOptions.DefaultIndexFieldName);
+        options.BoundingBoxFieldName.Should().Be(SpatialIndexOptions.DefaultBoundingBoxFieldName);
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_ShouldAllowCustomization()
+    {
+        var options = new SpatialIndexOptions(40, 128, 0.25, "_custom_idx", "_custom_mbb");
+
+        options.PrecisionBits.Should().Be(40);
+        options.MaxCoveringCells.Should().Be(128);
+        options.DistanceTolerance.Should().Be(0.25);
+        options.IndexFieldName.Should().Be("_custom_idx");
+        options.BoundingBoxFieldName.Should().Be("_custom_mbb");
+    }
+
+    [Fact]
+    public void SpatialIndexOptions_With_ShouldCreateNewInstance()
+    {
+        var options = new SpatialIndexOptions();
+        var updated = options.With(distanceTolerance: 0.01);
+
+        updated.Should().NotBeSameAs(options);
+        updated.DistanceTolerance.Should().Be(0.01);
+        updated.IndexFieldName.Should().Be(options.IndexFieldName);
+    }
+
+    [Theory]
+    [InlineData(0, 1, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 0, 0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, -0.1, "_idx", "_mbb")]
+    [InlineData(32, 1, 0.1, "", "_mbb")]
+    [InlineData(32, 1, 0.1, "_idx", " ")]
+    public void SpatialIndexOptions_ShouldValidateInputs(int precisionBits, int maxCells, double tolerance, string indexField, string mbbField)
+    {
+        Action act = () => new SpatialIndexOptions(precisionBits, maxCells, tolerance, indexField, mbbField);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/BoundingBoxTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class BoundingBoxTests
+{
+    [Fact]
+    public void BoundingBox_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(BoundingBox);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BoundingBox2D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From2D(-10, -5, 20, 15);
+
+        box.Dimensions.Should().Be(2);
+        box.Is3D.Should().BeFalse();
+        box.MinX.Should().Be(-10);
+        box.MinY.Should().Be(-5);
+        box.MaxX.Should().Be(20);
+        box.MaxY.Should().Be(15);
+        box.GetValues().ToArray().Should().Equal(-10, -5, 20, 15);
+    }
+
+    [Fact]
+    public void BoundingBox3D_ShouldExposeExtentsAndDimensions()
+    {
+        var box = BoundingBox.From3D(-1, -2, -3, 4, 5, 6);
+
+        box.Dimensions.Should().Be(3);
+        box.Is3D.Should().BeTrue();
+        box.MinX.Should().Be(-1);
+        box.MinY.Should().Be(-2);
+        box.MinZ.Should().Be(-3);
+        box.MaxX.Should().Be(4);
+        box.MaxY.Should().Be(5);
+        box.MaxZ.Should().Be(6);
+        box.GetValues().ToArray().Should().Equal(-1, -2, -3, 4, 5, 6);
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidAxisOrdering()
+    {
+        Action twoD = () => BoundingBox.From2D(5, 0, 4, 1);
+        Action threeD = () => BoundingBox.From3D(0, 0, 0, -1, 2, 3);
+
+        twoD.Should().Throw<ArgumentException>();
+        threeD.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void BoundingBox_ShouldRejectInvalidValueCount()
+    {
+        Action act = () => BoundingBox.Create(new[] { 1.0, 2.0, 3.0 });
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPoint3DTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPoint3DTests
+{
+    [Fact]
+    public void GeoPoint3D_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint3D);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint3D_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint3D(1, 2, 3);
+
+        point.X.Should().Be(1);
+        point.Y.Should().Be(2);
+        point.Z.Should().Be(3);
+        point.ToString().Should().Be("(1, 2, 3)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0, 0)]
+    [InlineData(0, double.NaN, 0)]
+    [InlineData(0, 0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0, 0)]
+    [InlineData(0, double.NegativeInfinity, 0)]
+    [InlineData(0, 0, double.PositiveInfinity)]
+    public void GeoPoint3D_ShouldRejectNonFiniteValues(double x, double y, double z)
+    {
+        Action act = () => new GeoPoint3D(x, y, z);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Geometry/GeoPointTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Geometry;
+
+public class GeoPointTests
+{
+    [Fact]
+    public void GeoPoint_ShouldBeReadOnlyStruct()
+    {
+        var type = typeof(GeoPoint);
+        type.IsValueType.Should().BeTrue();
+        type.IsDefined(typeof(System.Runtime.CompilerServices.IsReadOnlyAttribute), inherit: false).Should().BeTrue();
+
+        var nonReadonlyFields = type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => !field.IsInitOnly)
+            .ToList();
+
+        nonReadonlyFields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GeoPoint_ShouldExposeCoordinates()
+    {
+        var point = new GeoPoint(12.5, -23.4);
+
+        point.Longitude.Should().Be(12.5);
+        point.Latitude.Should().Be(-23.4);
+        point.ToString().Should().Be("(12.5, -23.4)");
+    }
+
+    [Theory]
+    [InlineData(double.NaN, 0)]
+    [InlineData(0, double.NaN)]
+    [InlineData(double.PositiveInfinity, 0)]
+    [InlineData(0, double.NegativeInfinity)]
+    public void GeoPoint_ShouldRejectNonFiniteValues(double longitude, double latitude)
+    {
+        Action act = () => new GeoPoint(longitude, latitude);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
@@ -1,0 +1,73 @@
+using System;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Indexing;
+
+public class MortonIndexEncoderTests
+{
+    [Fact]
+    public void Encode2D_ShouldProduceExpectedMortonCodes()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 3);
+
+        Encode(encoder, 0.0, 0.0).Should().Be(0UL);
+        Encode(encoder, 1.0, 0.0).Should().Be(21UL);
+        Encode(encoder, 0.0, 1.0).Should().Be(42UL);
+        Encode(encoder, 1.0, 1.0).Should().Be(63UL);
+    }
+
+    [Fact]
+    public void Encode3D_ShouldInterleaveAllAxes()
+    {
+        var encoder = new MortonIndexEncoder(3, precisionBits: 2);
+
+        Encode(encoder, 0.0, 0.0, 0.0).Should().Be(0UL);
+        Encode(encoder, 1.0, 0.0, 0.0).Should().Be(9UL);
+        Encode(encoder, 0.0, 1.0, 0.0).Should().Be(18UL);
+        Encode(encoder, 0.0, 0.0, 1.0).Should().Be(36UL);
+        Encode(encoder, 1.0, 1.0, 1.0).Should().Be(63UL);
+    }
+
+    [Fact]
+    public void Encode_ShouldRejectNaN()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 2);
+
+        Action act = () => encoder.Encode(new[] { double.NaN, 0.5 });
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Cover_ShouldReturnSingleRangeForEntireSpace()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 3);
+        var bounds = BoundingBox.From2D(0, 0, 1, 1);
+
+        var ranges = encoder.Cover(bounds, maxCells: 4);
+
+        ranges.Should().HaveCount(1);
+        ranges[0].Start.Should().Be(0UL);
+        ranges[0].End.Should().Be(63UL);
+    }
+
+    [Fact]
+    public void Cover_ShouldCoalesceAdjacentRanges()
+    {
+        var encoder = new MortonIndexEncoder(2, precisionBits: 3);
+        var bounds = BoundingBox.From2D(0, 0, 0.5, 0.25);
+
+        var ranges = encoder.Cover(bounds, maxCells: 2);
+
+        ranges.Should().NotBeEmpty();
+        ranges.Should().OnlyContain(range => range.Start <= range.End);
+        ranges.Count.Should().BeLessOrEqualTo(2);
+    }
+
+    private static ulong Encode(MortonIndexEncoder encoder, params double[] values)
+    {
+        return encoder.Encode(values);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial.Core.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>litedb</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Metadata/SpatialMetadataStoreTests.cs
@@ -1,0 +1,51 @@
+extern alias litedb;
+using System;
+using System.IO;
+using FluentAssertions;
+using LiteDbRuntime = litedb::LiteDB;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Metadata;
+
+public class SpatialMetadataStoreTests
+{
+    [Fact]
+    public void PersistAndLoadDescriptor_ShouldRoundTrip()
+    {
+        using var database = new LiteDbRuntime.LiteDatabase(new MemoryStream());
+        var options = new SpatialIndexOptions(precisionBits: 18, maxCoveringCells: 32, distanceTolerance: 0.01, indexFieldName: "idx", boundingBoxFieldName: "bbox");
+        var descriptor = new SpatialCollectionDescriptor("TestEngine", 2, options);
+
+        SpatialMetadataStore.Persist(database, "places", descriptor);
+        var loaded = SpatialMetadataStore.GetRequired(database, "places");
+
+        loaded.Should().NotBeNull();
+        loaded.EngineName.Should().Be(descriptor.EngineName);
+        loaded.Dimensions.Should().Be(descriptor.Dimensions);
+        loaded.Options.Should().Be(descriptor.Options);
+    }
+
+    [Fact]
+    public void GetRequired_WhenMissing_ShouldSurfaceHelpfulError()
+    {
+        using var database = new LiteDbRuntime.LiteDatabase(new MemoryStream());
+
+        Action act = () => SpatialMetadataStore.GetRequired(database, "missing");
+
+        act.Should().Throw<LiteDbRuntime.LiteException>()
+            .Which.Message.Should().Contain("UseGeographic");
+    }
+
+    [Fact]
+    public void ValidateBoundingBoxValue_ShouldRejectIncorrectLength()
+    {
+        var descriptor = new SpatialCollectionDescriptor("Engine", 3, new SpatialIndexOptions());
+        var invalidArray = new LiteDbRuntime.BsonArray { 0, 1, 2, 3 };
+
+        Action act = () => descriptor.ValidateBoundingBoxValue(invalidArray, "field");
+
+        act.Should().Throw<LiteDbRuntime.LiteException>()
+            .Which.Message.Should().Contain("Expected 6 values");
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfill.cs
@@ -1,0 +1,139 @@
+#nullable enable
+
+extern alias litedb;
+using System;
+using System.Collections.Generic;
+using LiteDbRuntime = litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides utilities for backfilling spatial index fields on existing collections.
+/// </summary>
+public static class SpatialBackfill
+{
+    /// <summary>
+    /// Executes a spatial backfill for the specified collection.
+    /// </summary>
+    /// <param name="collection">The target collection.</param>
+    /// <param name="descriptor">The spatial descriptor describing the collection.</param>
+    /// <param name="batchSize">The number of documents to update per batch.</param>
+    /// <param name="resumeAfter">Optional checkpoint identifier used to resume large backfills.</param>
+    public static SpatialBackfillResult Run(LiteDbRuntime.ILiteCollection<LiteDbRuntime.BsonDocument> collection, SpatialCollectionDescriptor descriptor, int batchSize, LiteDbRuntime.BsonValue? resumeAfter = null)
+    {
+        if (collection == null)
+        {
+            throw new ArgumentNullException(nameof(collection));
+        }
+
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (!descriptor.HasEngine)
+        {
+            throw new InvalidOperationException("A runtime engine must be attached to the descriptor before executing the backfill.");
+        }
+
+        if (batchSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(batchSize), "Batch size must be a positive number.");
+        }
+
+        var result = new SpatialBackfillResult();
+        var mapper = descriptor.Engine!.Mapper;
+        var options = descriptor.Options;
+        var expectedLength = descriptor.ExpectedBoundingBoxLength;
+        var indexField = options.IndexFieldName;
+        var boundingField = options.BoundingBoxFieldName;
+        var buffer = new List<LiteDbRuntime.BsonDocument>(batchSize);
+        LiteDbRuntime.BsonValue? lastId = null;
+
+        foreach (var document in collection.FindAll())
+        {
+            if (!document.TryGetValue("_id", out var identifier))
+            {
+                result.ErrorCount++;
+                continue;
+            }
+
+            if (resumeAfter != null && !resumeAfter.IsNull && identifier.CompareTo(resumeAfter) <= 0)
+            {
+                continue;
+            }
+
+            lastId = identifier;
+
+            var hasIndex = document.TryGetValue(indexField, out var indexValue) && indexValue.IsNumber;
+            var hasBounding = document.TryGetValue(boundingField, out var boundingValue) && boundingValue.IsArray;
+
+            if (hasBounding)
+            {
+                descriptor.ValidateBoundingBoxValue(boundingValue, boundingField);
+            }
+
+            if (hasIndex && hasBounding && boundingValue!.AsArray.Count == expectedLength)
+            {
+                result.SkippedCount++;
+                continue;
+            }
+
+            if (!mapper.TryMapDocument(document, options, out var index, out var boundingBox))
+            {
+                result.ErrorCount++;
+                continue;
+            }
+
+            descriptor.ValidateBoundingBox(boundingBox);
+
+            document[indexField] = ToIndexValue(index);
+            document[boundingField] = ToBoundingArray(boundingBox);
+
+            buffer.Add(document);
+            result.UpdatedCount++;
+
+            if (buffer.Count >= batchSize)
+            {
+                Flush(collection, buffer);
+            }
+        }
+
+        if (buffer.Count > 0)
+        {
+            Flush(collection, buffer);
+        }
+
+        result.LastCheckpoint = lastId;
+        return result;
+    }
+
+    private static void Flush(LiteDbRuntime.ILiteCollection<LiteDbRuntime.BsonDocument> collection, List<LiteDbRuntime.BsonDocument> buffer)
+    {
+        collection.Update(buffer);
+        buffer.Clear();
+    }
+
+    private static LiteDbRuntime.BsonValue ToIndexValue(ulong index)
+    {
+        if (index <= long.MaxValue)
+        {
+            return new LiteDbRuntime.BsonValue((long)index);
+        }
+
+        return new LiteDbRuntime.BsonValue((decimal)index);
+    }
+
+    private static LiteDbRuntime.BsonArray ToBoundingArray(BoundingBox boundingBox)
+    {
+        var values = boundingBox.GetValues();
+        var array = new LiteDbRuntime.BsonArray();
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            array.Add(new LiteDbRuntime.BsonValue(values[i]));
+        }
+
+        return array;
+    }
+}

--- a/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
+++ b/LiteDB.Spatial.Core/Backfill/SpatialBackfillResult.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+extern alias litedb;
+using LiteDbRuntime = litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents the outcome of a spatial backfill operation.
+/// </summary>
+public sealed class SpatialBackfillResult
+{
+    internal SpatialBackfillResult()
+    {
+    }
+
+    /// <summary>
+    /// Gets the number of documents that were updated during the backfill.
+    /// </summary>
+    public int UpdatedCount { get; internal set; }
+
+    /// <summary>
+    /// Gets the number of documents that already contained the expected spatial fields.
+    /// </summary>
+    public int SkippedCount { get; internal set; }
+
+    /// <summary>
+    /// Gets the number of documents that could not be processed.
+    /// </summary>
+    public int ErrorCount { get; internal set; }
+
+    /// <summary>
+    /// Gets the identifier of the last processed document, which can be used as a checkpoint.
+    /// </summary>
+    public LiteDbRuntime.BsonValue? LastCheckpoint { get; internal set; }
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialDistance.cs
@@ -1,0 +1,17 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes distances between spatial points for exact filtering.
+/// </summary>
+public interface ISpatialDistance
+{
+    /// <summary>
+    /// Computes the distance between two geographic points expressed in meters.
+    /// </summary>
+    double Distance(global::LiteDB.Spatial.GeoPoint left, global::LiteDB.Spatial.GeoPoint right);
+
+    /// <summary>
+    /// Computes the distance between two Cartesian points expressed in user-defined units.
+    /// </summary>
+    double Distance(global::LiteDB.Spatial.GeoPoint3D left, global::LiteDB.Spatial.GeoPoint3D right);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialEngine.cs
@@ -1,0 +1,52 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a spatial engine capable of producing index-aware query plans and mapping values.
+/// </summary>
+public interface ISpatialEngine
+{
+    /// <summary>
+    /// Gets the human-readable engine name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the engine.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the options associated with the engine.
+    /// </summary>
+    SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Gets the encoder used to map coordinates into index keys.
+    /// </summary>
+    ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <summary>
+    /// Gets the component responsible for mapping values to index fields.
+    /// </summary>
+    ISpatialMapper Mapper { get; }
+
+    /// <summary>
+    /// Gets the distance calculator used for exact filtering.
+    /// </summary>
+    ISpatialDistance Distance { get; }
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(global::LiteDB.Spatial.GeoPoint center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided radius of the target point.
+    /// </summary>
+    ISpatialQueryPlan PlanNear(global::LiteDB.Spatial.GeoPoint3D center, double radius);
+
+    /// <summary>
+    /// Creates a query plan that selects values within the provided bounding box.
+    /// </summary>
+    ISpatialQueryPlan PlanWithin(BoundingBox bounds);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialMapper.cs
@@ -1,0 +1,40 @@
+extern alias litedb;
+using LiteDbRuntime = litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Projects application-level spatial values into indexable representations.
+/// </summary>
+public interface ISpatialMapper
+{
+    /// <summary>
+    /// Computes the bounding box for the provided two-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(global::LiteDB.Spatial.GeoPoint point);
+
+    /// <summary>
+    /// Computes the bounding box for the provided three-dimensional point.
+    /// </summary>
+    BoundingBox GetBoundingBox(global::LiteDB.Spatial.GeoPoint3D point);
+
+    /// <summary>
+    /// Encodes a two-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(global::LiteDB.Spatial.GeoPoint point);
+
+    /// <summary>
+    /// Encodes a three-dimensional point into the spatial index key space.
+    /// </summary>
+    ulong Encode(global::LiteDB.Spatial.GeoPoint3D point);
+
+    /// <summary>
+    /// Attempts to map the provided document into index fields using the configured options.
+    /// </summary>
+    /// <param name="document">The source document.</param>
+    /// <param name="options">The spatial index options for the collection.</param>
+    /// <param name="index">When this method returns, contains the encoded index value.</param>
+    /// <param name="boundingBox">When this method returns, contains the computed bounding box.</param>
+    /// <returns><c>true</c> if the document contains a spatial value that can be indexed; otherwise, <c>false</c>.</returns>
+    bool TryMapDocument(LiteDbRuntime.BsonDocument document, SpatialIndexOptions options, out ulong index, out BoundingBox boundingBox);
+}

--- a/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes the pieces required to execute a spatial query using index ranges and precise filters.
+/// </summary>
+public interface ISpatialQueryPlan
+{
+    /// <summary>
+    /// Gets the dimensionality of the underlying spatial index.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the coarse bounding region evaluated before exact predicates. May be <c>null</c> when not applicable.
+    /// </summary>
+    BoundingBox? CoveringBounds { get; }
+
+    /// <summary>
+    /// Gets the ordered set of index ranges that should be scanned.
+    /// </summary>
+    IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <summary>
+    /// Gets a human readable description of the exact predicate applied after index filtering.
+    /// </summary>
+    string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialIndexOptions.cs
@@ -1,0 +1,167 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents configuration options that govern how spatial indexes are generated and queried.
+/// </summary>
+public sealed class SpatialIndexOptions : IEquatable<SpatialIndexOptions>
+{
+    /// <summary>
+    /// The default name for the numeric index field stored on documents.
+    /// </summary>
+    public const string DefaultIndexFieldName = "_idx";
+
+    /// <summary>
+    /// The default name for the bounding box field stored on documents.
+    /// </summary>
+    public const string DefaultBoundingBoxFieldName = "_mbb";
+
+    /// <summary>
+    /// The default precision in bits applied to each coordinate axis.
+    /// </summary>
+    public const int DefaultPrecision = 32;
+
+    /// <summary>
+    /// The default maximum number of cells used for index coverings.
+    /// </summary>
+    public const int DefaultMaxCoveringCells = 64;
+
+    /// <summary>
+    /// The default distance tolerance applied to near queries.
+    /// </summary>
+    public const double DefaultDistanceTolerance = 0.001d;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexOptions"/> class.
+    /// </summary>
+    /// <param name="precisionBits">Number of bits used by the index encoder to represent each axis.</param>
+    /// <param name="maxCoveringCells">The maximum number of index ranges allowed when covering a shape.</param>
+    /// <param name="distanceTolerance">Additional expansion applied to distance queries to accommodate floating-point error.</param>
+    /// <param name="indexFieldName">The field used to store the encoded index value on documents.</param>
+    /// <param name="boundingBoxFieldName">The field used to store the bounding box on documents.</param>
+    public SpatialIndexOptions(
+        int precisionBits = DefaultPrecision,
+        int maxCoveringCells = DefaultMaxCoveringCells,
+        double distanceTolerance = DefaultDistanceTolerance,
+        string indexFieldName = DefaultIndexFieldName,
+        string boundingBoxFieldName = DefaultBoundingBoxFieldName)
+    {
+        if (precisionBits <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be a positive number of bits.");
+        }
+
+        if (maxCoveringCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCoveringCells), "The maximum number of covering cells must be positive.");
+        }
+
+        if (distanceTolerance < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(distanceTolerance), "Distance tolerance cannot be negative.");
+        }
+
+        if (string.IsNullOrWhiteSpace(indexFieldName))
+        {
+            throw new ArgumentException("Index field name cannot be null or whitespace.", nameof(indexFieldName));
+        }
+
+        if (string.IsNullOrWhiteSpace(boundingBoxFieldName))
+        {
+            throw new ArgumentException("Bounding box field name cannot be null or whitespace.", nameof(boundingBoxFieldName));
+        }
+
+        PrecisionBits = precisionBits;
+        MaxCoveringCells = maxCoveringCells;
+        DistanceTolerance = distanceTolerance;
+        IndexFieldName = indexFieldName;
+        BoundingBoxFieldName = boundingBoxFieldName;
+    }
+
+    /// <summary>
+    /// Gets the number of bits allocated to represent each coordinate axis.
+    /// </summary>
+    public int PrecisionBits { get; }
+
+    /// <summary>
+    /// Gets the maximum number of index cells that planners may request when approximating shapes.
+    /// </summary>
+    public int MaxCoveringCells { get; }
+
+    /// <summary>
+    /// Gets the amount of tolerance applied to distance-based operations.
+    /// </summary>
+    public double DistanceTolerance { get; }
+
+    /// <summary>
+    /// Gets the document field used to store encoded index values.
+    /// </summary>
+    public string IndexFieldName { get; }
+
+    /// <summary>
+    /// Gets the document field used to store bounding boxes.
+    /// </summary>
+    public string BoundingBoxFieldName { get; }
+
+    /// <summary>
+    /// Creates a new <see cref="SpatialIndexOptions"/> instance using the existing values as defaults.
+    /// </summary>
+    public SpatialIndexOptions With(
+        int? precisionBits = null,
+        int? maxCoveringCells = null,
+        double? distanceTolerance = null,
+        string? indexFieldName = null,
+        string? boundingBoxFieldName = null)
+    {
+        return new SpatialIndexOptions(
+            precisionBits ?? PrecisionBits,
+            maxCoveringCells ?? MaxCoveringCells,
+            distanceTolerance ?? DistanceTolerance,
+            indexFieldName ?? IndexFieldName,
+            boundingBoxFieldName ?? BoundingBoxFieldName);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexOptions? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return PrecisionBits == other.PrecisionBits
+            && MaxCoveringCells == other.MaxCoveringCells
+            && DistanceTolerance.Equals(other.DistanceTolerance)
+            && string.Equals(IndexFieldName, other.IndexFieldName, StringComparison.Ordinal)
+            && string.Equals(BoundingBoxFieldName, other.BoundingBoxFieldName, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexOptions options && Equals(options);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = PrecisionBits;
+            hash = (hash * 397) ^ MaxCoveringCells;
+            hash = (hash * 397) ^ DistanceTolerance.GetHashCode();
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(IndexFieldName);
+            hash = (hash * 397) ^ StringComparer.Ordinal.GetHashCode(BoundingBoxFieldName);
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Precision={PrecisionBits}, Cells={MaxCoveringCells}, Tolerance={DistanceTolerance}, IndexField=\"{IndexFieldName}\", BoundingField=\"{BoundingBoxFieldName}\"";
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
+++ b/LiteDB.Spatial.Core/Geometry/BoundingBox.cs
@@ -1,0 +1,234 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents an axis-aligned bounding box in two or three dimensions.
+/// </summary>
+public readonly struct BoundingBox : IEquatable<BoundingBox>
+{
+    private readonly double[] _values;
+
+    private BoundingBox(double[] values)
+    {
+        _values = values;
+    }
+
+    /// <summary>
+    /// Creates a bounding box from raw coordinate values.
+    /// </summary>
+    /// <param name="values">
+    /// The coordinates describing the box. Two-dimensional boxes require four values
+    /// (<c>minX</c>, <c>minY</c>, <c>maxX</c>, <c>maxY</c>). Three-dimensional boxes require
+    /// six values (<c>minX</c>, <c>minY</c>, <c>minZ</c>, <c>maxX</c>, <c>maxY</c>, <c>maxZ</c>).
+    /// </param>
+    /// <returns>A new <see cref="BoundingBox"/> instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when the number of values is invalid or any value is non-finite.</exception>
+    public static BoundingBox Create(ReadOnlySpan<double> values)
+    {
+        if (values.Length != 4 && values.Length != 6)
+        {
+            throw new ArgumentException("Bounding boxes must be described by four (2D) or six (3D) values.", nameof(values));
+        }
+
+        var copy = new double[values.Length];
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var value = values[i];
+
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                throw new ArgumentException("Bounding box coordinates must be finite numbers.", nameof(values));
+            }
+
+            copy[i] = value;
+        }
+
+        ValidateExtents(copy);
+
+        return new BoundingBox(copy);
+    }
+
+    /// <summary>
+    /// Creates a two-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From2D(double minX, double minY, double maxX, double maxY)
+    {
+        return Create(new[] { minX, minY, maxX, maxY });
+    }
+
+    /// <summary>
+    /// Creates a three-dimensional bounding box.
+    /// </summary>
+    public static BoundingBox From3D(double minX, double minY, double minZ, double maxX, double maxY, double maxZ)
+    {
+        return Create(new[] { minX, minY, minZ, maxX, maxY, maxZ });
+    }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions represented by the box.
+    /// </summary>
+    public int Dimensions => _values.Length / 2;
+
+    /// <summary>
+    /// Gets a value indicating whether the bounding box captures three dimensions.
+    /// </summary>
+    public bool Is3D => Dimensions == 3;
+
+    /// <summary>
+    /// Gets the minimum X value.
+    /// </summary>
+    public double MinX => _values[0];
+
+    /// <summary>
+    /// Gets the minimum Y value.
+    /// </summary>
+    public double MinY => _values[1];
+
+    /// <summary>
+    /// Gets the minimum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MinZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[2];
+        }
+    }
+
+    /// <summary>
+    /// Gets the maximum X value.
+    /// </summary>
+    public double MaxX => _values[Dimensions == 2 ? 2 : 3];
+
+    /// <summary>
+    /// Gets the maximum Y value.
+    /// </summary>
+    public double MaxY => _values[Dimensions == 2 ? 3 : 4];
+
+    /// <summary>
+    /// Gets the maximum Z value.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when accessing the Z axis on a 2D box.</exception>
+    public double MaxZ
+    {
+        get
+        {
+            EnsureThreeDimensions();
+            return _values[5];
+        }
+    }
+
+    /// <summary>
+    /// Returns the raw coordinate values that describe the box.
+    /// </summary>
+    public ReadOnlySpan<double> GetValues()
+    {
+        return _values;
+    }
+
+    /// <summary>
+    /// Copies the coordinate values into a new array.
+    /// </summary>
+    public double[] ToArray()
+    {
+        var copy = new double[_values.Length];
+        Array.Copy(_values, copy, _values.Length);
+        return copy;
+    }
+
+    /// <inheritdoc />
+    public bool Equals(BoundingBox other)
+    {
+        if (Dimensions != other.Dimensions)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _values.Length; i++)
+        {
+            if (!_values[i].Equals(other._values[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is BoundingBox box && Equals(box);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Dimensions;
+
+            for (var i = 0; i < _values.Length; i++)
+            {
+                hash = (hash * 397) ^ _values[i].GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{string.Join(", ", _values.Select(value => value.ToString(CultureInfo.InvariantCulture)))}]";
+    }
+
+    public static bool operator ==(BoundingBox left, BoundingBox right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(BoundingBox left, BoundingBox right)
+    {
+        return !left.Equals(right);
+    }
+
+    private static void ValidateExtents(IReadOnlyList<double> values)
+    {
+        if (values.Count == 4)
+        {
+            ValidateAxis(values[0], values[2], "X");
+            ValidateAxis(values[1], values[3], "Y");
+            return;
+        }
+
+        ValidateAxis(values[0], values[3], "X");
+        ValidateAxis(values[1], values[4], "Y");
+        ValidateAxis(values[2], values[5], "Z");
+    }
+
+    private static void ValidateAxis(double min, double max, string axis)
+    {
+        if (max < min)
+        {
+            throw new ArgumentException($"The maximum {axis} value must be greater than or equal to the minimum value.");
+        }
+    }
+
+    private void EnsureThreeDimensions()
+    {
+        if (!Is3D)
+        {
+            throw new InvalidOperationException("The bounding box does not define a Z axis.");
+        }
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a geographic coordinate using longitude and latitude expressed in decimal degrees.
+/// </summary>
+public readonly struct GeoPoint : IEquatable<GeoPoint>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint"/> struct.
+    /// </summary>
+    /// <param name="longitude">The longitude component in decimal degrees.</param>
+    /// <param name="latitude">The latitude component in decimal degrees.</param>
+    /// <exception cref="ArgumentException">Thrown when either coordinate is not a finite number.</exception>
+    public GeoPoint(double longitude, double latitude)
+    {
+        if (double.IsNaN(longitude) || double.IsInfinity(longitude))
+        {
+            throw new ArgumentException("Longitude must be a finite number.", nameof(longitude));
+        }
+
+        if (double.IsNaN(latitude) || double.IsInfinity(latitude))
+        {
+            throw new ArgumentException("Latitude must be a finite number.", nameof(latitude));
+        }
+
+        Longitude = longitude;
+        Latitude = latitude;
+    }
+
+    /// <summary>
+    /// Gets the longitude component in decimal degrees where positive values indicate east.
+    /// </summary>
+    public double Longitude { get; }
+
+    /// <summary>
+    /// Gets the latitude component in decimal degrees where positive values indicate north.
+    /// </summary>
+    public double Latitude { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint other)
+    {
+        return Longitude.Equals(other.Longitude) && Latitude.Equals(other.Latitude);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Longitude.GetHashCode();
+            hash = (hash * 397) ^ Latitude.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1})", Longitude, Latitude);
+    }
+
+    public static bool operator ==(GeoPoint left, GeoPoint right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint left, GeoPoint right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPoint3D.cs
@@ -1,0 +1,96 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a three-dimensional Cartesian coordinate.
+/// </summary>
+public readonly struct GeoPoint3D : IEquatable<GeoPoint3D>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPoint3D"/> struct.
+    /// </summary>
+    /// <param name="x">The X component.</param>
+    /// <param name="y">The Y component.</param>
+    /// <param name="z">The Z component.</param>
+    /// <exception cref="ArgumentException">Thrown when any component is not a finite number.</exception>
+    public GeoPoint3D(double x, double y, double z)
+    {
+        if (double.IsNaN(x) || double.IsInfinity(x))
+        {
+            throw new ArgumentException("X must be a finite number.", nameof(x));
+        }
+
+        if (double.IsNaN(y) || double.IsInfinity(y))
+        {
+            throw new ArgumentException("Y must be a finite number.", nameof(y));
+        }
+
+        if (double.IsNaN(z) || double.IsInfinity(z))
+        {
+            throw new ArgumentException("Z must be a finite number.", nameof(z));
+        }
+
+        X = x;
+        Y = y;
+        Z = z;
+    }
+
+    /// <summary>
+    /// Gets the X component of the coordinate.
+    /// </summary>
+    public double X { get; }
+
+    /// <summary>
+    /// Gets the Y component of the coordinate.
+    /// </summary>
+    public double Y { get; }
+
+    /// <summary>
+    /// Gets the Z component of the coordinate.
+    /// </summary>
+    public double Z { get; }
+
+    /// <inheritdoc />
+    public bool Equals(GeoPoint3D other)
+    {
+        return X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPoint3D point && Equals(point);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = X.GetHashCode();
+            hash = (hash * 397) ^ Y.GetHashCode();
+            hash = (hash * 397) ^ Z.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return string.Format(CultureInfo.InvariantCulture, "({0}, {1}, {2})", X, Y, Z);
+    }
+
+    public static bool operator ==(GeoPoint3D left, GeoPoint3D right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(GeoPoint3D left, GeoPoint3D right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides the ability to encode coordinates into spatial index values and derive coarse coverings.
+/// </summary>
+public interface ISpatialIndexEncoder
+{
+    /// <summary>
+    /// Gets the number of spatial dimensions supported by the encoder.
+    /// </summary>
+    int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the number of precision bits allocated per axis.
+    /// </summary>
+    int PrecisionBits { get; }
+
+    /// <summary>
+    /// Encodes the provided coordinate tuple into a sortable spatial index value.
+    /// </summary>
+    /// <param name="coordinates">The coordinate tuple. The span length must match <see cref="Dimensions"/>.</param>
+    /// <returns>The encoded index value.</returns>
+    ulong Encode(ReadOnlySpan<double> coordinates);
+
+    /// <summary>
+    /// Produces a set of index ranges that cover the provided bounding box.
+    /// </summary>
+    /// <param name="bounds">The bounding box to cover.</param>
+    /// <param name="maxCells">The maximum number of ranges the caller is willing to accept.</param>
+    /// <returns>A collection of closed index ranges ordered from lowest to highest.</returns>
+    IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells);
+}

--- a/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
@@ -1,0 +1,361 @@
+#nullable enable
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides Morton (Z-order) encoding for two and three-dimensional coordinates.
+/// </summary>
+public sealed class MortonIndexEncoder : ISpatialIndexEncoder
+{
+    private readonly int _dimensions;
+    private readonly int _precisionBits;
+    private readonly ulong _maxCoordinateValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MortonIndexEncoder"/> class.
+    /// </summary>
+    /// <param name="dimensions">The number of spatial dimensions (2 or 3).</param>
+    /// <param name="precisionBits">The number of precision bits per axis.</param>
+    public MortonIndexEncoder(int dimensions, int precisionBits)
+    {
+        if (dimensions != 2 && dimensions != 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Morton encoding is defined for 2D or 3D inputs.");
+        }
+
+        if (precisionBits <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "Precision must be a positive number of bits.");
+        }
+
+        if ((long)dimensions * precisionBits > 64)
+        {
+            throw new ArgumentOutOfRangeException(nameof(precisionBits), "The requested precision exceeds the 64-bit key space.");
+        }
+
+        _dimensions = dimensions;
+        _precisionBits = precisionBits;
+        _maxCoordinateValue = (1UL << precisionBits) - 1UL;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions => _dimensions;
+
+    /// <inheritdoc />
+    public int PrecisionBits => _precisionBits;
+
+    /// <inheritdoc />
+    public ulong Encode(ReadOnlySpan<double> coordinates)
+    {
+        if (coordinates.Length != _dimensions)
+        {
+            throw new ArgumentException($"Expected {_dimensions} coordinates, but received {coordinates.Length}.", nameof(coordinates));
+        }
+
+        Span<ulong> quantized = stackalloc ulong[3];
+
+        for (var axis = 0; axis < _dimensions; axis++)
+        {
+            quantized[axis] = Quantize(coordinates[axis]);
+        }
+
+        return InterleaveBits(quantized);
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells)
+    {
+        if (bounds.Dimensions != _dimensions)
+        {
+            throw new ArgumentException($"The encoder expects a {_dimensions}D bounding box.", nameof(bounds));
+        }
+
+        if (maxCells <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxCells), "The maximum number of cells must be positive.");
+        }
+
+        var min = ArrayPool<ulong>.Shared.Rent(_dimensions);
+        var max = ArrayPool<ulong>.Shared.Rent(_dimensions);
+
+        try
+        {
+            QuantizeBounds(bounds, min, max);
+
+            var ranges = new List<SpatialIndexRange>();
+            var stack = new Stack<Node>();
+            var initialSpan = 1UL << _precisionBits;
+
+            var root = new Node(0, 0UL, CreateArray(_dimensions, initialSpan, isMin: true), CreateArray(_dimensions, initialSpan, isMin: false), initialSpan);
+            stack.Push(root);
+
+            while (stack.Count > 0)
+            {
+                var node = stack.Pop();
+                try
+                {
+                    if (!Intersects(ref node, min, max))
+                    {
+                        continue;
+                    }
+
+                    if (IsContained(ref node, min, max) || node.Level == _precisionBits)
+                    {
+                        ranges.Add(CreateRange(node.Prefix, node.Level));
+                        continue;
+                    }
+
+                    var nextLevel = node.Level + 1;
+                    var childSpan = node.Span / 2UL;
+
+                    for (var child = (1 << _dimensions) - 1; child >= 0; child--)
+                    {
+                        var childPrefix = (node.Prefix << _dimensions) | (ulong)(uint)child;
+                        var childMin = ArrayPool<ulong>.Shared.Rent(_dimensions);
+                        var childMax = ArrayPool<ulong>.Shared.Rent(_dimensions);
+
+                        try
+                        {
+                            for (var axis = 0; axis < _dimensions; axis++)
+                            {
+                                var bit = (child >> axis) & 1;
+                                var offset = childSpan * (ulong)bit;
+                                childMin[axis] = node.Min[axis] + offset;
+                                childMax[axis] = childMin[axis] + childSpan - 1UL;
+                            }
+
+                            stack.Push(new Node(nextLevel, childPrefix, childMin, childMax, childSpan));
+                        }
+                        catch
+                        {
+                            ArrayPool<ulong>.Shared.Return(childMin);
+                            ArrayPool<ulong>.Shared.Return(childMax);
+                            throw;
+                        }
+                    }
+                }
+                finally
+                {
+                    ArrayPool<ulong>.Shared.Return(node.Min);
+                    ArrayPool<ulong>.Shared.Return(node.Max);
+                }
+            }
+
+            ranges.Sort((left, right) => left.Start.CompareTo(right.Start));
+            var coalesced = CoalesceRanges(ranges);
+            return EnforceCellBudget(coalesced, maxCells);
+        }
+        finally
+        {
+            ArrayPool<ulong>.Shared.Return(min);
+            ArrayPool<ulong>.Shared.Return(max);
+        }
+    }
+
+    private void QuantizeBounds(BoundingBox bounds, Span<ulong> min, Span<ulong> max)
+    {
+        if (_dimensions == 2)
+        {
+            min[0] = Quantize(bounds.MinX);
+            min[1] = Quantize(bounds.MinY);
+            max[0] = Quantize(bounds.MaxX);
+            max[1] = Quantize(bounds.MaxY);
+        }
+        else
+        {
+            min[0] = Quantize(bounds.MinX);
+            min[1] = Quantize(bounds.MinY);
+            min[2] = Quantize(bounds.MinZ);
+            max[0] = Quantize(bounds.MaxX);
+            max[1] = Quantize(bounds.MaxY);
+            max[2] = Quantize(bounds.MaxZ);
+        }
+
+        for (var i = 0; i < _dimensions; i++)
+        {
+            if (min[i] > max[i])
+            {
+                (min[i], max[i]) = (max[i], min[i]);
+            }
+        }
+    }
+
+    private ulong Quantize(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), "Coordinates must be finite numbers.");
+        }
+
+        var clamped = value;
+        if (clamped < 0d)
+        {
+            clamped = 0d;
+        }
+        else if (clamped > 1d)
+        {
+            clamped = 1d;
+        }
+        var scaled = clamped * _maxCoordinateValue;
+        var quantized = (ulong)Math.Round(scaled, MidpointRounding.AwayFromZero);
+        return Math.Min(quantized, _maxCoordinateValue);
+    }
+
+    private ulong InterleaveBits(ReadOnlySpan<ulong> values)
+    {
+        ulong result = 0UL;
+
+        for (var bit = 0; bit < _precisionBits; bit++)
+        {
+            for (var axis = 0; axis < _dimensions; axis++)
+            {
+                var bitMask = (values[axis] >> bit) & 1UL;
+                var shift = (bit * _dimensions) + axis;
+                result |= bitMask << shift;
+            }
+        }
+
+        return result;
+    }
+
+    private static bool Intersects(ref Node node, Span<ulong> min, Span<ulong> max)
+    {
+        for (var axis = 0; axis < node.Min.Length; axis++)
+        {
+            if (node.Min[axis] > max[axis] || node.Max[axis] < min[axis])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsContained(ref Node node, Span<ulong> min, Span<ulong> max)
+    {
+        for (var axis = 0; axis < node.Min.Length; axis++)
+        {
+            if (node.Min[axis] < min[axis] || node.Max[axis] > max[axis])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private SpatialIndexRange CreateRange(ulong prefix, int level)
+    {
+        var remainingBits = _dimensions * (_precisionBits - level);
+
+        if (remainingBits >= 64)
+        {
+            return new SpatialIndexRange(0UL, ulong.MaxValue);
+        }
+
+        var start = prefix << remainingBits;
+        var mask = (1UL << remainingBits) - 1UL;
+        var end = start | mask;
+        return new SpatialIndexRange(start, end);
+    }
+
+    private static List<SpatialIndexRange> CoalesceRanges(List<SpatialIndexRange> ranges)
+    {
+        if (ranges.Count == 0)
+        {
+            return ranges;
+        }
+
+        var cursor = 0;
+
+        for (var i = 1; i < ranges.Count; i++)
+        {
+            var current = ranges[cursor];
+            var next = ranges[i];
+
+            if (current.CanMerge(next))
+            {
+                ranges[cursor] = current.Merge(next);
+            }
+            else
+            {
+                cursor++;
+                ranges[cursor] = next;
+            }
+        }
+
+        ranges.RemoveRange(cursor + 1, ranges.Count - (cursor + 1));
+        return ranges;
+    }
+
+    private static IReadOnlyList<SpatialIndexRange> EnforceCellBudget(List<SpatialIndexRange> ranges, int maxCells)
+    {
+        if (ranges.Count <= maxCells)
+        {
+            return ranges;
+        }
+
+        while (ranges.Count > maxCells)
+        {
+            var bestIndex = 0;
+            ulong smallestGap = ulong.MaxValue;
+
+            for (var i = 0; i < ranges.Count - 1; i++)
+            {
+                var current = ranges[i];
+                var next = ranges[i + 1];
+                ulong gap = next.Start > current.End ? next.Start - current.End - 1UL : 0UL;
+
+                if (gap < smallestGap)
+                {
+                    smallestGap = gap;
+                    bestIndex = i;
+                }
+            }
+
+            var merged = ranges[bestIndex].Merge(ranges[bestIndex + 1]);
+            ranges[bestIndex] = merged;
+            ranges.RemoveAt(bestIndex + 1);
+        }
+
+        return ranges;
+    }
+
+    private static ulong[] CreateArray(int dimensions, ulong span, bool isMin)
+    {
+        var result = ArrayPool<ulong>.Shared.Rent(dimensions);
+
+        for (var i = 0; i < dimensions; i++)
+        {
+            result[i] = isMin ? 0UL : span - 1UL;
+        }
+
+        return result;
+    }
+
+    private readonly struct Node
+    {
+        public Node(int level, ulong prefix, ulong[] min, ulong[] max, ulong span)
+        {
+            Level = level;
+            Prefix = prefix;
+            Min = min;
+            Max = max;
+            Span = span;
+        }
+
+        public int Level { get; }
+
+        public ulong Prefix { get; }
+
+        public ulong[] Min { get; }
+
+        public ulong[] Max { get; }
+
+        public ulong Span { get; }
+    }
+}

--- a/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
+++ b/LiteDB.Spatial.Core/Indexing/SpatialIndexRange.cs
@@ -1,0 +1,94 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a closed range of spatial index values.
+/// </summary>
+public readonly struct SpatialIndexRange : IEquatable<SpatialIndexRange>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexRange"/> struct.
+    /// </summary>
+    /// <param name="start">The inclusive start of the range.</param>
+    /// <param name="end">The inclusive end of the range.</param>
+    public SpatialIndexRange(ulong start, ulong end)
+    {
+        if (end < start)
+        {
+            throw new ArgumentOutOfRangeException(nameof(end), "The end of the range must be greater than or equal to the start.");
+        }
+
+        Start = start;
+        End = end;
+    }
+
+    /// <summary>
+    /// Gets the inclusive start of the range.
+    /// </summary>
+    public ulong Start { get; }
+
+    /// <summary>
+    /// Gets the inclusive end of the range.
+    /// </summary>
+    public ulong End { get; }
+
+    /// <summary>
+    /// Determines whether the current range intersects or is immediately adjacent to the provided range.
+    /// </summary>
+    public bool CanMerge(in SpatialIndexRange other)
+    {
+        return !(other.Start > End + 1 || other.End + 1 < Start);
+    }
+
+    /// <summary>
+    /// Produces a new range spanning both the current range and the provided range.
+    /// </summary>
+    public SpatialIndexRange Merge(in SpatialIndexRange other)
+    {
+        var start = Math.Min(Start, other.Start);
+        var end = Math.Max(End, other.End);
+        return new SpatialIndexRange(start, end);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialIndexRange other)
+    {
+        return Start == other.Start && End == other.End;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialIndexRange range && Equals(range);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = Start.GetHashCode();
+            hash = (hash * 397) ^ End.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"[{Start}, {End}]";
+    }
+
+    public static bool operator ==(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return left.Equals(right);
+    }
+
+    public static bool operator !=(SpatialIndexRange left, SpatialIndexRange right)
+    {
+        return !left.Equals(right);
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialExpressions.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides LINQ-friendly spatial helpers. These methods are intended to be used within expression trees
+/// and will be translated by <see cref="SpatialResolver"/> into engine-specific query plans.
+/// </summary>
+public static class SpatialExpressions
+{
+    /// <summary>
+    /// Placeholder for a query that selects points near a geographic center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint candidate, GeoPoint center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points near a three-dimensional center.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool Near(GeoPoint3D candidate, GeoPoint3D center, double radius)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    /// <summary>
+    /// Placeholder for a query that selects three-dimensional points contained within a bounding box.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Always thrown when invoked directly.</exception>
+    public static bool InBox(GeoPoint3D candidate, BoundingBox bounds)
+    {
+        throw CreateUsageException();
+    }
+
+    private static InvalidOperationException CreateUsageException()
+    {
+        return new InvalidOperationException("SpatialExpressions are intended for use within LINQ expressions and should not be executed directly.");
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System.Linq.Expressions;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Translates method calls that originate from <see cref="SpatialExpressions"/> into spatial query plans.
+/// </summary>
+public sealed class SpatialResolver
+{
+    /// <summary>
+    /// Attempts to translate the provided method call expression into a spatial query plan.
+    /// </summary>
+    /// <param name="expression">The method call expression extracted from a LINQ query.</param>
+    /// <param name="plan">When this method returns, contains the resulting query plan if translation succeeded.</param>
+    /// <returns><c>true</c> when translation succeeded; otherwise, <c>false</c>.</returns>
+    public bool TryResolve(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        plan = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
+++ b/LiteDB.Spatial.Core/LiteDB.Spatial.Core.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Core</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Core.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>litedb</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.0" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Core/Metadata/SpatialCollectionDescriptor.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialCollectionDescriptor.cs
@@ -1,0 +1,184 @@
+#nullable enable
+
+extern alias litedb;
+using System;
+using LiteDbRuntime = litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents the spatial configuration associated with a collection.
+/// </summary>
+public sealed class SpatialCollectionDescriptor : IEquatable<SpatialCollectionDescriptor>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialCollectionDescriptor"/> class.
+    /// </summary>
+    /// <param name="engineName">The engine name stored in metadata.</param>
+    /// <param name="dimensions">The number of spatial dimensions.</param>
+    /// <param name="options">The spatial index options associated with the collection.</param>
+    /// <param name="engine">An optional runtime engine instance.</param>
+    public SpatialCollectionDescriptor(string engineName, int dimensions, SpatialIndexOptions options, ISpatialEngine? engine = null)
+    {
+        if (string.IsNullOrWhiteSpace(engineName))
+        {
+            throw new ArgumentException("Engine name cannot be null or whitespace.", nameof(engineName));
+        }
+
+        if (dimensions != 2 && dimensions != 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial descriptors support two or three dimensions.");
+        }
+
+        EngineName = engineName;
+        Dimensions = dimensions;
+        Options = options ?? throw new ArgumentNullException(nameof(options));
+        Engine = engine;
+    }
+
+    /// <summary>
+    /// Gets the name of the engine responsible for indexing the collection.
+    /// </summary>
+    public string EngineName { get; }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions associated with the collection.
+    /// </summary>
+    public int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the spatial index options recorded for the collection.
+    /// </summary>
+    public SpatialIndexOptions Options { get; }
+
+    /// <summary>
+    /// Gets the runtime engine instance when available.
+    /// </summary>
+    public ISpatialEngine? Engine { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether a runtime engine has been attached to the descriptor.
+    /// </summary>
+    public bool HasEngine => Engine != null;
+
+    /// <summary>
+    /// Gets the expected number of values stored in the bounding box field.
+    /// </summary>
+    public int ExpectedBoundingBoxLength => Dimensions == 3 ? 6 : 4;
+
+    /// <summary>
+    /// Creates a new descriptor that is associated with the provided runtime engine.
+    /// </summary>
+    /// <param name="engine">The engine instance used at runtime.</param>
+    public SpatialCollectionDescriptor WithEngine(ISpatialEngine engine)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        if (!string.Equals(engine.Name, EngineName, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, $"Cannot attach engine '{engine.Name}' to metadata configured for '{EngineName}'.");
+        }
+
+        if (engine.Dimensions != Dimensions)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, $"Engine '{engine.Name}' reports {engine.Dimensions} dimensions but metadata expects {Dimensions}.");
+        }
+
+        if (!engine.Options.Equals(Options))
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, "Engine options do not match the persisted metadata.");
+        }
+
+        return new SpatialCollectionDescriptor(EngineName, Dimensions, Options, engine);
+    }
+
+    /// <summary>
+    /// Validates the shape of a bounding box stored on a document.
+    /// </summary>
+    /// <param name="value">The BSON value representing the bounding box.</param>
+    /// <param name="fieldName">An optional field name used to enrich error messages.</param>
+    public void ValidateBoundingBoxValue(LiteDbRuntime.BsonValue value, string? fieldName = null)
+    {
+        if (value == null || value.IsNull)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, BuildBoundingBoxErrorMessage(fieldName, "A bounding box value was expected but null was found."));
+        }
+
+        if (!value.IsArray)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, BuildBoundingBoxErrorMessage(fieldName, "Bounding boxes must be stored as arrays."));
+        }
+
+        var array = value.AsArray;
+        if (array.Count != ExpectedBoundingBoxLength)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, BuildBoundingBoxErrorMessage(fieldName, $"Expected {ExpectedBoundingBoxLength} values but found {array.Count}."));
+        }
+    }
+
+    /// <summary>
+    /// Validates that the provided bounding box matches the descriptor dimensionality.
+    /// </summary>
+    /// <param name="boundingBox">The bounding box produced at runtime.</param>
+    public void ValidateBoundingBox(BoundingBox boundingBox)
+    {
+        if (boundingBox.Dimensions != Dimensions)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, $"Engine returned a {boundingBox.Dimensions}D bounding box but metadata expects {Dimensions}D values.");
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Equals(SpatialCollectionDescriptor? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (!string.Equals(EngineName, other.EngineName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (Dimensions != other.Dimensions)
+        {
+            return false;
+        }
+
+        return Options.Equals(other.Options);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is SpatialCollectionDescriptor descriptor && Equals(descriptor);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = StringComparer.Ordinal.GetHashCode(EngineName);
+            hash = (hash * 397) ^ Dimensions;
+            hash = (hash * 397) ^ Options.GetHashCode();
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Engine={EngineName}, Dimensions={Dimensions}, Options=[{Options}]";
+    }
+
+    private string BuildBoundingBoxErrorMessage(string? fieldName, string message)
+    {
+        var field = string.IsNullOrWhiteSpace(fieldName) ? Options.BoundingBoxFieldName : fieldName!;
+        return $"Spatial metadata for engine '{EngineName}' ({Dimensions}D) expects field '{field}' to contain {ExpectedBoundingBoxLength} numeric values. {message} Consider re-running the spatial backfill or configuring the collection via UseGeographic/UseCartesian* helpers.";
+    }
+}

--- a/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
+++ b/LiteDB.Spatial.Core/Metadata/SpatialMetadataStore.cs
@@ -1,0 +1,157 @@
+#nullable enable
+
+extern alias litedb;
+using System;
+using LiteDbRuntime = litedb::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Persists and retrieves spatial metadata associated with collections.
+/// </summary>
+public static class SpatialMetadataStore
+{
+    /// <summary>
+    /// The name of the collection used to persist spatial metadata.
+    /// </summary>
+    public const string MetadataCollectionName = "_spatial_meta";
+
+    /// <summary>
+    /// Persists metadata for the specified collection.
+    /// </summary>
+    /// <param name="database">The LiteDB database instance.</param>
+    /// <param name="collectionName">The target collection name.</param>
+    /// <param name="descriptor">The descriptor to persist.</param>
+    public static void Persist(LiteDbRuntime.LiteDatabase database, string collectionName, SpatialCollectionDescriptor descriptor)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name cannot be null or whitespace.", nameof(collectionName));
+        }
+
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        var metadataCollection = database.GetCollection<LiteDbRuntime.BsonDocument>(MetadataCollectionName);
+        metadataCollection.EnsureIndex("collection");
+
+        var document = new LiteDbRuntime.BsonDocument
+        {
+            ["_id"] = new LiteDbRuntime.BsonValue(collectionName),
+            ["collection"] = new LiteDbRuntime.BsonValue(collectionName),
+            ["engine"] = new LiteDbRuntime.BsonValue(descriptor.EngineName),
+            ["dimensions"] = new LiteDbRuntime.BsonValue(descriptor.Dimensions),
+            ["options"] = SerializeOptions(descriptor.Options),
+            ["updatedUtc"] = new LiteDbRuntime.BsonValue(DateTime.UtcNow)
+        };
+
+        metadataCollection.Upsert(document);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve metadata for the specified collection.
+    /// </summary>
+    /// <param name="database">The LiteDB database instance.</param>
+    /// <param name="collectionName">The collection name.</param>
+    /// <returns>The descriptor when found; otherwise, <c>null</c>.</returns>
+    public static SpatialCollectionDescriptor? TryGet(LiteDbRuntime.LiteDatabase database, string collectionName)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name cannot be null or whitespace.", nameof(collectionName));
+        }
+
+        var metadataCollection = database.GetCollection<LiteDbRuntime.BsonDocument>(MetadataCollectionName);
+        var document = metadataCollection.FindById(collectionName);
+        if (document == null)
+        {
+            return null;
+        }
+
+        return DeserializeDescriptor(document);
+    }
+
+    /// <summary>
+    /// Retrieves metadata for the specified collection, throwing when none is available.
+    /// </summary>
+    /// <param name="database">The LiteDB database instance.</param>
+    /// <param name="collectionName">The collection name.</param>
+    public static SpatialCollectionDescriptor GetRequired(LiteDbRuntime.LiteDatabase database, string collectionName)
+    {
+        var descriptor = TryGet(database, collectionName);
+        if (descriptor == null)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.COLLECTION_NOT_FOUND, $"Spatial metadata for collection '{collectionName}' was not found. Configure the collection via UseGeographic/UseCartesian helpers before running spatial queries.");
+        }
+
+        return descriptor;
+    }
+
+    private static LiteDbRuntime.BsonDocument SerializeOptions(SpatialIndexOptions options)
+    {
+        return new LiteDbRuntime.BsonDocument
+        {
+            ["precisionBits"] = new LiteDbRuntime.BsonValue(options.PrecisionBits),
+            ["maxCoveringCells"] = new LiteDbRuntime.BsonValue(options.MaxCoveringCells),
+            ["distanceTolerance"] = new LiteDbRuntime.BsonValue(options.DistanceTolerance),
+            ["indexFieldName"] = new LiteDbRuntime.BsonValue(options.IndexFieldName),
+            ["boundingBoxFieldName"] = new LiteDbRuntime.BsonValue(options.BoundingBoxFieldName)
+        };
+    }
+
+    private static SpatialIndexOptions DeserializeOptions(LiteDbRuntime.BsonDocument document)
+    {
+        var precisionBits = document.TryGetValue("precisionBits", out var precisionValue) && precisionValue.IsNumber
+            ? precisionValue.AsInt32
+            : SpatialIndexOptions.DefaultPrecision;
+
+        var maxCells = document.TryGetValue("maxCoveringCells", out var cellValue) && cellValue.IsNumber
+            ? cellValue.AsInt32
+            : SpatialIndexOptions.DefaultMaxCoveringCells;
+
+        var tolerance = document.TryGetValue("distanceTolerance", out var toleranceValue) && toleranceValue.IsNumber
+            ? toleranceValue.AsDouble
+            : SpatialIndexOptions.DefaultDistanceTolerance;
+
+        var indexField = document.TryGetValue("indexFieldName", out var indexFieldValue) && indexFieldValue.IsString
+            ? indexFieldValue.AsString
+            : SpatialIndexOptions.DefaultIndexFieldName;
+
+        var boundingField = document.TryGetValue("boundingBoxFieldName", out var boundingFieldValue) && boundingFieldValue.IsString
+            ? boundingFieldValue.AsString
+            : SpatialIndexOptions.DefaultBoundingBoxFieldName;
+
+        return new SpatialIndexOptions(precisionBits, maxCells, tolerance, indexField, boundingField);
+    }
+
+    private static SpatialCollectionDescriptor DeserializeDescriptor(LiteDbRuntime.BsonDocument document)
+    {
+        if (!document.TryGetValue("engine", out var engineValue) || !engineValue.IsString)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, "Spatial metadata is missing the engine name.");
+        }
+
+        if (!document.TryGetValue("dimensions", out var dimensionsValue) || !dimensionsValue.IsNumber)
+        {
+            throw new LiteDbRuntime.LiteException(LiteDbRuntime.LiteException.INVALID_DATA_TYPE, "Spatial metadata is missing the dimensions value.");
+        }
+
+        var options = document.TryGetValue("options", out var optionsValue) && optionsValue.IsDocument
+            ? DeserializeOptions(optionsValue.AsDocument)
+            : new SpatialIndexOptions();
+
+        return new SpatialCollectionDescriptor(engineValue.AsString, dimensionsValue.AsInt32, options);
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -40,6 +40,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.ReproRunner.Shared",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedMutexHarness", "LiteDB.Tests.SharedMutexHarness\SharedMutexHarness.csproj", "{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core", "LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj", "{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core.Tests", "LiteDB.Spatial.Core.Tests\LiteDB.Spatial.Core.Tests.csproj", "{99F2946D-65FB-4FC8-827D-C3241FB5EF93}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +162,30 @@ Global
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x64.Build.0 = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.ActiveCfg = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x64.Build.0 = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C59CA06-B24E-4928-AD6F-D6D09AE67AEF}.Release|x86.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x64.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Debug|x86.Build.0 = Debug|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.Build.0 = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.ActiveCfg = Release|Any CPU
+		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -1,0 +1,278 @@
+# Epic: Modular Spatial Revamp (2D Geographic, 2D Cartesian, 3D Cartesian)
+
+## Goals (scope)
+
+- Extract an engine-agnostic core (`LiteDB.Spatial.Core`).
+- Add engines:
+  - `LiteDB.Spatial.Geographic` (2D, WGS84, meters).
+  - `LiteDB.Spatial.Cartesian2D` (flat 2D).
+  - `LiteDB.Spatial.Cartesian3D` (flat 3D points).
+- Standardize internal fields:
+  - `_idx` — numeric index key (Morton/Hilbert later).
+  - `_mbb` — bounding box (4 or 6 values).
+- Keep LINQ-friendly API with index-aware query plans.
+- Provide backfill + deterministic metadata per collection.
+- Ship diagnostics ("explain") and a minimum GeoJSON I/O.
+- Preserve backward compatibility as much as possible.
+
+## Non-Goals (for now)
+
+- 3D meshes/polyhedra predicates.
+- Advanced projections/CRS transforms beyond WGS84.
+- Alternate encoders beyond Morton (scaffold only).
+
+---
+
+## Architecture overview (target)
+
+```
+LiteDB.Spatial.Core
+  Geometry, Engine contracts, LINQ resolver, Metadata, Backfill
+
+LiteDB.Spatial.Indexing
+  MortonIndexEncoder (2D/3D), Hilbert (stub)
+
+LiteDB.Spatial.Geographic
+  GeographicEngine (2D), Haversine/Vincenty, wrap/polar helpers, facade
+
+LiteDB.Spatial.Cartesian2D
+  Cartesian2DEngine, Euclidean2D, facade
+
+LiteDB.Spatial.Cartesian3D
+  Cartesian3DEngine, Euclidean3D, facade
+
+LiteDB.Spatial.Diagnostics
+  Explain(plan) utilities
+
+LiteDB.Spatial.GeoJson
+  Basic GeoJSON serializer
+
+LiteDB.Spatial
+  Top-level facade (dispatch by collection metadata)
+```
+
+---
+
+## Stories & Acceptance Criteria
+
+### S1 — Core contracts & geometry (engine-agnostic)
+
+- [x] Add `GeoPoint`, `GeoPoint3D`, `BoundingBox` (2D: 4 elems; 3D: 6 elems).
+- [x] Define interfaces: `ISpatialEngine`, `ISpatialIndexEncoder`, `ISpatialDistance`, `ISpatialMapper`, `ISpatialQueryPlan`.
+- [x] Core options: `SpatialIndexOptions` (precision, max cells, tolerance, field names).
+- [x] LINQ surface: `SpatialExpressions` (Near/InBox overloads for 2D/3D).
+- [x] Stub `SpatialResolver` for expression translation.
+
+### S2 — Indexing: Morton encoder (2D/3D)
+
+- [x] Implement `MortonIndexEncoder(int dimensions)` with bit-interleaving and helpers.
+- [x] Provide helper to union adjacent ranges for nicer covers.
+
+### S3 — Metadata store & schema conventions
+
+- [x] `SpatialMetadataStore` persists per-collection descriptor `{ engine, dimensions, options }` in `"_spatial_meta"`.
+- [x] Internal field names customizable via options but default to `_idx` and `_mbb`.
+- [x] Guard mismatches and surface friendly errors.
+
+### S4 — Backfill utility
+
+- [x] `SpatialBackfill.Run<T>(collection, descriptor, batchSize)` populates `_idx`/`_mbb`.
+- [x] Ensure idempotent behavior with detailed counters and error reporting.
+
+### S5 — Geographic engine (2D)
+
+- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+
+### S6 — Cartesian 2D engine
+
+- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+
+### S7 — Cartesian 3D engine (points)
+
+- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+
+### S8 — LINQ resolver
+
+- [ ] Translate `SpatialExpressions` into query plans based on metadata.
+
+### S9 — Diagnostics ("Explain")
+
+- [ ] Produce printable `SpatialExplainResult` summaries for query plans.
+
+### S10 — GeoJSON I/O (minimal)
+
+- [ ] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
+
+### S11 — Top-level facade & dispatch
+
+- [ ] `LiteDB.Spatial.Spatial` entry point manages engine configuration and dispatch.
+
+### S12 — Migration & docs
+
+- [ ] Author upgrade/guide/diagnostics documentation with samples.
+
+### S13 — Benchmarks & regression guardrails
+
+- [ ] Capture performance baselines and add regression guardrails.
+
+---
+
+## Backward Compatibility & Risk Mitigation
+
+- **Internal field rename**: standardize on `_idx` (previously `_gh`). Keep `_gh` reading optional if present (migration path), but **do not** write new `_gh`. Provide backfill to `_idx`.
+- **Engine selection**: no global singletons; bind per collection via metadata to avoid cross-collection leakage.
+- **Precision in 3D**: document that 3D needs higher `PrecisionBits` for similar spatial locality; default +4 vs 2D.
+- **Range explosion**: cap by `MaxCoveringCells`; if exceeded, coarsen ranges and rely on exact filters (documented behavior).
+
+---
+
+## Public API sketch (stable surface)
+
+```csharp
+// Top-level
+Spatial.UseGeographic(col, new GeographicOptions { PrecisionBits = 32 });
+Spatial.EnsurePointIndex(col, x => x.Location); // GeoPoint
+var near = Spatial.Near(col, x => x.Location, new GeoPoint(lon, lat), radius: 1500).ToList();
+
+Spatial.UseCartesian2D(col2, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col2, x => x.Pos2D); // GeoPoint
+var inBox = Spatial.WithinBoundingBox(col2, x => x.Pos2D, BoundingBox.From2D(0,0,10,10)).ToList();
+
+Spatial.UseCartesian3D(col3, new SpatialIndexOptions { PrecisionBits = 28 });
+Spatial.EnsurePointIndex(col3, x => x.Pos3D); // GeoPoint3D
+var hits = Spatial.Near(col3, x => x.Pos3D, new GeoPoint3D(1,2,3), radius: 5).ToList();
+```
+
+---
+
+## Test Matrix (minimum)
+
+- **Core**: BoundingBox dims, options defaults, metadata round-trip.
+- **Indexing**: Morton 2D/3D grids + boundaries.
+- **Geographic**: Near Berlin; anti-meridian bbox; polar bbox.
+- **Cartesian2D**: Near/InBox on grid; candidate pruning verified.
+- **Cartesian3D**: Near3D + AABB on 3D lattice; MaxCoveringCells respected.
+- **LINQ**: Expression translation picks correct engine; index predicate present.
+- **Backfill**: idempotency; mixed docs with/without fields.
+- **Diagnostics**: explain outputs consistent and human-readable.
+
+---
+
+## Deliverables checklist (per PR)
+
+- [ ] Code compiles, no public API breaking changes outside the new surface.
+- [ ] Unit + integration tests green.
+- [ ] Samples updated.
+- [ ] Docs updated (guide/upgrade/diagnostics).
+- [ ] Bench baseline captured.
+- [ ] Changelog entry with migration notes (`_gh` → `_idx`).
+
+---
+
+## Rollout plan
+
+1. Merge Core + Indexing + Geographic (smallest behavior delta). ✅ Core indexing, metadata, and backfill scaffolding landed.
+2. Introduce Cartesian2D (flat replacement for non-Earth use).
+3. Add Cartesian3D (points + AABB + Near3D).
+4. Enable LINQ resolver by default; keep a feature flag to disable if needed.
+5. Publish docs and a sample upgrade script demonstrating backfill.
+
+---
+
+## Addendum: Battle-Tested Oracles & Datasets
+
+### Reference libraries (use as **oracles**, not dependencies of runtime)
+
+- **Geometry predicates (2D):** `NetTopologySuite (NTS)` — robust predicates: `Contains`, `Intersects`, `Within`, polygon holes/edge cases.
+- **Geodesic distances (Earth):** `GeographicLib` — great-circle, inverse geodesic; use as golden values.
+- **Projections / CRS transforms (optional sanity):** `ProjNET` — to cross-check lon/lat ↔ projected calculations for small-radius approximations.
+- **3D math:** `MathNet.Spatial` — Euclidean 3D distances and vector ops for oracle checks.
+- **GeoJSON parsing (test-only):** `GeoJSON.Net` — load complex fixtures without maintaining your own parser.
+- **External systems for differential tests (CI optional):** `PostGIS`, `SQLite+RTree/SpatiaLite` for bbox/near behavior.
+
+### Public datasets & fixtures
+
+- `Turf.js` fixtures (GeoJSON): points/lines/polygons with holes; great for predicate parity.
+- `Natural Earth`: coastlines, large polygons crossing the anti-meridian (Aleutians, Russia); polar stress.
+- `OSM` extracts (tiny tiles): dense urban point clouds for performance & correctness mixes.
+- Synthetic grids & lattices: controlled point sets for Morton/Hilbert locality tests.
+- Precomputed geodesic pairs from GeographicLib samples (save as JSON with expected distances).
+
+### New Stories (append to Epic)
+
+#### T1 — Oracle Adapters
+
+- [ ] Add `LiteDB.Spatial.Testing.Oracles` project with adapters for NTS, GeographicLib, MathNet, PostGIS.
+
+#### T2 — Golden Fixtures & Tolerances
+
+- [ ] Store fixtures under `/tests/fixtures` with documented tolerances and snapshot helpers.
+
+#### T3 — Differential Correctness: Geographic 2D
+
+- [ ] Cross-check `SpatialGeographic` behavior against PostGIS and GeographicLib oracles.
+
+#### T4 — Differential Correctness: Cartesian 2D
+
+- [ ] Validate Euclidean behavior with NTS and property-based testing.
+
+#### T5 — Differential Correctness: Cartesian 3D
+
+- [ ] Ensure 3D results align with MathNet.Spatial and range caps.
+
+#### T6 — Index Locality & Stability (Morton)
+
+- [ ] Measure locality/monotonicity and compare to reference encoders.
+
+#### T7 — Query Plan Parity (LINQ)
+
+- [ ] Assert LINQ plans use indexes and match oracles.
+
+#### T8 — Performance Sanity vs External Systems (optional `perf`)
+
+- [ ] Benchmark LiteDB.Spatial vs SQLite/PostGIS and record findings.
+
+---
+
+## Concrete snippets (test-only patterns)
+
+```csharp
+// Distance parity (Geographic)
+var d1 = GeographicLibOracle.Distance(lon1, lat1, lon2, lat2);
+var d2 = SpatialGeographicDistance.Haversine(lon1, lat1, lon2, lat2);
+d2.Should().BeApproximately(d1, 1e-4 * d1 + 0.05);
+```
+
+```csharp
+// Predicate parity (2D)
+var expected = NtsOracle.Contains(poly, pt);
+var actual = SpatialExpressions.Within(/* polygon */, /* point */);
+actual.Should().Be(expected);
+```
+
+```csharp
+// 3D near parity
+var dRef = MathNetOracle3D.Distance(a, b);
+var dOur = Euclidean3D.Distance(a, b);
+dOur.Should().BeApproximately(dRef, 1e-9);
+```
+
+---
+
+## Integration guidance
+
+- Keep external libraries under `tests` only and guard with categories/env vars.
+- Persist expensive oracle outputs to JSON fixtures for reproducible CI runs.
+- Document toggles like `SPATIAL_ORACLES` and `SPATIAL_DB_TESTS` for optional suites.
+
+---
+
+## Acceptance Criteria (global)
+
+- Geographic distances match GeographicLib within tolerance on 1,000 diverse pairs.
+- 2D predicates match NTS on 100 complex polygons × 1,000 random points each.
+- 3D distances match MathNet.Spatial within floating-point tolerance on 10,000 random pairs.
+- Index usage verified by explain output in every LINQ test; no full scans when index present.
+- Fixtures pack checked into the repo; tests avoid network calls.
+


### PR DESCRIPTION
## Summary
- add a Morton index encoder with covering helpers and range coalescing
- persist spatial collection metadata with descriptor validation and options round-tripping
- add a spatial backfill pipeline and unit tests covering encoder, metadata, and backfill flows

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e7407432f083268c81ccebffb8f4bb