### PR TITLE
Add geographic and cartesian spatial engines

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian/Cartesian2DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian/Cartesian2DEngineTests.cs
@@ -1,0 +1,63 @@
+#nullable enable
+
+extern alias LiteDbBase;
+
+using System;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Cartesian;
+
+public sealed class Cartesian2DEngineTests
+{
+    [Fact]
+    public void PlanNear_ShouldProduceAxisAlignedCover()
+    {
+        var engine = new Cartesian2DEngine("position", new SpatialIndexOptions(precisionBits: 8));
+        var center = new GeoPoint(0.5, 0.5);
+        var radius = 0.2;
+        var plan = engine.PlanNear(center, radius);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+        var bounds = plan.CoveringBounds!.Value;
+        var expectedOffset = radius + engine.Options.DistanceTolerance;
+        bounds.MinX.Should().BeApproximately(center.Longitude - expectedOffset, 1e-9);
+        bounds.MaxY.Should().BeApproximately(center.Latitude + expectedOffset, 1e-9);
+    }
+
+    [Fact]
+    public void PlanWithin_ShouldRespectBoundingBox()
+    {
+        var engine = new Cartesian2DEngine("position", new SpatialIndexOptions(precisionBits: 8));
+        var bounds = BoundingBox.From2D(0.1, 0.2, 0.9, 0.95);
+        var plan = engine.PlanWithin(bounds);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.Should().Be(bounds);
+    }
+
+    [Fact]
+    public void Mapper_ShouldReadDocumentWithXY()
+    {
+        var engine = new Cartesian2DEngine("position");
+        var mapper = (Cartesian2DMapper)engine.Mapper;
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 7,
+            ["position"] = new BaseLiteDB.BsonDocument
+            {
+                ["x"] = 0.1,
+                ["y"] = 0.9
+            }
+        };
+
+        GeoPoint point;
+        mapper.TryReadPoint(document, out point).Should().BeTrue();
+        point.Should().Be(new GeoPoint(0.1, 0.9));
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian/Cartesian3DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian/Cartesian3DEngineTests.cs
@@ -1,0 +1,64 @@
+#nullable enable
+
+extern alias LiteDbBase;
+
+using System;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Cartesian;
+
+public sealed class Cartesian3DEngineTests
+{
+    [Fact]
+    public void PlanNear_ShouldProduceThreeDimensionalCover()
+    {
+        var engine = new Cartesian3DEngine("position", new SpatialIndexOptions(precisionBits: 6));
+        var center = new GeoPoint3D(1.0, 2.0, 3.0);
+        var radius = 0.5;
+        var plan = engine.PlanNear(center, radius);
+
+        plan.Dimensions.Should().Be(3);
+        plan.CoveringBounds.Should().NotBeNull();
+        var bounds = plan.CoveringBounds!.Value;
+        var expectedOffset = radius + engine.Options.DistanceTolerance;
+        bounds.MinZ.Should().BeApproximately(center.Z - expectedOffset, 1e-9);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void PlanWithin_ShouldRequireThreeDimensionalBox()
+    {
+        var engine = new Cartesian3DEngine("position", new SpatialIndexOptions(precisionBits: 6));
+        var bounds = BoundingBox.From3D(0, 0, 0, 1, 2, 3);
+        var plan = engine.PlanWithin(bounds);
+
+        plan.Dimensions.Should().Be(3);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.Should().Be(bounds);
+    }
+
+    [Fact]
+    public void Mapper_ShouldReadDocumentWithXYZ()
+    {
+        var engine = new Cartesian3DEngine("position");
+        var mapper = (Cartesian3DMapper)engine.Mapper;
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 3,
+            ["position"] = new BaseLiteDB.BsonDocument
+            {
+                ["x"] = 1.2,
+                ["y"] = -2.3,
+                ["z"] = 4.5
+            }
+        };
+
+        GeoPoint3D point;
+        mapper.TryReadPoint(document, out point).Should().BeTrue();
+        point.Should().Be(new GeoPoint3D(1.2, -2.3, 4.5));
+        mapper.Encode(point).Should().BeGreaterThan(0);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Geographic/GeographicEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Geographic/GeographicEngineTests.cs
@@ -1,0 +1,93 @@
+#nullable enable
+
+extern alias LiteDbBase;
+
+using System;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Geographic;
+
+public sealed class GeographicEngineTests
+{
+    [Fact]
+    public void PlanNear_ShouldProduceCoveringForUrbanCoordinates()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions(precisionBits: 12));
+        var center = new GeoPoint(13.4050, 52.5200); // Berlin
+        var plan = engine.PlanNear(center, 5_000); // five kilometers
+
+        plan.Dimensions.Should().Be(2);
+        plan.CoveringBounds.Should().NotBeNull();
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinY.Should().BeLessThan(center.Latitude);
+        bounds.MaxY.Should().BeGreaterThan(center.Latitude);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.ExactPredicateDescription.Should().Contain("distance");
+    }
+
+    [Fact]
+    public void PlanNear_ShouldHandleAntiMeridianWrapAround()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions(precisionBits: 10));
+        var center = new GeoPoint(179.5, 0);
+        var plan = engine.PlanNear(center, 150_000);
+
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().BeLessThanOrEqualTo(-180d);
+        bounds.MaxX.Should().BeGreaterThanOrEqualTo(180d);
+    }
+
+    [Fact]
+    public void PlanNear_ShouldExpandToFullLongitudeNearPoles()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions(precisionBits: 10));
+        var center = new GeoPoint(-45d, 89.0);
+        var plan = engine.PlanNear(center, 250_000);
+
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().BeApproximately(-180d, 1e-6);
+        bounds.MaxX.Should().BeApproximately(180d, 1e-6);
+    }
+
+    [Fact]
+    public void PlanWithin_ShouldRespectWrapAroundBoundingBoxes()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions(precisionBits: 10));
+        var bounds = BoundingBox.From2D(170d, -10d, 190d, 10d);
+        var plan = engine.PlanWithin(bounds);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+        var covering = plan.CoveringBounds!.Value;
+        covering.MaxX.Should().BeGreaterThan(covering.MinX);
+    }
+
+    [Fact]
+    public void Mapper_ShouldReadCommonGeoJsonRepresentations()
+    {
+        var engine = new GeographicEngine("location");
+        var mapper = (GeographicMapper)engine.Mapper;
+        var point = new GeoPoint(12.3, -45.6);
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 1,
+            ["location"] = new BaseLiteDB.BsonDocument
+            {
+                ["type"] = "Point",
+                ["coordinates"] = new BaseLiteDB.BsonArray { point.Longitude, point.Latitude }
+            }
+        };
+
+        GeoPoint extracted;
+        mapper.TryReadPoint(document, out extracted).Should().BeTrue();
+        extracted.Should().Be(point);
+        mapper.Encode(point).Should().BeGreaterThan(0);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DEngine.cs
@@ -1,0 +1,92 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Spatial engine for two-dimensional Cartesian coordinates using Euclidean distance.
+/// </summary>
+public sealed class Cartesian2DEngine : ISpatialEngine
+{
+    /// <summary>
+    /// Gets the canonical engine name.
+    /// </summary>
+    public const string EngineName = "Cartesian2D";
+
+    private readonly Cartesian2DMapper _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian2DEngine"/> class.
+    /// </summary>
+    public Cartesian2DEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        _mapper = new Cartesian2DMapper(geometryFieldName, IndexEncoder);
+        Mapper = _mapper;
+        Distance = new EuclideanDistance();
+    }
+
+    /// <inheritdoc />
+    public string Name => EngineName;
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance { get; }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+        var minX = center.Longitude - effectiveRadius;
+        var maxX = center.Longitude + effectiveRadius;
+        var minY = center.Latitude - effectiveRadius;
+        var maxY = center.Latitude + effectiveRadius;
+
+        var covering = BoundingBox.From2D(minX, minY, maxX, maxY);
+        var ranges = IndexEncoder.Cover(covering, Options.MaxCoveringCells);
+        var description = $"distance <= {radius:F6}";
+
+        return new SpatialQueryPlan(Dimensions, covering, ranges, description);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Cartesian2D engine operates on two-dimensional coordinates.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Cartesian2D engine expects a two-dimensional bounding box.", nameof(bounds));
+        }
+
+        var ranges = IndexEncoder.Cover(bounds, Options.MaxCoveringCells);
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, "within bounding box");
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DMapper.cs
@@ -1,0 +1,136 @@
+#nullable enable
+
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps two-dimensional Cartesian points for indexing.
+/// </summary>
+public sealed class Cartesian2DMapper : ISpatialMapper
+{
+    private readonly string _geometryFieldName;
+    private readonly ISpatialIndexEncoder _encoder;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian2DMapper"/> class.
+    /// </summary>
+    public Cartesian2DMapper(string geometryFieldName, ISpatialIndexEncoder encoder)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        _geometryFieldName = geometryFieldName;
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper cannot operate on three-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = point.Longitude;
+        coordinates[1] = point.Latitude;
+        return _encoder.Encode(coordinates);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper cannot operate on three-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+
+        if (!document.TryGetValue(_geometryFieldName, out var value) || value.IsNull)
+        {
+            return false;
+        }
+
+        if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+            if (TryReadCoordinatePair(doc, out var x, out var y))
+            {
+                point = new GeoPoint(x, y);
+                return true;
+            }
+
+            if (doc.TryGetValue("coordinates", out var arrayValue) && TryReadFromArray(arrayValue, out x, out y))
+            {
+                point = new GeoPoint(x, y);
+                return true;
+            }
+        }
+        else if (TryReadFromArray(value, out var x, out var y))
+        {
+            point = new GeoPoint(x, y);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadCoordinatePair(BaseLiteDB.BsonDocument document, out double x, out double y)
+    {
+        if (document.TryGetValue("x", out var xValue) && document.TryGetValue("y", out var yValue)
+            && xValue.IsNumber && yValue.IsNumber)
+        {
+            x = xValue.AsDouble;
+            y = yValue.AsDouble;
+            return true;
+        }
+
+        x = 0d;
+        y = 0d;
+        return false;
+    }
+
+    private static bool TryReadFromArray(BaseLiteDB.BsonValue value, out double x, out double y)
+    {
+        if (!value.IsArray)
+        {
+            x = 0d;
+            y = 0d;
+            return false;
+        }
+
+        var array = value.AsArray;
+        if (array.Count < 2 || !array[0].IsNumber || !array[1].IsNumber)
+        {
+            x = 0d;
+            y = 0d;
+            return false;
+        }
+
+        x = array[0].AsDouble;
+        y = array[1].AsDouble;
+        return true;
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DEngine.cs
@@ -1,0 +1,94 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Spatial engine for three-dimensional Cartesian coordinates.
+/// </summary>
+public sealed class Cartesian3DEngine : ISpatialEngine
+{
+    /// <summary>
+    /// Gets the canonical engine name.
+    /// </summary>
+    public const string EngineName = "Cartesian3D";
+
+    private readonly Cartesian3DMapper _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian3DEngine"/> class.
+    /// </summary>
+    public Cartesian3DEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(3, Options.PrecisionBits);
+        _mapper = new Cartesian3DMapper(geometryFieldName, IndexEncoder);
+        Mapper = _mapper;
+        Distance = new EuclideanDistance();
+    }
+
+    /// <inheritdoc />
+    public string Name => EngineName;
+
+    /// <inheritdoc />
+    public int Dimensions => 3;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance { get; }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        throw new NotSupportedException("Cartesian3D engine requires three-dimensional coordinates.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+        var minX = center.X - effectiveRadius;
+        var maxX = center.X + effectiveRadius;
+        var minY = center.Y - effectiveRadius;
+        var maxY = center.Y + effectiveRadius;
+        var minZ = center.Z - effectiveRadius;
+        var maxZ = center.Z + effectiveRadius;
+
+        var covering = BoundingBox.From3D(minX, minY, minZ, maxX, maxY, maxZ);
+        var ranges = IndexEncoder.Cover(covering, Options.MaxCoveringCells);
+        var description = $"distance <= {radius:F6}";
+
+        return new SpatialQueryPlan(Dimensions, covering, ranges, description);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (!bounds.Is3D)
+        {
+            throw new ArgumentException("Cartesian3D engine expects a three-dimensional bounding box.", nameof(bounds));
+        }
+
+        var ranges = IndexEncoder.Cover(bounds, Options.MaxCoveringCells);
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, "within bounding box");
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DMapper.cs
@@ -1,0 +1,143 @@
+#nullable enable
+
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps three-dimensional Cartesian points for indexing.
+/// </summary>
+public sealed class Cartesian3DMapper : ISpatialMapper
+{
+    private readonly string _geometryFieldName;
+    private readonly ISpatialIndexEncoder _encoder;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian3DMapper"/> class.
+    /// </summary>
+    public Cartesian3DMapper(string geometryFieldName, ISpatialIndexEncoder encoder)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        _geometryFieldName = geometryFieldName;
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper requires three-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper requires three-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint3D point)
+    {
+        Span<double> coordinates = stackalloc double[3];
+        coordinates[0] = point.X;
+        coordinates[1] = point.Y;
+        coordinates[2] = point.Z;
+        return _encoder.Encode(coordinates);
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+
+        if (!document.TryGetValue(_geometryFieldName, out var value) || value.IsNull)
+        {
+            return false;
+        }
+
+        if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+            if (TryReadCoordinateTriple(doc, out var x, out var y, out var z))
+            {
+                point = new GeoPoint3D(x, y, z);
+                return true;
+            }
+
+            if (doc.TryGetValue("coordinates", out var arrayValue) && TryReadFromArray(arrayValue, out x, out y, out z))
+            {
+                point = new GeoPoint3D(x, y, z);
+                return true;
+            }
+        }
+        else if (TryReadFromArray(value, out var xValue, out var yValue, out var zValue))
+        {
+            point = new GeoPoint3D(xValue, yValue, zValue);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadCoordinateTriple(BaseLiteDB.BsonDocument document, out double x, out double y, out double z)
+    {
+        if (document.TryGetValue("x", out var xValue) && document.TryGetValue("y", out var yValue)
+            && document.TryGetValue("z", out var zValue)
+            && xValue.IsNumber && yValue.IsNumber && zValue.IsNumber)
+        {
+            x = xValue.AsDouble;
+            y = yValue.AsDouble;
+            z = zValue.AsDouble;
+            return true;
+        }
+
+        x = 0d;
+        y = 0d;
+        z = 0d;
+        return false;
+    }
+
+    private static bool TryReadFromArray(BaseLiteDB.BsonValue value, out double x, out double y, out double z)
+    {
+        if (!value.IsArray)
+        {
+            x = 0d;
+            y = 0d;
+            z = 0d;
+            return false;
+        }
+
+        var array = value.AsArray;
+        if (array.Count < 3 || !array[0].IsNumber || !array[1].IsNumber || !array[2].IsNumber)
+        {
+            x = 0d;
+            y = 0d;
+            z = 0d;
+            return false;
+        }
+
+        x = array[0].AsDouble;
+        y = array[1].AsDouble;
+        z = array[2].AsDouble;
+        return true;
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/EuclideanDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/EuclideanDistance.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes Euclidean distances for Cartesian coordinates.
+/// </summary>
+public sealed class EuclideanDistance : ISpatialDistance
+{
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var dx = left.Longitude - right.Longitude;
+        var dy = left.Latitude - right.Latitude;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        var dz = left.Z - right.Z;
+        return Math.Sqrt(dx * dx + dy * dy + dz * dz);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/SpatialCartesian2D.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/SpatialCartesian2D.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Convenience helpers for working with the two-dimensional Cartesian engine.
+/// </summary>
+public static class SpatialCartesian2D
+{
+    /// <summary>
+    /// Creates a Cartesian 2D engine configured for the provided geometry field.
+    /// </summary>
+    public static Cartesian2DEngine CreateEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        return new Cartesian2DEngine(geometryFieldName, options);
+    }
+
+    /// <summary>
+    /// Creates a descriptor that associates the 2D Cartesian engine with a collection.
+    /// </summary>
+    public static SpatialCollectionDescriptor CreateDescriptor(
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        var engine = new Cartesian2DEngine(geometryFieldName, options);
+        return new SpatialCollectionDescriptor(collectionName, Cartesian2DEngine.EngineName, engine.Dimensions, geometryFieldName, engine.Options, engine);
+    }
+
+    /// <summary>
+    /// Creates a near query plan using the provided engine.
+    /// </summary>
+    public static ISpatialQueryPlan Near(Cartesian2DEngine engine, GeoPoint center, double radius)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Creates a bounding box query plan using the provided engine.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(Cartesian2DEngine engine, BoundingBox bounds)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanWithin(bounds);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Cartesian/SpatialCartesian3D.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/SpatialCartesian3D.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Convenience helpers for working with the three-dimensional Cartesian engine.
+/// </summary>
+public static class SpatialCartesian3D
+{
+    /// <summary>
+    /// Creates a 3D Cartesian engine configured for the provided geometry field.
+    /// </summary>
+    public static Cartesian3DEngine CreateEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        return new Cartesian3DEngine(geometryFieldName, options);
+    }
+
+    /// <summary>
+    /// Creates a descriptor that associates the 3D Cartesian engine with a collection.
+    /// </summary>
+    public static SpatialCollectionDescriptor CreateDescriptor(
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        var engine = new Cartesian3DEngine(geometryFieldName, options);
+        return new SpatialCollectionDescriptor(collectionName, Cartesian3DEngine.EngineName, engine.Dimensions, geometryFieldName, engine.Options, engine);
+    }
+
+    /// <summary>
+    /// Creates a near query plan using the provided engine.
+    /// </summary>
+    public static ISpatialQueryPlan Near(Cartesian3DEngine engine, GeoPoint3D center, double radius)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Creates a bounding box query plan using the provided engine.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(Cartesian3DEngine engine, BoundingBox bounds)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanWithin(bounds);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicBoundsBuilder.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicBoundsBuilder.cs
@@ -1,0 +1,172 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+internal static class GeographicBoundsBuilder
+{
+    private const double LongitudinalFullSpan = 360d - 1e-9;
+
+    internal static IReadOnlyList<BoundingBox> CircleToBoundingBoxes(GeoPoint center, double radiusMeters)
+    {
+        if (radiusMeters < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radiusMeters));
+        }
+
+        if (radiusMeters == 0d)
+        {
+            var longitude = GeographicMath.NormalizeLongitude(center.Longitude);
+            var latitude = GeographicMath.ClampLatitude(center.Latitude);
+            return new[] { BoundingBox.From2D(longitude, latitude, longitude, latitude) };
+        }
+
+        var angularDistance = radiusMeters / GeographicMath.EarthRadiusMeters;
+        var centerLatRadians = GeographicMath.ToRadians(center.Latitude);
+        var minLatRadians = centerLatRadians - angularDistance;
+        var maxLatRadians = centerLatRadians + angularDistance;
+
+        var minLat = GeographicMath.ClampLatitude(GeographicMath.ToDegrees(minLatRadians));
+        var maxLat = GeographicMath.ClampLatitude(GeographicMath.ToDegrees(maxLatRadians));
+
+        if (minLat <= -90d || maxLat >= 90d)
+        {
+            return new[] { BoundingBox.From2D(-180d, minLat, 180d, maxLat) };
+        }
+
+        var cosLat = Math.Cos(centerLatRadians);
+        if (Math.Abs(cosLat) < 1e-12)
+        {
+            return new[] { BoundingBox.From2D(-180d, minLat, 180d, maxLat) };
+        }
+
+        var sinAngular = Math.Sin(angularDistance);
+        var ratio = Math.Min(1d, Math.Max(-1d, sinAngular / cosLat));
+        var deltaLon = GeographicMath.ToDegrees(Math.Asin(ratio));
+
+        var minLon = center.Longitude - deltaLon;
+        var maxLon = center.Longitude + deltaLon;
+
+        return BuildLongitudeSegments(minLon, maxLon, minLat, maxLat);
+    }
+
+    internal static IReadOnlyList<BoundingBox> SplitBoundingBox(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Expected a 2D bounding box for geographic queries.", nameof(bounds));
+        }
+
+        var minLat = GeographicMath.ClampLatitude(bounds.MinY);
+        var maxLat = GeographicMath.ClampLatitude(bounds.MaxY);
+
+        return BuildLongitudeSegments(bounds.MinX, bounds.MaxX, minLat, maxLat);
+    }
+
+    internal static BoundingBox CombineForCovering(IReadOnlyList<BoundingBox> boxes)
+    {
+        if (boxes.Count == 0)
+        {
+            throw new ArgumentException("At least one bounding box is required to compute a covering region.", nameof(boxes));
+        }
+
+        var minLat = boxes.Min(b => b.MinY);
+        var maxLat = boxes.Max(b => b.MaxY);
+        var minLon = boxes.Min(b => b.MinX);
+        var maxLon = boxes.Max(b => b.MaxX);
+
+        return BoundingBox.From2D(minLon, minLat, maxLon, maxLat);
+    }
+
+    internal static IReadOnlyList<SpatialIndexRange> CoverWithEncoder(
+        IReadOnlyList<BoundingBox> boxes,
+        ISpatialIndexEncoder encoder,
+        int maxCells)
+    {
+        var ranges = new List<SpatialIndexRange>();
+        foreach (var box in boxes)
+        {
+            var normalized = NormalizeToUnit(box);
+            ranges.AddRange(encoder.Cover(normalized, maxCells));
+        }
+
+        if (ranges.Count == 0)
+        {
+            return Array.Empty<SpatialIndexRange>();
+        }
+
+        return MortonIndexEncoder.UnionAdjacentRanges(ranges);
+    }
+
+    private static IReadOnlyList<BoundingBox> BuildLongitudeSegments(double minLon, double maxLon, double minLat, double maxLat)
+    {
+        var span = maxLon - minLon;
+        if (span >= LongitudinalFullSpan)
+        {
+            var normalizedMinLat = Math.Min(minLat, maxLat);
+            var normalizedMaxLat = Math.Max(minLat, maxLat);
+            return new[] { BoundingBox.From2D(-180d, normalizedMinLat, 180d, normalizedMaxLat) };
+        }
+
+        var normalizedMin = GeographicMath.NormalizeLongitude(minLon);
+        var normalizedMax = normalizedMin + span;
+
+        if (normalizedMax <= 180d)
+        {
+            return new[] { BoundingBox.From2D(normalizedMin, Math.Min(minLat, maxLat), Math.Min(180d, normalizedMax), Math.Max(minLat, maxLat)) };
+        }
+
+        var first = BoundingBox.From2D(normalizedMin, Math.Min(minLat, maxLat), 180d, Math.Max(minLat, maxLat));
+        var secondEnd = normalizedMax - 360d;
+        var second = BoundingBox.From2D(-180d, Math.Min(minLat, maxLat), secondEnd, Math.Max(minLat, maxLat));
+
+        if (second.MaxX <= second.MinX)
+        {
+            return new[] { BoundingBox.From2D(-180d, Math.Min(minLat, maxLat), 180d, Math.Max(minLat, maxLat)) };
+        }
+
+        return new[] { first, second };
+    }
+
+    private static BoundingBox NormalizeToUnit(BoundingBox degreesBox)
+    {
+        var minLon = GeographicMath.NormalizeLongitude(degreesBox.MinX);
+        var maxLon = GeographicMath.NormalizeLongitude(degreesBox.MaxX);
+
+        if (maxLon < minLon)
+        {
+            maxLon += 360d;
+        }
+
+        var span = maxLon - minLon;
+        if (span >= LongitudinalFullSpan)
+        {
+            minLon = -180d;
+            maxLon = 180d;
+        }
+
+        var minLat = GeographicMath.ClampLatitude(degreesBox.MinY);
+        var maxLat = GeographicMath.ClampLatitude(degreesBox.MaxY);
+
+        var minX = GeographicMath.LongitudeToUnit(minLon);
+        var maxX = GeographicMath.LongitudeToUnit(maxLon);
+
+        if (span >= LongitudinalFullSpan)
+        {
+            minX = 0d;
+            maxX = 1d;
+        }
+        else if (maxX < minX)
+        {
+            maxX += 1d;
+        }
+
+        var minY = GeographicMath.LatitudeToUnit(minLat);
+        var maxY = GeographicMath.LatitudeToUnit(maxLat);
+
+        return BoundingBox.From2D(minX, minY, maxX, maxY);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistance.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes great-circle distances between geographic points using the Haversine formula.
+/// </summary>
+public sealed class GeographicDistance : ISpatialDistance
+{
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        return GeographicMath.HaversineDistance(left, right);
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        throw new NotSupportedException("Geographic distance is defined only for two-dimensional points.");
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicEngine.cs
@@ -1,0 +1,95 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Implements a WGS84-based spatial engine capable of producing index-aware query plans for geographic coordinates.
+/// </summary>
+public sealed class GeographicEngine : ISpatialEngine
+{
+    /// <summary>
+    /// Gets the canonical name of the geographic engine.
+    /// </summary>
+    public const string EngineName = "Geographic2D";
+
+    private readonly GeographicMapper _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicEngine"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">The document field that stores the geometry value.</param>
+    /// <param name="options">Optional spatial index options; defaults are used when <c>null</c>.</param>
+    public GeographicEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        _mapper = new GeographicMapper(geometryFieldName, IndexEncoder);
+        Mapper = _mapper;
+        Distance = new GeographicDistance();
+    }
+
+    /// <inheritdoc />
+    public string Name => EngineName;
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance { get; }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+        var boxes = GeographicBoundsBuilder.CircleToBoundingBoxes(center, effectiveRadius);
+        var covering = GeographicBoundsBuilder.CombineForCovering(boxes);
+        var ranges = GeographicBoundsBuilder.CoverWithEncoder(boxes, IndexEncoder, Options.MaxCoveringCells);
+        var description = $"distance <= {radius:F3} m";
+
+        return new SpatialQueryPlan(Dimensions, covering, ranges, description);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Geographic engine operates on two-dimensional coordinates.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic engine expects a two-dimensional bounding box.", nameof(bounds));
+        }
+
+        var boxes = GeographicBoundsBuilder.SplitBoundingBox(bounds);
+        var covering = GeographicBoundsBuilder.CombineForCovering(boxes);
+        var ranges = GeographicBoundsBuilder.CoverWithEncoder(boxes, IndexEncoder, Options.MaxCoveringCells);
+        var description = "within bounding box";
+
+        return new SpatialQueryPlan(Dimensions, covering, ranges, description);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicMapper.cs
@@ -1,0 +1,166 @@
+#nullable enable
+
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps geographic values into index and bounding box representations.
+/// </summary>
+public sealed class GeographicMapper : ISpatialMapper
+{
+    private static readonly string[] LongitudeKeys = { "longitude", "lon", "lng", "x" };
+    private static readonly string[] LatitudeKeys = { "latitude", "lat", "y" };
+
+    private readonly string _geometryFieldName;
+    private readonly ISpatialIndexEncoder _encoder;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicMapper"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">Name of the document field that stores the geometry.</param>
+    /// <param name="encoder">Encoder used to generate Morton codes.</param>
+    public GeographicMapper(string geometryFieldName, ISpatialIndexEncoder encoder)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        _geometryFieldName = geometryFieldName;
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        var longitude = GeographicMath.NormalizeLongitude(point.Longitude);
+        var latitude = GeographicMath.ClampLatitude(point.Latitude);
+        return BoundingBox.From2D(longitude, latitude, longitude, latitude);
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper supports only two-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = GeographicMath.LongitudeToUnit(point.Longitude);
+        coordinates[1] = GeographicMath.LatitudeToUnit(point.Latitude);
+        return _encoder.Encode(coordinates);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper supports only two-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            return false;
+        }
+
+        if (TryReadFromDocument(geometry, out point))
+        {
+            return true;
+        }
+
+        if (TryReadFromArray(geometry, out point))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadFromDocument(BaseLiteDB.BsonValue value, out GeoPoint point)
+    {
+        point = default;
+
+        if (!value.IsDocument)
+        {
+            return false;
+        }
+
+        var doc = value.AsDocument;
+
+        if (doc.TryGetValue("type", out var typeValue) && typeValue.IsString && string.Equals(typeValue.AsString, "Point", StringComparison.OrdinalIgnoreCase))
+        {
+            if (doc.TryGetValue("coordinates", out var coordinates) && TryReadFromArray(coordinates, out point))
+            {
+                return true;
+            }
+        }
+
+        if (TryReadCoordinatePair(doc, out var longitude, out var latitude))
+        {
+            point = new GeoPoint(longitude, latitude);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadFromArray(BaseLiteDB.BsonValue value, out GeoPoint point)
+    {
+        point = default;
+
+        if (!value.IsArray)
+        {
+            return false;
+        }
+
+        var array = value.AsArray;
+        if (array.Count < 2 || !array[0].IsNumber || !array[1].IsNumber)
+        {
+            return false;
+        }
+
+        point = new GeoPoint(array[0].AsDouble, array[1].AsDouble);
+        return true;
+    }
+
+    private static bool TryReadCoordinatePair(BaseLiteDB.BsonDocument doc, out double longitude, out double latitude)
+    {
+        foreach (var key in LongitudeKeys)
+        {
+            if (doc.TryGetValue(key, out var lonValue) && lonValue.IsNumber)
+            {
+                longitude = lonValue.AsDouble;
+
+                foreach (var latKey in LatitudeKeys)
+                {
+                    if (doc.TryGetValue(latKey, out var latValue) && latValue.IsNumber)
+                    {
+                        latitude = latValue.AsDouble;
+                        return true;
+                    }
+                }
+            }
+        }
+
+        longitude = 0d;
+        latitude = 0d;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicMath.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicMath.cs
@@ -1,0 +1,93 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+internal static class GeographicMath
+{
+    internal const double EarthRadiusMeters = 6_371_000d;
+    private const double DegToRad = Math.PI / 180d;
+    private const double RadToDeg = 180d / Math.PI;
+
+    internal static double ClampLatitude(double latitude)
+    {
+        if (double.IsNaN(latitude))
+        {
+            return latitude;
+        }
+
+        if (latitude > 90d)
+        {
+            return 90d;
+        }
+
+        if (latitude < -90d)
+        {
+            return -90d;
+        }
+
+        return latitude;
+    }
+
+    internal static double NormalizeLongitude(double longitude)
+    {
+        if (double.IsNaN(longitude))
+        {
+            return longitude;
+        }
+
+        var normalized = longitude % 360d;
+
+        if (normalized <= -180d)
+        {
+            normalized += 360d;
+        }
+        else if (normalized > 180d)
+        {
+            normalized -= 360d;
+        }
+
+        return normalized;
+    }
+
+    internal static double ToRadians(double degrees) => degrees * DegToRad;
+
+    internal static double ToDegrees(double radians) => radians * RadToDeg;
+
+    internal static double LongitudeToUnit(double longitude)
+    {
+        var normalized = NormalizeLongitude(longitude);
+        return (normalized + 180d) / 360d;
+    }
+
+    internal static double LatitudeToUnit(double latitude)
+    {
+        var clamped = ClampLatitude(latitude);
+        return (clamped + 90d) / 180d;
+    }
+
+    internal static double HaversineDistance(GeoPoint left, GeoPoint right)
+    {
+        return HaversineDistance(left.Longitude, left.Latitude, right.Longitude, right.Latitude);
+    }
+
+    internal static double HaversineDistance(double lon1, double lat1, double lon2, double lat2)
+    {
+        var lat1Rad = ToRadians(lat1);
+        var lat2Rad = ToRadians(lat2);
+        var dLat = lat2Rad - lat1Rad;
+        var dLon = ToRadians(NormalizeLongitude(lon2 - lon1));
+
+        var sinLat = Math.Sin(dLat / 2d);
+        var sinLon = Math.Sin(dLon / 2d);
+        var cosLat1 = Math.Cos(lat1Rad);
+        var cosLat2 = Math.Cos(lat2Rad);
+
+        var hav = sinLat * sinLat + cosLat1 * cosLat2 * sinLon * sinLon;
+        hav = Math.Min(1d, Math.Max(0d, hav));
+
+        var c = 2d * Math.Atan2(Math.Sqrt(hav), Math.Sqrt(Math.Max(0d, 1d - hav)));
+        return EarthRadiusMeters * c;
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/SpatialGeographic.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/SpatialGeographic.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Convenience helpers for working with the geographic engine.
+/// </summary>
+public static class SpatialGeographic
+{
+    /// <summary>
+    /// Creates a geographic engine configured for the provided geometry field.
+    /// </summary>
+    /// <param name="geometryFieldName">The document field containing point geometries.</param>
+    /// <param name="options">Optional spatial index options.</param>
+    /// <returns>An initialized <see cref="GeographicEngine"/>.</returns>
+    public static GeographicEngine CreateEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        return new GeographicEngine(geometryFieldName, options);
+    }
+
+    /// <summary>
+    /// Creates a descriptor that associates the geographic engine with the specified collection.
+    /// </summary>
+    public static SpatialCollectionDescriptor CreateDescriptor(
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        var engine = new GeographicEngine(geometryFieldName, options);
+        return new SpatialCollectionDescriptor(collectionName, GeographicEngine.EngineName, engine.Dimensions, geometryFieldName, engine.Options, engine);
+    }
+
+    /// <summary>
+    /// Creates a near query plan using the geographic engine.
+    /// </summary>
+    public static ISpatialQueryPlan Near(GeographicEngine engine, GeoPoint center, double radius)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Creates a bounding box query plan using the geographic engine.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(GeographicEngine engine, BoundingBox bounds)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanWithin(bounds);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/Geographic/SpatialGeographicDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/SpatialGeographicDistance.cs
@@ -1,0 +1,22 @@
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides standalone helpers for computing geographic distances.
+/// </summary>
+public static class SpatialGeographicDistance
+{
+    /// <summary>
+    /// Computes the great-circle distance in meters between two coordinates.
+    /// </summary>
+    /// <param name="longitude1">Longitude of the first point in decimal degrees.</param>
+    /// <param name="latitude1">Latitude of the first point in decimal degrees.</param>
+    /// <param name="longitude2">Longitude of the second point in decimal degrees.</param>
+    /// <param name="latitude2">Latitude of the second point in decimal degrees.</param>
+    /// <returns>The distance in meters along the surface of the Earth.</returns>
+    public static double Haversine(double longitude1, double latitude1, double longitude2, double latitude2)
+    {
+        return GeographicMath.HaversineDistance(longitude1, latitude1, longitude2, latitude2);
+    }
+}

--- a/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
@@ -1,0 +1,57 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Default implementation of <see cref="ISpatialQueryPlan"/> describing the
+/// ranges, bounding information, and predicates required to service a spatial query.
+/// </summary>
+public sealed class SpatialQueryPlan : ISpatialQueryPlan
+{
+    private readonly IReadOnlyList<SpatialIndexRange> _indexRanges;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialQueryPlan"/> class.
+    /// </summary>
+    /// <param name="dimensions">Dimensionality of the underlying spatial index.</param>
+    /// <param name="coveringBounds">Optional bounding region evaluated prior to exact predicates.</param>
+    /// <param name="indexRanges">The ordered set of index ranges to scan.</param>
+    /// <param name="exactPredicateDescription">Human-readable description of the exact predicate applied after index filtering.</param>
+    public SpatialQueryPlan(
+        int dimensions,
+        BoundingBox? coveringBounds,
+        IReadOnlyList<SpatialIndexRange> indexRanges,
+        string? exactPredicateDescription)
+    {
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial query plans must describe either two or three dimensions.");
+        }
+
+        if (indexRanges == null)
+        {
+            throw new ArgumentNullException(nameof(indexRanges));
+        }
+
+        Dimensions = dimensions;
+        CoveringBounds = coveringBounds;
+        _indexRanges = indexRanges.Count == 0 ? Array.Empty<SpatialIndexRange>() : indexRanges.ToArray();
+        ExactPredicateDescription = exactPredicateDescription;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> IndexRanges => _indexRanges;
+
+    /// <inheritdoc />
+    public string? ExactPredicateDescription { get; }
+}

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -96,16 +96,16 @@ LiteDB.Spatial
 
 ### S5 — Geographic engine (2D)
 
-- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
-- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+- [x] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [x] Handle wraparound and polar helpers with tests for real-world coordinates.
 
 ### S6 — Cartesian 2D engine
 
-- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+- [x] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
 
 ### S7 — Cartesian 3D engine (points)
 
-- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+- [x] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
 
 ### S8 — LINQ resolver
 


### PR DESCRIPTION
## Summary
- introduce a reusable `SpatialQueryPlan` along with a geographic engine, mapper, helpers, and facade support
- add Euclidean-based Cartesian 2D and 3D engines with dedicated mappers and public helpers
- cover new planners with unit tests and mark the corresponding roadmap items complete

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e75fa2f94c8326ad2b426f3de99ecd