### PR TITLE
Add spatial engines and facades

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian2DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian2DEngineTests.cs
@@ -1,0 +1,53 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class Cartesian2DEngineTests
+{
+    [Fact]
+    public void PlanNearProducesEuclideanPredicate()
+    {
+        var engine = new LiteDB.Spatial.Cartesian2DEngine("location", new LiteDB.Spatial.SpatialIndexOptions(distanceTolerance: 0.25));
+        var plan = engine.PlanNear(new LiteDB.Spatial.GeoPoint(0.5, 0.5), 0.1);
+
+        plan.Dimensions.Should().Be(2);
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.ExactPredicateDescription.Should().Contain("Euclidean2D");
+    }
+
+    [Fact]
+    public void MapperReadsDocumentCoordinates()
+    {
+        var encoder = new LiteDB.Spatial.MortonIndexEncoder(2, 8);
+        var mapper = new LiteDB.Spatial.Cartesian2DMapper(encoder, "location");
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["location"] = new BaseLiteDB.BsonDocument
+            {
+                ["x"] = 0.25,
+                ["y"] = 0.75
+            }
+        };
+
+        mapper.TryReadPoint(document, out LiteDB.Spatial.GeoPoint point).Should().BeTrue();
+        point.Longitude.Should().Be(0.25);
+        point.Latitude.Should().Be(0.75);
+    }
+
+    [Fact]
+    public void SpatialCartesian2DEnsuresMetadata()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        LiteDB.Spatial.SpatialCartesian2D.EnsurePointIndex(database, "points", "location", new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 8));
+
+        var plan = LiteDB.Spatial.SpatialCartesian2D.Near(database, "points", new LiteDB.Spatial.GeoPoint(0.5, 0.5), 0.1);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian3DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian3DEngineTests.cs
@@ -1,0 +1,55 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class Cartesian3DEngineTests
+{
+    [Fact]
+    public void PlanNearProducesThreeDimensionalPredicate()
+    {
+        var engine = new LiteDB.Spatial.Cartesian3DEngine("location", new LiteDB.Spatial.SpatialIndexOptions(distanceTolerance: 0.5));
+        var plan = engine.PlanNear(new LiteDB.Spatial.GeoPoint3D(0.25, 0.5, 0.75), 0.2);
+
+        plan.Dimensions.Should().Be(3);
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.ExactPredicateDescription.Should().Contain("Euclidean3D");
+    }
+
+    [Fact]
+    public void MapperReadsArrayCoordinates()
+    {
+        var encoder = new LiteDB.Spatial.MortonIndexEncoder(3, 8);
+        var mapper = new LiteDB.Spatial.Cartesian3DMapper(encoder, "location");
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["location"] = new BaseLiteDB.BsonArray
+            {
+                new BaseLiteDB.BsonValue(0.1),
+                new BaseLiteDB.BsonValue(0.2),
+                new BaseLiteDB.BsonValue(0.3)
+            }
+        };
+
+        mapper.TryReadPoint(document, out LiteDB.Spatial.GeoPoint3D point).Should().BeTrue();
+        point.X.Should().Be(0.1);
+        point.Y.Should().Be(0.2);
+        point.Z.Should().Be(0.3);
+    }
+
+    [Fact]
+    public void SpatialCartesian3DEnsuresMetadata()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        LiteDB.Spatial.SpatialCartesian3D.EnsurePointIndex(database, "cloud", "position", new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 6));
+
+        var plan = LiteDB.Spatial.SpatialCartesian3D.Near(database, "cloud", new LiteDB.Spatial.GeoPoint3D(0d, 0d, 0d), 0.5);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/GeographicEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/GeographicEngineTests.cs
@@ -1,0 +1,88 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class GeographicEngineTests
+{
+    [Fact]
+    public void PlanNearProducesVincentyPredicate()
+    {
+        var engine = new LiteDB.Spatial.GeographicEngine("location", new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 16, distanceTolerance: 5));
+        var plan = engine.PlanNear(new LiteDB.Spatial.GeoPoint(13.4050, 52.5200), 1_000d);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.ExactPredicateDescription.Should().Contain("Vincenty");
+        plan.CoveringBounds.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void PlanWithinHandlesAntimeridian()
+    {
+        var engine = new LiteDB.Spatial.GeographicEngine("location");
+        var plan = engine.PlanWithin(LiteDB.Spatial.BoundingBox.From2D(170d, -10d, 190d, 10d));
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void MapperNormalizesCoordinatesAndEncodes()
+    {
+        var encoder = new LiteDB.Spatial.MortonIndexEncoder(2, 16);
+        var mapper = new LiteDB.Spatial.GeographicMapper(encoder, "location");
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["location"] = new BaseLiteDB.BsonDocument
+            {
+                ["longitude"] = 190d,
+                ["latitude"] = 95d
+            }
+        };
+
+        mapper.TryReadPoint(document, out LiteDB.Spatial.GeoPoint point).Should().BeTrue();
+        point.Longitude.Should().BeApproximately(-170d, 1e-6);
+        point.Latitude.Should().BeLessThan(90d);
+
+        var bounding = mapper.GetBoundingBox(point);
+        bounding.MinX.Should().BeGreaterOrEqualTo(0d);
+        bounding.MaxX.Should().BeLessOrEqualTo(1d);
+
+        mapper.Invoking(m => m.Encode(point)).Should().NotThrow();
+    }
+
+    [Fact]
+    public void GeographicDistanceVincentyMatchesHaversineWithinTolerance()
+    {
+        var left = new LiteDB.Spatial.GeoPoint(-0.1278, 51.5074); // London
+        var right = new LiteDB.Spatial.GeoPoint(2.3522, 48.8566); // Paris
+
+        var haversine = new LiteDB.Spatial.GeographicDistance(LiteDB.Spatial.GeographicDistanceMode.Haversine);
+        var vincenty = new LiteDB.Spatial.GeographicDistance(LiteDB.Spatial.GeographicDistanceMode.Vincenty);
+
+        var d1 = haversine.Distance(left, right);
+        var d2 = vincenty.Distance(left, right);
+
+        d2.Should().BeApproximately(343_556d, 500d);
+        d1.Should().BeApproximately(d2, 750d);
+    }
+
+    [Fact]
+    public void SpatialGeographicFacadePersistsDescriptor()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var descriptor = LiteDB.Spatial.SpatialGeographic.EnsurePointIndex(database, "places", "location", new LiteDB.Spatial.SpatialIndexOptions(precisionBits: 10));
+
+        descriptor.EngineName.Should().Be("Geographic");
+
+        var plan = LiteDB.Spatial.SpatialGeographic.Near(database, "places", new LiteDB.Spatial.GeoPoint(0d, 0d), 500d);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DEngine.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Plans queries for flat two-dimensional Cartesian coordinates.
+/// </summary>
+public sealed class Cartesian2DEngine : ISpatialEngine
+{
+    private readonly Cartesian2DMapper _mapper;
+    private readonly EuclideanDistance _distance = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian2DEngine"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">The document field that stores the point geometry.</param>
+    /// <param name="options">Optional spatial index options.</param>
+    public Cartesian2DEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        _mapper = new Cartesian2DMapper(IndexEncoder, geometryFieldName);
+    }
+
+    /// <inheritdoc />
+    public string Name => "Cartesian2D";
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper => _mapper;
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance => _distance;
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var expansion = radius + Options.DistanceTolerance;
+        var bounds = BoundingBox.From2D(
+            center.Longitude - expansion,
+            center.Latitude - expansion,
+            center.Longitude + expansion,
+            center.Latitude + expansion);
+
+        return BuildPlan(bounds, string.Format(CultureInfo.InvariantCulture, "Euclidean2D distance ≤ {0:N3}", expansion));
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        return PlanNear(new GeoPoint(center.X, center.Y), radius);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Cartesian 2D queries require two-dimensional bounding boxes.", nameof(bounds));
+        }
+
+        return BuildPlan(bounds, "Within bounding box");
+    }
+
+    private SpatialQueryPlan BuildPlan(BoundingBox bounds, string predicate)
+    {
+        var cover = IndexEncoder.Cover(bounds, Options.MaxCoveringCells);
+        var merged = MortonIndexEncoder.UnionAdjacentRanges(cover);
+        return new SpatialQueryPlan(Dimensions, bounds, merged, predicate);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DMapper.cs
@@ -1,0 +1,145 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian2DMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+
+    public Cartesian2DMapper(ISpatialIndexEncoder encoder, string geometryFieldName)
+    {
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName))
+            : geometryFieldName;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        return BoundingBox.From2D(point.X, point.Y, point.X, point.Y);
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = point.Longitude;
+        coordinates[1] = point.Latitude;
+        return _encoder.Encode(coordinates);
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = point.X;
+        coordinates[1] = point.Y;
+        return _encoder.Encode(coordinates);
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (TryReadComponents(geometry, out var x, out var y, out _))
+        {
+            point = new GeoPoint(x, y);
+            return true;
+        }
+
+        throw new SpatialMetadataException($"Geometry field '{_geometryFieldName}' must contain numeric X/Y coordinates.");
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (TryReadComponents(geometry, out var x, out var y, out var z))
+        {
+            point = new GeoPoint3D(x, y, z);
+            return true;
+        }
+
+        throw new SpatialMetadataException($"Geometry field '{_geometryFieldName}' must contain numeric X/Y coordinates.");
+    }
+
+    internal static bool TryReadComponents(BaseLiteDB.BsonValue geometry, out double x, out double y, out double z)
+    {
+        x = y = z = 0d;
+
+        if (geometry.IsArray)
+        {
+            var array = geometry.AsArray;
+            if (array.Count < 2 || !array[0].IsNumber || !array[1].IsNumber)
+            {
+                return false;
+            }
+
+            x = array[0].AsDouble;
+            y = array[1].AsDouble;
+            z = array.Count > 2 && array[2].IsNumber ? array[2].AsDouble : 0d;
+            return true;
+        }
+
+        if (geometry.IsDocument)
+        {
+            var doc = geometry.AsDocument;
+            if (!TryRead(doc, new[] { "x", "longitude", "lon" }, out x))
+            {
+                return false;
+            }
+
+            if (!TryRead(doc, new[] { "y", "latitude", "lat" }, out y))
+            {
+                return false;
+            }
+
+            TryRead(doc, new[] { "z" }, out z);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryRead(BaseLiteDB.BsonDocument document, string[] candidates, out double value)
+    {
+        foreach (var name in candidates)
+        {
+            if (document.TryGetValue(name, out var bson) && bson.IsNumber)
+            {
+                value = bson.AsDouble;
+                return true;
+            }
+        }
+
+        value = 0d;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DEngine.cs
@@ -1,0 +1,94 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides spatial planning for three-dimensional Cartesian point clouds.
+/// </summary>
+public sealed class Cartesian3DEngine : ISpatialEngine
+{
+    private readonly Cartesian3DMapper _mapper;
+    private readonly EuclideanDistance _distance = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian3DEngine"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">The document field containing the 3D point.</param>
+    /// <param name="options">Optional spatial index options.</param>
+    public Cartesian3DEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(3, Options.PrecisionBits);
+        _mapper = new Cartesian3DMapper(IndexEncoder, geometryFieldName);
+    }
+
+    /// <inheritdoc />
+    public string Name => "Cartesian3D";
+
+    /// <inheritdoc />
+    public int Dimensions => 3;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper => _mapper;
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance => _distance;
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        return PlanNear(new GeoPoint3D(center.Longitude, center.Latitude, 0d), radius);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var expansion = radius + Options.DistanceTolerance;
+        var bounds = BoundingBox.From3D(
+            center.X - expansion,
+            center.Y - expansion,
+            center.Z - expansion,
+            center.X + expansion,
+            center.Y + expansion,
+            center.Z + expansion);
+
+        return BuildPlan(bounds, string.Format(CultureInfo.InvariantCulture, "Euclidean3D distance ≤ {0:N3}", expansion));
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 3)
+        {
+            throw new ArgumentException("Cartesian 3D queries require three-dimensional bounding boxes.", nameof(bounds));
+        }
+
+        return BuildPlan(bounds, "Within bounding box");
+    }
+
+    private SpatialQueryPlan BuildPlan(BoundingBox bounds, string predicate)
+    {
+        var cover = IndexEncoder.Cover(bounds, Options.MaxCoveringCells);
+        var merged = MortonIndexEncoder.UnionAdjacentRanges(cover);
+        return new SpatialQueryPlan(Dimensions, bounds, merged, predicate);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DMapper.cs
@@ -1,0 +1,84 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian3DMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+
+    public Cartesian3DMapper(ISpatialIndexEncoder encoder, string geometryFieldName)
+    {
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName))
+            : geometryFieldName;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From3D(point.Longitude, point.Latitude, 0d, point.Longitude, point.Latitude, 0d);
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[3];
+        coordinates[0] = point.Longitude;
+        coordinates[1] = point.Latitude;
+        coordinates[2] = 0d;
+        return _encoder.Encode(coordinates);
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        Span<double> coordinates = stackalloc double[3];
+        coordinates[0] = point.X;
+        coordinates[1] = point.Y;
+        coordinates[2] = point.Z;
+        return _encoder.Encode(coordinates);
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (!TryReadPoint(document, out GeoPoint3D point3D))
+        {
+            point = default;
+            return false;
+        }
+
+        point = new GeoPoint(point3D.X, point3D.Y);
+        return true;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (Cartesian2DMapper.TryReadComponents(geometry, out var x, out var y, out var z))
+        {
+            point = new GeoPoint3D(x, y, z);
+            return true;
+        }
+
+        throw new SpatialMetadataException($"Geometry field '{_geometryFieldName}' must contain numeric X/Y/Z coordinates.");
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/EuclideanDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/EuclideanDistance.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+internal sealed class EuclideanDistance : ISpatialDistance
+{
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var dx = right.Longitude - left.Longitude;
+        var dy = right.Latitude - left.Latitude;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = right.X - left.X;
+        var dy = right.Y - left.Y;
+        var dz = right.Z - left.Z;
+        return Math.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistance.cs
@@ -1,0 +1,130 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes distances between geographic coordinates.
+/// </summary>
+public sealed class GeographicDistance : ISpatialDistance
+{
+    private const double EarthRadiusMeters = 6_378_137d;
+    private const double Flattening = 1d / 298.257223563d;
+    private const double EarthSemiMinorAxis = EarthRadiusMeters * (1d - Flattening);
+    private readonly GeographicDistanceMode _mode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicDistance"/> class.
+    /// </summary>
+    /// <param name="mode">The distance calculation mode.</param>
+    public GeographicDistance(GeographicDistanceMode mode)
+    {
+        _mode = mode;
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        return _mode switch
+        {
+            GeographicDistanceMode.Haversine => DistanceHaversine(left, right),
+            GeographicDistanceMode.Vincenty => DistanceVincenty(left, right),
+            _ => DistanceHaversine(left, right)
+        };
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = right.X - left.X;
+        var dy = right.Y - left.Y;
+        var dz = right.Z - left.Z;
+        return Math.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
+    }
+
+    private static double DistanceHaversine(GeoPoint left, GeoPoint right)
+    {
+        var lat1 = DegreesToRadians(left.Latitude);
+        var lat2 = DegreesToRadians(right.Latitude);
+        var dLat = DegreesToRadians(right.Latitude - left.Latitude);
+        var dLon = DegreesToRadians(right.Longitude - left.Longitude);
+
+        var a = Math.Pow(Math.Sin(dLat / 2d), 2d) + Math.Cos(lat1) * Math.Cos(lat2) * Math.Pow(Math.Sin(dLon / 2d), 2d);
+        var c = 2d * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1d - a));
+        return EarthRadiusMeters * c;
+    }
+
+    private static double DistanceVincenty(GeoPoint left, GeoPoint right)
+    {
+        var lat1 = DegreesToRadians(left.Latitude);
+        var lat2 = DegreesToRadians(right.Latitude);
+        var lon1 = DegreesToRadians(left.Longitude);
+        var lon2 = DegreesToRadians(right.Longitude);
+
+        var u1 = Math.Atan((1d - Flattening) * Math.Tan(lat1));
+        var u2 = Math.Atan((1d - Flattening) * Math.Tan(lat2));
+        var sinU1 = Math.Sin(u1);
+        var cosU1 = Math.Cos(u1);
+        var sinU2 = Math.Sin(u2);
+        var cosU2 = Math.Cos(u2);
+
+        var lambda = lon2 - lon1;
+        var previousLambda = double.NaN;
+        var iterationLimit = 100;
+
+        var sinSigma = 0d;
+        var cosSigma = 0d;
+        var sigma = 0d;
+        var sinAlpha = 0d;
+        var cosSqAlpha = 0d;
+        var cos2SigmaM = 0d;
+
+        while (iterationLimit-- > 0)
+        {
+            var sinLambda = Math.Sin(lambda);
+            var cosLambda = Math.Cos(lambda);
+            sinSigma = Math.Sqrt(Math.Pow(cosU2 * sinLambda, 2d) + Math.Pow(cosU1 * sinU2 - sinU1 * cosU2 * cosLambda, 2d));
+
+            if (sinSigma == 0d)
+            {
+                return 0d;
+            }
+
+            cosSigma = sinU1 * sinU2 + cosU1 * cosU2 * cosLambda;
+            sigma = Math.Atan2(sinSigma, cosSigma);
+            sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
+            cosSqAlpha = 1d - (sinAlpha * sinAlpha);
+
+            cos2SigmaM = cosSqAlpha == 0d ? 0d : cosSigma - 2d * sinU1 * sinU2 / cosSqAlpha;
+            var c = Flattening / 16d * cosSqAlpha * (4d + Flattening * (4d - 3d * cosSqAlpha));
+            previousLambda = lambda;
+            lambda = (lon2 - lon1) + (1d - c) * Flattening * sinAlpha *
+                (sigma + c * sinSigma * (cos2SigmaM + c * cosSigma * (-1d + 2d * Math.Pow(cos2SigmaM, 2d))));
+
+            if (Math.Abs(lambda - previousLambda) < 1e-12)
+            {
+                break;
+            }
+        }
+
+        if (Math.Abs(lambda - previousLambda) >= 1e-9)
+        {
+            return DistanceHaversine(left, right);
+        }
+
+        var uSq = cosSqAlpha * (Math.Pow(EarthRadiusMeters, 2d) - Math.Pow(EarthSemiMinorAxis, 2d)) /
+                  Math.Pow(EarthSemiMinorAxis, 2d);
+        var a = 1d + uSq / 16384d * (4096d + uSq * (-768d + uSq * (320d - 175d * uSq)));
+        var b = uSq / 1024d * (256d + uSq * (-128d + uSq * (74d - 47d * uSq)));
+        var deltaSigma = b * sinSigma * (cos2SigmaM + b / 4d * (cosSigma * (-1d + 2d * Math.Pow(cos2SigmaM, 2d)) -
+            b / 6d * cos2SigmaM * (-3d + 4d * Math.Pow(sinSigma, 2d)) * (-3d + 4d * Math.Pow(cos2SigmaM, 2d))));
+        var distance = EarthSemiMinorAxis * a * (sigma - deltaSigma);
+        return distance;
+    }
+
+    private static double DegreesToRadians(double degrees)
+    {
+        return degrees * Math.PI / 180d;
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistanceMode.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistanceMode.cs
@@ -1,0 +1,17 @@
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Enumerates the supported distance calculation strategies for geographic coordinates.
+/// </summary>
+public enum GeographicDistanceMode
+{
+    /// <summary>
+    /// Uses the haversine formula for spherical distance approximations.
+    /// </summary>
+    Haversine,
+
+    /// <summary>
+    /// Uses the Vincenty inverse formula for ellipsoidal distance calculations.
+    /// </summary>
+    Vincenty
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicEngine.cs
@@ -1,0 +1,100 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides query planning and mapping for two-dimensional geographic data stored in LiteDB.
+/// </summary>
+public sealed class GeographicEngine : ISpatialEngine
+{
+    private readonly GeographicMapper _mapper;
+    private readonly GeographicDistance _distance;
+    private readonly GeographicDistanceMode _mode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicEngine"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">The document field that stores the geographic point.</param>
+    /// <param name="options">Optional spatial index options. Defaults are used when <c>null</c>.</param>
+    /// <param name="mode">The distance mode used for exact filtering.</param>
+    public GeographicEngine(string geometryFieldName, SpatialIndexOptions? options = null, GeographicDistanceMode mode = GeographicDistanceMode.Vincenty)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        _mode = mode;
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        _mapper = new GeographicMapper(IndexEncoder, geometryFieldName);
+        _distance = new GeographicDistance(mode);
+    }
+
+    /// <inheritdoc />
+    public string Name => "Geographic";
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper => _mapper;
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance => _distance;
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var envelopes = GeographicMath.CreateBoundingBoxesForCircle(center, radius + Options.DistanceTolerance);
+        return BuildPlan(envelopes, string.Format(CultureInfo.InvariantCulture, "{0} distance ≤ {1:N3} m", _mode, radius + Options.DistanceTolerance));
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        return PlanNear(new GeoPoint(center.X, center.Y), radius);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        var normalized = GeographicMath.NormalizeBoundingBox(bounds);
+        return BuildPlan(normalized, "Within bounding box");
+    }
+
+    private SpatialQueryPlan BuildPlan(IReadOnlyList<BoundingBox> segments, string predicate)
+    {
+        var ranges = new List<SpatialIndexRange>();
+        BoundingBox? covering = null;
+
+        foreach (var segment in segments)
+        {
+            var normalized = GeographicMath.ToNormalizedBox(segment);
+            covering ??= normalized;
+            var coverRanges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+            if (coverRanges.Count > 0)
+            {
+                ranges.AddRange(coverRanges);
+            }
+        }
+
+        var merged = MortonIndexEncoder.UnionAdjacentRanges(ranges);
+        return new SpatialQueryPlan(Dimensions, covering, merged, predicate);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicMapper.cs
@@ -1,0 +1,128 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+internal sealed class GeographicMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+
+    public GeographicMapper(ISpatialIndexEncoder encoder, string geometryFieldName)
+    {
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName))
+            : geometryFieldName;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(
+            GeographicMath.ToNormalizedLongitude(point.Longitude),
+            GeographicMath.ToNormalizedLatitude(point.Latitude),
+            GeographicMath.ToNormalizedLongitude(point.Longitude),
+            GeographicMath.ToNormalizedLatitude(point.Latitude));
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapping is restricted to two-dimensional coordinates.");
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = GeographicMath.ToNormalizedLongitude(point.Longitude);
+        coordinates[1] = GeographicMath.ToNormalizedLatitude(point.Latitude);
+        return _encoder.Encode(coordinates);
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapping is restricted to two-dimensional coordinates.");
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (geometry.IsArray)
+        {
+            var array = geometry.AsArray;
+            if (array.Count < 2 || !array[0].IsNumber || !array[1].IsNumber)
+            {
+                throw new SpatialMetadataException($"Geometry field '{_geometryFieldName}' must contain two numeric values when stored as an array.");
+            }
+
+            point = GeographicMath.NormalizePoint(new GeoPoint(array[0].AsDouble, array[1].AsDouble));
+            return true;
+        }
+
+        if (geometry.IsDocument)
+        {
+            var geoDoc = geometry.AsDocument;
+            if (!TryReadDocumentCoordinates(geoDoc, out var longitude, out var latitude))
+            {
+                throw new SpatialMetadataException($"Geometry field '{_geometryFieldName}' must expose longitude and latitude members.");
+            }
+
+            point = GeographicMath.NormalizePoint(new GeoPoint(longitude, latitude));
+            return true;
+        }
+
+        throw new SpatialMetadataException($"Geometry field '{_geometryFieldName}' must be either an array or document containing coordinates.");
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadDocumentCoordinates(BaseLiteDB.BsonDocument document, out double longitude, out double latitude)
+    {
+        longitude = 0d;
+        latitude = 0d;
+
+        if (!TryRead(document, new[] { "longitude", "lon", "lng", "x" }, out longitude))
+        {
+            return false;
+        }
+
+        if (!TryRead(document, new[] { "latitude", "lat", "y" }, out latitude))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryRead(BaseLiteDB.BsonDocument document, string[] candidates, out double value)
+    {
+        foreach (var name in candidates)
+        {
+            if (document.TryGetValue(name, out var bson) && bson.IsNumber)
+            {
+                value = bson.AsDouble;
+                return true;
+            }
+        }
+
+        value = 0d;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicMath.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicMath.cs
@@ -1,0 +1,170 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+internal static class GeographicMath
+{
+    private const double DegToRad = Math.PI / 180d;
+    private const double RadToDeg = 180d / Math.PI;
+    private const double EarthRadiusMeters = 6_378_137d;
+    private const double PolarClamp = 90d - 1e-9;
+
+    public static GeoPoint NormalizePoint(GeoPoint point)
+    {
+        var longitude = NormalizeLongitude(point.Longitude);
+        var latitude = ClampLatitude(point.Latitude);
+        return new GeoPoint(longitude, latitude);
+    }
+
+    public static double NormalizeLongitude(double longitude)
+    {
+        var wrapped = longitude % 360d;
+        if (wrapped > 180d)
+        {
+            wrapped -= 360d;
+        }
+        else if (wrapped < -180d)
+        {
+            wrapped += 360d;
+        }
+
+        return wrapped;
+    }
+
+    public static double ClampLatitude(double latitude)
+    {
+        if (latitude > PolarClamp)
+        {
+            return PolarClamp;
+        }
+
+        if (latitude < -PolarClamp)
+        {
+            return -PolarClamp;
+        }
+
+        return latitude;
+    }
+
+    public static double ToNormalizedLongitude(double longitude)
+    {
+        return (NormalizeLongitude(longitude) + 180d) / 360d;
+    }
+
+    public static double ToNormalizedLatitude(double latitude)
+    {
+        return (ClampLatitude(latitude) + 90d) / 180d;
+    }
+
+    public static IReadOnlyList<BoundingBox> CreateBoundingBoxesForCircle(GeoPoint center, double radiusMeters)
+    {
+        if (radiusMeters < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radiusMeters), "Radius must be non-negative.");
+        }
+
+        var normalizedCenter = NormalizePoint(center);
+        var latRadius = radiusMeters / EarthRadiusMeters * RadToDeg;
+        var minLat = ClampLatitude(normalizedCenter.Latitude - latRadius);
+        var maxLat = ClampLatitude(normalizedCenter.Latitude + latRadius);
+
+        double minLon;
+        double maxLon;
+
+        if (Math.Abs(maxLat) >= PolarClamp || Math.Abs(minLat) >= PolarClamp)
+        {
+            minLon = -180d;
+            maxLon = 180d;
+        }
+        else
+        {
+            var latRad = normalizedCenter.Latitude * DegToRad;
+            var cosLat = Math.Cos(latRad);
+            if (Math.Abs(cosLat) < 1e-12)
+            {
+                minLon = -180d;
+                maxLon = 180d;
+            }
+            else
+            {
+                var lonRadius = radiusMeters / (EarthRadiusMeters * cosLat) * RadToDeg;
+                if (lonRadius >= 180d)
+                {
+                    minLon = -180d;
+                    maxLon = 180d;
+                }
+                else
+                {
+                    minLon = NormalizeLongitude(normalizedCenter.Longitude - lonRadius);
+                    maxLon = NormalizeLongitude(normalizedCenter.Longitude + lonRadius);
+                }
+            }
+        }
+
+        return SplitAntimeridian(minLon, maxLon, minLat, maxLat);
+    }
+
+    public static IReadOnlyList<BoundingBox> NormalizeBoundingBox(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic bounding boxes must be two-dimensional.", nameof(bounds));
+        }
+
+        var minLat = ClampLatitude(bounds.MinY);
+        var maxLat = ClampLatitude(bounds.MaxY);
+
+        var minLon = NormalizeLongitude(bounds.MinX);
+        var maxLon = NormalizeLongitude(bounds.MaxX);
+
+        return SplitAntimeridian(minLon, maxLon, minLat, maxLat);
+    }
+
+    public static BoundingBox ToNormalizedBox(BoundingBox box)
+    {
+        if (box.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic bounding boxes must be two-dimensional.");
+        }
+
+        return BoundingBox.From2D(
+            ToNormalizedLongitude(box.MinX),
+            ToNormalizedLatitude(box.MinY),
+            ToNormalizedLongitude(box.MaxX),
+            ToNormalizedLatitude(box.MaxY));
+    }
+
+    public static BoundingBox NormalizeToUnitBounds(BoundingBox box)
+    {
+        if (box.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic bounding boxes must be two-dimensional.");
+        }
+
+        var minX = Math.Max(0d, Math.Min(1d, box.MinX));
+        var minY = Math.Max(0d, Math.Min(1d, box.MinY));
+        var maxX = Math.Max(minX, Math.Max(0d, Math.Min(1d, box.MaxX)));
+        var maxY = Math.Max(minY, Math.Max(0d, Math.Min(1d, box.MaxY)));
+        return BoundingBox.From2D(minX, minY, maxX, maxY);
+    }
+
+    private static IReadOnlyList<BoundingBox> SplitAntimeridian(double minLon, double maxLon, double minLat, double maxLat)
+    {
+        minLat = ClampLatitude(minLat);
+        maxLat = ClampLatitude(maxLat);
+
+        if (minLon <= maxLon)
+        {
+            return new[] { BoundingBox.From2D(minLon, minLat, maxLon, maxLat) };
+        }
+
+        return new[]
+        {
+            BoundingBox.From2D(minLon, minLat, 180d, maxLat),
+            BoundingBox.From2D(-180d, minLat, maxLon, maxLat)
+        };
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents an immutable implementation of <see cref="ISpatialQueryPlan"/>.
+/// </summary>
+public sealed class SpatialQueryPlan : ISpatialQueryPlan
+{
+    private readonly IReadOnlyList<SpatialIndexRange> _ranges;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialQueryPlan"/> class.
+    /// </summary>
+    /// <param name="dimensions">The spatial dimensionality of the plan.</param>
+    /// <param name="coveringBounds">The coarse bounding box applied before exact filtering.</param>
+    /// <param name="ranges">The index ranges used to service the query.</param>
+    /// <param name="exactPredicateDescription">Optional description of the exact predicate used after index pruning.</param>
+    public SpatialQueryPlan(
+        int dimensions,
+        BoundingBox? coveringBounds,
+        IEnumerable<SpatialIndexRange> ranges,
+        string? exactPredicateDescription)
+    {
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial query plans must be two- or three-dimensional.");
+        }
+
+        if (ranges == null)
+        {
+            throw new ArgumentNullException(nameof(ranges));
+        }
+
+        Dimensions = dimensions;
+        CoveringBounds = coveringBounds;
+        _ranges = new ReadOnlyCollection<SpatialIndexRange>(new List<SpatialIndexRange>(ranges));
+        ExactPredicateDescription = exactPredicateDescription;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> IndexRanges => _ranges;
+
+    /// <inheritdoc />
+    public string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Core/Facades/SpatialCartesian2D.cs
+++ b/LiteDB.Spatial.Core/Facades/SpatialCartesian2D.cs
@@ -1,0 +1,87 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helpers for configuring flat two-dimensional spatial collections.
+/// </summary>
+public static class SpatialCartesian2D
+{
+    private const string MissingConfigurationMessage = "Call SpatialCartesian2D.EnsurePointIndex before issuing 2D spatial queries.";
+
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var engine = new Cartesian2DEngine(geometryFieldName, options);
+        var descriptor = new SpatialCollectionDescriptor(collectionName, engine.Name, engine.Dimensions, geometryFieldName, engine.Options, engine);
+
+        var metadata = new SpatialMetadataStore(database);
+        metadata.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(engine.Options.IndexFieldName, BaseLiteDB.BsonExpression.Create("$." + engine.Options.IndexFieldName));
+
+        return descriptor;
+    }
+
+    public static ISpatialQueryPlan Near(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        GeoPoint center,
+        double radius)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        var metadata = new SpatialMetadataStore(database);
+        var descriptor = metadata.GetRequiredDescriptor(collectionName, MissingConfigurationMessage);
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanNear(center, radius);
+    }
+
+    public static ISpatialQueryPlan WithinBoundingBox(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        BoundingBox bounds)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        var metadata = new SpatialMetadataStore(database);
+        var descriptor = metadata.GetRequiredDescriptor(collectionName, MissingConfigurationMessage);
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static Cartesian2DEngine ResolveEngine(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor.Engine is Cartesian2DEngine engine)
+        {
+            return engine;
+        }
+
+        return new Cartesian2DEngine(descriptor.GeometryFieldName, descriptor.Options);
+    }
+}

--- a/LiteDB.Spatial.Core/Facades/SpatialCartesian3D.cs
+++ b/LiteDB.Spatial.Core/Facades/SpatialCartesian3D.cs
@@ -1,0 +1,87 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helpers for configuring three-dimensional spatial collections.
+/// </summary>
+public static class SpatialCartesian3D
+{
+    private const string MissingConfigurationMessage = "Call SpatialCartesian3D.EnsurePointIndex before issuing 3D spatial queries.";
+
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var engine = new Cartesian3DEngine(geometryFieldName, options);
+        var descriptor = new SpatialCollectionDescriptor(collectionName, engine.Name, engine.Dimensions, geometryFieldName, engine.Options, engine);
+
+        var metadata = new SpatialMetadataStore(database);
+        metadata.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(engine.Options.IndexFieldName, BaseLiteDB.BsonExpression.Create("$." + engine.Options.IndexFieldName));
+
+        return descriptor;
+    }
+
+    public static ISpatialQueryPlan Near(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        GeoPoint3D center,
+        double radius)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        var metadata = new SpatialMetadataStore(database);
+        var descriptor = metadata.GetRequiredDescriptor(collectionName, MissingConfigurationMessage);
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanNear(center, radius);
+    }
+
+    public static ISpatialQueryPlan WithinBoundingBox(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        BoundingBox bounds)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        var metadata = new SpatialMetadataStore(database);
+        var descriptor = metadata.GetRequiredDescriptor(collectionName, MissingConfigurationMessage);
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static Cartesian3DEngine ResolveEngine(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor.Engine is Cartesian3DEngine engine)
+        {
+            return engine;
+        }
+
+        return new Cartesian3DEngine(descriptor.GeometryFieldName, descriptor.Options);
+    }
+}

--- a/LiteDB.Spatial.Core/Facades/SpatialGeographic.cs
+++ b/LiteDB.Spatial.Core/Facades/SpatialGeographic.cs
@@ -1,0 +1,99 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helpers that configure collections for geographic indexing and produce query plans.
+/// </summary>
+public static class SpatialGeographic
+{
+    private const string MissingConfigurationMessage = "Call SpatialGeographic.EnsurePointIndex before issuing geographic queries.";
+
+    /// <summary>
+    /// Configures the specified collection for geographic point indexing.
+    /// </summary>
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null,
+        GeographicDistanceMode mode = GeographicDistanceMode.Vincenty)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var engine = new GeographicEngine(geometryFieldName, options, mode);
+        var descriptor = new SpatialCollectionDescriptor(collectionName, engine.Name, engine.Dimensions, geometryFieldName, engine.Options, engine);
+
+        var metadata = new SpatialMetadataStore(database);
+        metadata.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(engine.Options.IndexFieldName, BaseLiteDB.BsonExpression.Create("$." + engine.Options.IndexFieldName));
+
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Produces a geographic near query plan using persisted metadata.
+    /// </summary>
+    public static ISpatialQueryPlan Near(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        GeoPoint center,
+        double radius,
+        GeographicDistanceMode mode = GeographicDistanceMode.Vincenty)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        var metadata = new SpatialMetadataStore(database);
+        var descriptor = metadata.GetRequiredDescriptor(collectionName, MissingConfigurationMessage);
+        var engine = ResolveEngine(descriptor, mode);
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Produces a geographic bounding box query plan using persisted metadata.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        BoundingBox bounds,
+        GeographicDistanceMode mode = GeographicDistanceMode.Vincenty)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        var metadata = new SpatialMetadataStore(database);
+        var descriptor = metadata.GetRequiredDescriptor(collectionName, MissingConfigurationMessage);
+        var engine = ResolveEngine(descriptor, mode);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static GeographicEngine ResolveEngine(SpatialCollectionDescriptor descriptor, GeographicDistanceMode mode)
+    {
+        if (descriptor.Engine is GeographicEngine geographic)
+        {
+            return geographic;
+        }
+
+        return new GeographicEngine(descriptor.GeometryFieldName, descriptor.Options, mode);
+    }
+}

--- a/LiteDB.Spatial.Core/Properties/AssemblyInfo.cs
+++ b/LiteDB.Spatial.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("LiteDB.Spatial.Core.Tests")]

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -97,15 +97,48 @@ LiteDB.Spatial
 ### S5 — Geographic engine (2D)
 
 - [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+  - `PlanNear2D` must expose both Haversine and Vincenty distance modes with range coalescing tuned for meter-based tolerances.
+  - `PlanWithinBox2D` needs explicit anti-meridian handling so bounding boxes that cross ±180° still emit coherent `_mbb` filters.
+  - Mapper should quantize lon/lat into Morton2D codes, normalize bounding boxes, and record metadata for subsequent backfills.
 - [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+  - Introduce helpers for longitude wrapping and polar clamping to avoid discontinuities around the poles.
+  - Guard rails for invalid latitude/longitude inputs with actionable error messages surfaced through the facade.
+- [ ] Ship `SpatialGeographic` facade utilities (`EnsurePointIndex`, `Near`, `WithinBoundingBox`) delegating to the engine and wiring common options.
+
+**Testing outline**
+
+- Regression tests for Berlin vicinity distances and tolerance envelopes vs GeographicLib samples.
+- Anti-meridian fixtures (e.g., Aleutian Islands) verifying bounding box queries prune correctly.
+- Polar bounding boxes proving wrap helpers maintain deterministic Morton codes.
+- Facade integration tests ensuring friendly errors when metadata or indexes are missing.
 
 ### S6 — Cartesian 2D engine
 
 - [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+  - `PlanNear2D` should compute Euclidean radii, fall back to bounding-box approximations when `MaxCoveringCells` is exceeded, and reuse Morton2D coverings.
+  - `PlanWithinBox2D` maps axis-aligned bounding boxes directly to `_mbb` predicates with consistent normalization.
+- [ ] Implement mapper to encode points with Morton2D and persist `_mbb` spans without geographic-specific logic.
+- [ ] Ship `SpatialCartesian2D` facade mirroring the geographic API surface for flat-coordinate callers.
+
+**Testing outline**
+
+- Synthetic grid suites confirming near/box queries leverage the index and return precise Euclidean distances.
+- Property-based tests covering randomized bounding boxes to ensure deterministic Morton ordering and pruning.
+- Facade smoke tests validating options propagation and descriptive errors when the index is absent.
 
 ### S7 — Cartesian 3D engine (points)
 
 - [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+  - `PlanNear3D` forms spherical shells via Morton3D coverings, adds `_mbb` pruning, and applies exact Euclidean3D distance filtering.
+  - `PlanWithinBox3D` translates 3D axis-aligned bounding boxes into `_mbb` spans and Morton3D range plans.
+- [ ] Implement mapper to normalize XYZ coordinates, emit Morton3D keys, and maintain six-value `_mbb` arrays respecting descriptor precision.
+- [ ] Ship `SpatialCartesian3D` facade with helpers for ensuring indexes, running near queries, and bulk backfills for point clouds.
+
+**Testing outline**
+
+- 3D lattice fixtures validating near-query shells, range coalescing, and respect for `MaxCoveringCells` fallbacks.
+- Randomized AABB suites checking mapper output and `_mbb` normalization for varied coordinate scales.
+- Euclidean3D parity checks vs MathNet.Spatial (or similar oracle) to guarantee floating-point tolerance targets.
 
 ### S8 — LINQ resolver
 


### PR DESCRIPTION
## Summary
- add geographic planning components with Morton-based coverings, wraparound helpers, and immutable query plans
- introduce Cartesian 2D/3D engines plus facades to configure collections and generate spatial plans
- exercise the new engines and facades with unit tests covering planners, mappers, and metadata wiring

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e75d35712c83269d4d1d29133f42c4