### PR TITLE
Add geographic and Cartesian spatial engines

### DIFF
--- a/LiteDB.Spatial.Cartesian2D/Cartesian2DDistance.cs
+++ b/LiteDB.Spatial.Cartesian2D/Cartesian2DDistance.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian2DDistance : ISpatialDistance
+{
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var dx = left.Longitude - right.Longitude;
+        var dy = left.Latitude - right.Latitude;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        throw new NotSupportedException("Cartesian2D engine does not support 3D distances.");
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/Cartesian2DEngine.cs
+++ b/LiteDB.Spatial.Cartesian2D/Cartesian2DEngine.cs
@@ -1,0 +1,144 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+public sealed class Cartesian2DEngine : ISpatialEngine
+{
+    public const string EngineName = "Cartesian2D";
+
+    private readonly BoundingBox _coordinateSpace;
+    private readonly double _minX;
+    private readonly double _maxX;
+    private readonly double _minY;
+    private readonly double _maxY;
+    private readonly double _rangeX;
+    private readonly double _rangeY;
+
+    public Cartesian2DEngine(
+        SpatialIndexOptions? options = null,
+        BoundingBox? coordinateSpace = null,
+        string geometryFieldName = SpatialCollectionDescriptor.DefaultGeometryFieldName)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        _coordinateSpace = coordinateSpace ?? BoundingBox.From2D(0d, 0d, 1d, 1d);
+
+        if (_coordinateSpace.Dimensions != 2)
+        {
+            throw new ArgumentException("Coordinate space must be a 2D bounding box.", nameof(coordinateSpace));
+        }
+
+        _minX = _coordinateSpace.MinX;
+        _maxX = _coordinateSpace.MaxX;
+        _minY = _coordinateSpace.MinY;
+        _maxY = _coordinateSpace.MaxY;
+
+        _rangeX = _maxX - _minX;
+        _rangeY = _maxY - _minY;
+
+        if (_rangeX <= 0d || _rangeY <= 0d)
+        {
+            throw new ArgumentException("Coordinate space must have positive extents on all axes.", nameof(coordinateSpace));
+        }
+
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        Mapper = new Cartesian2DMapper(IndexEncoder, _coordinateSpace, geometryFieldName);
+        Distance = new Cartesian2DDistance();
+    }
+
+    public string Name => EngineName;
+
+    public int Dimensions => 2;
+
+    public SpatialIndexOptions Options { get; }
+
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    public ISpatialMapper Mapper { get; }
+
+    public ISpatialDistance Distance { get; }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+
+        var minX = Math.Max(_minX, center.Longitude - effectiveRadius);
+        var maxX = Math.Min(_maxX, center.Longitude + effectiveRadius);
+        var minY = Math.Max(_minY, center.Latitude - effectiveRadius);
+        var maxY = Math.Min(_maxY, center.Latitude + effectiveRadius);
+
+        if (minX > maxX || minY > maxY)
+        {
+            return new SpatialQueryPlan(Dimensions, null, Array.Empty<SpatialIndexRange>(), "center outside coordinate space");
+        }
+
+        var covering = BoundingBox.From2D(minX, minY, maxX, maxY);
+        var ranges = Cover(covering);
+        var description = string.Format(CultureInfo.InvariantCulture, "euclidean distance <= {0}", effectiveRadius);
+        return new SpatialQueryPlan(Dimensions, covering, ranges, description);
+    }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Cartesian2D engine cannot plan three-dimensional near queries.");
+    }
+
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Cartesian2D engine expects a 2D bounding box.", nameof(bounds));
+        }
+
+        var minX = Math.Max(bounds.MinX, _minX);
+        var maxX = Math.Min(bounds.MaxX, _maxX);
+        var minY = Math.Max(bounds.MinY, _minY);
+        var maxY = Math.Min(bounds.MaxY, _maxY);
+
+        if (minX > maxX || minY > maxY)
+        {
+            return new SpatialQueryPlan(Dimensions, null, Array.Empty<SpatialIndexRange>(), "bounding box outside coordinate space");
+        }
+
+        var covering = BoundingBox.From2D(minX, minY, maxX, maxY);
+        var ranges = Cover(covering);
+        return new SpatialQueryPlan(Dimensions, covering, ranges, "within cartesian bounding box");
+    }
+
+    private IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds)
+    {
+        var normalized = BoundingBox.From2D(
+            Normalize(bounds.MinX, _minX, _rangeX),
+            Normalize(bounds.MinY, _minY, _rangeY),
+            Normalize(bounds.MaxX, _minX, _rangeX),
+            Normalize(bounds.MaxY, _minY, _rangeY));
+
+        var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        return ranges.Count > 1 ? MortonIndexEncoder.UnionAdjacentRanges(ranges) : ranges;
+    }
+
+    private static double Normalize(double value, double min, double range)
+    {
+        var normalized = (value - min) / range;
+
+        if (normalized < 0d)
+        {
+            return 0d;
+        }
+
+        if (normalized > 1d)
+        {
+            return 1d;
+        }
+
+        return normalized;
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/Cartesian2DMapper.cs
+++ b/LiteDB.Spatial.Cartesian2D/Cartesian2DMapper.cs
@@ -1,0 +1,197 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian2DMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+    private readonly double _minX;
+    private readonly double _maxX;
+    private readonly double _minY;
+    private readonly double _maxY;
+    private readonly double _rangeX;
+    private readonly double _rangeY;
+
+    public Cartesian2DMapper(
+        ISpatialIndexEncoder encoder,
+        BoundingBox coordinateSpace,
+        string geometryFieldName)
+    {
+        if (coordinateSpace.Dimensions != 2)
+        {
+            throw new ArgumentException("Coordinate space must be two-dimensional.", nameof(coordinateSpace));
+        }
+
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryFieldName;
+
+        _minX = coordinateSpace.MinX;
+        _maxX = coordinateSpace.MaxX;
+        _minY = coordinateSpace.MinY;
+        _maxY = coordinateSpace.MaxY;
+
+        _rangeX = _maxX - _minX;
+        _rangeY = _maxY - _minY;
+
+        if (_rangeX <= 0d || _rangeY <= 0d)
+        {
+            throw new ArgumentException("Coordinate space must have positive extents on all axes.", nameof(coordinateSpace));
+        }
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper cannot produce three-dimensional bounding boxes.");
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = Normalize(point.Longitude, _minX, _rangeX);
+        coordinates[1] = Normalize(point.Latitude, _minY, _rangeY);
+        return _encoder.Encode(coordinates);
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper cannot encode three-dimensional coordinates.");
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var value))
+        {
+            point = default;
+            return false;
+        }
+
+        if (TryExtract(value, out point))
+        {
+            return true;
+        }
+
+        point = default;
+        return false;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryExtract(BaseLiteDB.BsonValue value, out GeoPoint point)
+    {
+        if (value.IsArray)
+        {
+            var array = value.AsArray;
+            if (array.Count >= 2 && TryReadDouble(array[0], out var x) && TryReadDouble(array[1], out var y))
+            {
+                point = new GeoPoint(x, y);
+                return true;
+            }
+        }
+        else if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+
+            if (doc.TryGetValue("coordinates", out var coordinates) && coordinates.IsArray)
+            {
+                var array = coordinates.AsArray;
+                if (array.Count >= 2 && TryReadDouble(array[0], out var x) && TryReadDouble(array[1], out var y))
+                {
+                    point = new GeoPoint(x, y);
+                    return true;
+                }
+            }
+
+            if (TryReadDouble(doc, new[] { "x", "longitude", "lon", "lng" }, out var xValue)
+                && TryReadDouble(doc, new[] { "y", "latitude", "lat" }, out var yValue))
+            {
+                point = new GeoPoint(xValue, yValue);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonDocument document, IReadOnlyList<string> keys, out double value)
+    {
+        foreach (var key in keys)
+        {
+            if (document.TryGetValue(key, out var candidate) && TryReadDouble(candidate, out value))
+            {
+                return true;
+            }
+        }
+
+        value = 0d;
+        return false;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonValue value, out double result)
+    {
+        if (value.IsInt32)
+        {
+            result = value.AsInt32;
+            return true;
+        }
+
+        if (value.IsInt64)
+        {
+            result = value.AsInt64;
+            return true;
+        }
+
+        if (value.IsDecimal)
+        {
+            result = (double)value.AsDecimal;
+            return true;
+        }
+
+        if (value.IsDouble)
+        {
+            result = value.AsDouble;
+            return true;
+        }
+
+        result = 0d;
+        return false;
+    }
+
+    private static double Normalize(double value, double minimum, double range)
+    {
+        var normalized = (value - minimum) / range;
+
+        if (normalized < 0d)
+        {
+            return 0d;
+        }
+
+        if (normalized > 1d)
+        {
+            return 1d;
+        }
+
+        return normalized;
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/LiteDB.Spatial.Cartesian2D.csproj
+++ b/LiteDB.Spatial.Cartesian2D/LiteDB.Spatial.Cartesian2D.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Cartesian2D</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Cartesian2D.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Cartesian2D/SpatialCartesian2D.cs
+++ b/LiteDB.Spatial.Cartesian2D/SpatialCartesian2D.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+public static class SpatialCartesian2D
+{
+    public static Cartesian2DEngine CreateEngine(
+        SpatialIndexOptions? options = null,
+        BoundingBox? coordinateSpace = null,
+        string geometryFieldName = SpatialCollectionDescriptor.DefaultGeometryFieldName)
+    {
+        return new Cartesian2DEngine(options, coordinateSpace, geometryFieldName);
+    }
+
+    public static SpatialCollectionDescriptor CreateDescriptor(
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null,
+        BoundingBox? coordinateSpace = null)
+    {
+        var engine = CreateEngine(options, coordinateSpace, geometryFieldName);
+        return new SpatialCollectionDescriptor(collectionName, Cartesian2DEngine.EngineName, engine.Dimensions, geometryFieldName, engine.Options, engine);
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Cartesian3DDistance.cs
+++ b/LiteDB.Spatial.Cartesian3D/Cartesian3DDistance.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian3DDistance : ISpatialDistance
+{
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        throw new NotSupportedException("Cartesian3D engine does not support 2D distances.");
+    }
+
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        var dz = left.Z - right.Z;
+        return Math.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Cartesian3DEngine.cs
+++ b/LiteDB.Spatial.Cartesian3D/Cartesian3DEngine.cs
@@ -1,0 +1,156 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+public sealed class Cartesian3DEngine : ISpatialEngine
+{
+    public const string EngineName = "Cartesian3D";
+
+    private readonly BoundingBox _coordinateSpace;
+    private readonly double _minX;
+    private readonly double _maxX;
+    private readonly double _minY;
+    private readonly double _maxY;
+    private readonly double _minZ;
+    private readonly double _maxZ;
+    private readonly double _rangeX;
+    private readonly double _rangeY;
+    private readonly double _rangeZ;
+
+    public Cartesian3DEngine(
+        SpatialIndexOptions? options = null,
+        BoundingBox? coordinateSpace = null,
+        string geometryFieldName = SpatialCollectionDescriptor.DefaultGeometryFieldName)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        _coordinateSpace = coordinateSpace ?? BoundingBox.From3D(0d, 0d, 0d, 1d, 1d, 1d);
+
+        if (_coordinateSpace.Dimensions != 3)
+        {
+            throw new ArgumentException("Coordinate space must be a 3D bounding box.", nameof(coordinateSpace));
+        }
+
+        _minX = _coordinateSpace.MinX;
+        _maxX = _coordinateSpace.MaxX;
+        _minY = _coordinateSpace.MinY;
+        _maxY = _coordinateSpace.MaxY;
+        _minZ = _coordinateSpace.MinZ;
+        _maxZ = _coordinateSpace.MaxZ;
+
+        _rangeX = _maxX - _minX;
+        _rangeY = _maxY - _minY;
+        _rangeZ = _maxZ - _minZ;
+
+        if (_rangeX <= 0d || _rangeY <= 0d || _rangeZ <= 0d)
+        {
+            throw new ArgumentException("Coordinate space must have positive extents on all axes.", nameof(coordinateSpace));
+        }
+
+        IndexEncoder = new MortonIndexEncoder(3, Options.PrecisionBits);
+        Mapper = new Cartesian3DMapper(IndexEncoder, _coordinateSpace, geometryFieldName);
+        Distance = new Cartesian3DDistance();
+    }
+
+    public string Name => EngineName;
+
+    public int Dimensions => 3;
+
+    public SpatialIndexOptions Options { get; }
+
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    public ISpatialMapper Mapper { get; }
+
+    public ISpatialDistance Distance { get; }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        throw new NotSupportedException("Cartesian3D engine cannot plan two-dimensional near queries.");
+    }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+
+        var minX = Math.Max(_minX, center.X - effectiveRadius);
+        var maxX = Math.Min(_maxX, center.X + effectiveRadius);
+        var minY = Math.Max(_minY, center.Y - effectiveRadius);
+        var maxY = Math.Min(_maxY, center.Y + effectiveRadius);
+        var minZ = Math.Max(_minZ, center.Z - effectiveRadius);
+        var maxZ = Math.Min(_maxZ, center.Z + effectiveRadius);
+
+        if (minX > maxX || minY > maxY || minZ > maxZ)
+        {
+            return new SpatialQueryPlan(Dimensions, null, Array.Empty<SpatialIndexRange>(), "center outside coordinate space");
+        }
+
+        var covering = BoundingBox.From3D(minX, minY, minZ, maxX, maxY, maxZ);
+        var ranges = Cover(covering);
+        var description = string.Format(CultureInfo.InvariantCulture, "euclidean3d distance <= {0}", effectiveRadius);
+        return new SpatialQueryPlan(Dimensions, covering, ranges, description);
+    }
+
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 3)
+        {
+            throw new ArgumentException("Cartesian3D engine expects a 3D bounding box.", nameof(bounds));
+        }
+
+        var minX = Math.Max(bounds.MinX, _minX);
+        var maxX = Math.Min(bounds.MaxX, _maxX);
+        var minY = Math.Max(bounds.MinY, _minY);
+        var maxY = Math.Min(bounds.MaxY, _maxY);
+        var minZ = Math.Max(bounds.MinZ, _minZ);
+        var maxZ = Math.Min(bounds.MaxZ, _maxZ);
+
+        if (minX > maxX || minY > maxY || minZ > maxZ)
+        {
+            return new SpatialQueryPlan(Dimensions, null, Array.Empty<SpatialIndexRange>(), "bounding box outside coordinate space");
+        }
+
+        var covering = BoundingBox.From3D(minX, minY, minZ, maxX, maxY, maxZ);
+        var ranges = Cover(covering);
+        return new SpatialQueryPlan(Dimensions, covering, ranges, "within cartesian 3d bounding box");
+    }
+
+    private IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds)
+    {
+        var normalized = BoundingBox.From3D(
+            Normalize(bounds.MinX, _minX, _rangeX),
+            Normalize(bounds.MinY, _minY, _rangeY),
+            Normalize(bounds.MinZ, _minZ, _rangeZ),
+            Normalize(bounds.MaxX, _minX, _rangeX),
+            Normalize(bounds.MaxY, _minY, _rangeY),
+            Normalize(bounds.MaxZ, _minZ, _rangeZ));
+
+        var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        return ranges.Count > 1 ? MortonIndexEncoder.UnionAdjacentRanges(ranges) : ranges;
+    }
+
+    private static double Normalize(double value, double min, double range)
+    {
+        var normalized = (value - min) / range;
+
+        if (normalized < 0d)
+        {
+            return 0d;
+        }
+
+        if (normalized > 1d)
+        {
+            return 1d;
+        }
+
+        return normalized;
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Cartesian3DMapper.cs
+++ b/LiteDB.Spatial.Cartesian3D/Cartesian3DMapper.cs
@@ -1,0 +1,211 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian3DMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+    private readonly double _minX;
+    private readonly double _maxX;
+    private readonly double _minY;
+    private readonly double _maxY;
+    private readonly double _minZ;
+    private readonly double _maxZ;
+    private readonly double _rangeX;
+    private readonly double _rangeY;
+    private readonly double _rangeZ;
+
+    public Cartesian3DMapper(
+        ISpatialIndexEncoder encoder,
+        BoundingBox coordinateSpace,
+        string geometryFieldName)
+    {
+        if (coordinateSpace.Dimensions != 3)
+        {
+            throw new ArgumentException("Coordinate space must be three-dimensional.", nameof(coordinateSpace));
+        }
+
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryFieldName;
+
+        _minX = coordinateSpace.MinX;
+        _maxX = coordinateSpace.MaxX;
+        _minY = coordinateSpace.MinY;
+        _maxY = coordinateSpace.MaxY;
+        _minZ = coordinateSpace.MinZ;
+        _maxZ = coordinateSpace.MaxZ;
+
+        _rangeX = _maxX - _minX;
+        _rangeY = _maxY - _minY;
+        _rangeZ = _maxZ - _minZ;
+
+        if (_rangeX <= 0d || _rangeY <= 0d || _rangeZ <= 0d)
+        {
+            throw new ArgumentException("Coordinate space must have positive extents on all axes.", nameof(coordinateSpace));
+        }
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper does not support 2D bounding boxes.");
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper does not support 2D encoding.");
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        Span<double> coordinates = stackalloc double[3];
+        coordinates[0] = Normalize(point.X, _minX, _rangeX);
+        coordinates[1] = Normalize(point.Y, _minY, _rangeY);
+        coordinates[2] = Normalize(point.Z, _minZ, _rangeZ);
+        return _encoder.Encode(coordinates);
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+        return false;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var value))
+        {
+            point = default;
+            return false;
+        }
+
+        if (TryExtract(value, out point))
+        {
+            return true;
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryExtract(BaseLiteDB.BsonValue value, out GeoPoint3D point)
+    {
+        if (value.IsArray)
+        {
+            var array = value.AsArray;
+            if (array.Count >= 3
+                && TryReadDouble(array[0], out var x)
+                && TryReadDouble(array[1], out var y)
+                && TryReadDouble(array[2], out var z))
+            {
+                point = new GeoPoint3D(x, y, z);
+                return true;
+            }
+        }
+        else if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+
+            if (doc.TryGetValue("coordinates", out var coordinates) && coordinates.IsArray)
+            {
+                var array = coordinates.AsArray;
+                if (array.Count >= 3
+                    && TryReadDouble(array[0], out var x)
+                    && TryReadDouble(array[1], out var y)
+                    && TryReadDouble(array[2], out var z))
+                {
+                    point = new GeoPoint3D(x, y, z);
+                    return true;
+                }
+            }
+
+            if (TryReadDouble(doc, new[] { "x", "longitude", "lon", "lng" }, out var xValue)
+                && TryReadDouble(doc, new[] { "y", "latitude", "lat" }, out var yValue)
+                && TryReadDouble(doc, new[] { "z", "alt", "elevation" }, out var zValue))
+            {
+                point = new GeoPoint3D(xValue, yValue, zValue);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonDocument document, IReadOnlyList<string> keys, out double value)
+    {
+        foreach (var key in keys)
+        {
+            if (document.TryGetValue(key, out var candidate) && TryReadDouble(candidate, out value))
+            {
+                return true;
+            }
+        }
+
+        value = 0d;
+        return false;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonValue value, out double result)
+    {
+        if (value.IsInt32)
+        {
+            result = value.AsInt32;
+            return true;
+        }
+
+        if (value.IsInt64)
+        {
+            result = value.AsInt64;
+            return true;
+        }
+
+        if (value.IsDecimal)
+        {
+            result = (double)value.AsDecimal;
+            return true;
+        }
+
+        if (value.IsDouble)
+        {
+            result = value.AsDouble;
+            return true;
+        }
+
+        result = 0d;
+        return false;
+    }
+
+    private static double Normalize(double value, double minimum, double range)
+    {
+        var normalized = (value - minimum) / range;
+
+        if (normalized < 0d)
+        {
+            return 0d;
+        }
+
+        if (normalized > 1d)
+        {
+            return 1d;
+        }
+
+        return normalized;
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/LiteDB.Spatial.Cartesian3D.csproj
+++ b/LiteDB.Spatial.Cartesian3D/LiteDB.Spatial.Cartesian3D.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Cartesian3D</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Cartesian3D.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Cartesian3D/SpatialCartesian3D.cs
+++ b/LiteDB.Spatial.Cartesian3D/SpatialCartesian3D.cs
@@ -1,0 +1,24 @@
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+public static class SpatialCartesian3D
+{
+    public static Cartesian3DEngine CreateEngine(
+        SpatialIndexOptions? options = null,
+        BoundingBox? coordinateSpace = null,
+        string geometryFieldName = SpatialCollectionDescriptor.DefaultGeometryFieldName)
+    {
+        return new Cartesian3DEngine(options, coordinateSpace, geometryFieldName);
+    }
+
+    public static SpatialCollectionDescriptor CreateDescriptor(
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null,
+        BoundingBox? coordinateSpace = null)
+    {
+        var engine = CreateEngine(options, coordinateSpace, geometryFieldName);
+        return new SpatialCollectionDescriptor(collectionName, Cartesian3DEngine.EngineName, engine.Dimensions, geometryFieldName, engine.Options, engine);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian2DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian2DEngineTests.cs
@@ -1,0 +1,72 @@
+extern alias LiteDbBase;
+
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class Cartesian2DEngineTests
+{
+    [Fact]
+    public void PlanNearProducesExpectedBounds()
+    {
+        var space = BoundingBox.From2D(0d, 0d, 100d, 100d);
+        var engine = new Cartesian2DEngine(coordinateSpace: space);
+
+        var plan = engine.PlanNear(new GeoPoint(50d, 50d), 10d);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().BeApproximately(40d, 0.001d);
+        bounds.MaxX.Should().BeApproximately(60d, 0.001d);
+        bounds.MinY.Should().BeApproximately(40d, 0.001d);
+        bounds.MaxY.Should().BeApproximately(60d, 0.001d);
+    }
+
+    [Fact]
+    public void PlanWithinOutsideSpaceReturnsEmptyPlan()
+    {
+        var space = BoundingBox.From2D(0d, 0d, 100d, 100d);
+        var engine = new Cartesian2DEngine(coordinateSpace: space);
+
+        var plan = engine.PlanWithin(BoundingBox.From2D(200d, 200d, 210d, 210d));
+
+        plan.CoveringBounds.Should().BeNull();
+        plan.IndexRanges.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DistanceUsesEuclideanMetric()
+    {
+        var engine = new Cartesian2DEngine();
+        var left = new GeoPoint(0d, 0d);
+        var right = new GeoPoint(3d, 4d);
+
+        engine.Distance.Distance(left, right).Should().Be(5d);
+    }
+
+    [Fact]
+    public void MapperReadsDocumentCoordinates()
+    {
+        var engine = new Cartesian2DEngine(coordinateSpace: BoundingBox.From2D(0d, 0d, 10d, 10d), geometryFieldName: "location");
+        var mapper = engine.Mapper;
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["location"] = new BaseLiteDB.BsonDocument
+            {
+                ["x"] = 2.5,
+                ["y"] = 7.5
+            }
+        };
+
+        mapper.TryReadPoint(document, out GeoPoint point).Should().BeTrue();
+        point.Longitude.Should().Be(2.5);
+        point.Latitude.Should().Be(7.5);
+
+        mapper.Invoking(m => m.Encode(point)).Should().NotThrow();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian3DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian3DEngineTests.cs
@@ -1,0 +1,71 @@
+extern alias LiteDbBase;
+
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class Cartesian3DEngineTests
+{
+    [Fact]
+    public void PlanNearProducesExpectedBounds()
+    {
+        var space = BoundingBox.From3D(0d, 0d, 0d, 10d, 10d, 10d);
+        var engine = new Cartesian3DEngine(coordinateSpace: space);
+
+        var plan = engine.PlanNear(new GeoPoint3D(5d, 5d, 5d), 2d);
+
+        plan.Dimensions.Should().Be(3);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().BeApproximately(3d, 0.001d);
+        bounds.MaxX.Should().BeApproximately(7d, 0.001d);
+        bounds.MinY.Should().BeApproximately(3d, 0.001d);
+        bounds.MaxY.Should().BeApproximately(7d, 0.001d);
+        bounds.MinZ.Should().BeApproximately(3d, 0.001d);
+        bounds.MaxZ.Should().BeApproximately(7d, 0.001d);
+    }
+
+    [Fact]
+    public void PlanWithinOutsideSpaceReturnsEmptyPlan()
+    {
+        var space = BoundingBox.From3D(0d, 0d, 0d, 10d, 10d, 10d);
+        var engine = new Cartesian3DEngine(coordinateSpace: space);
+
+        var plan = engine.PlanWithin(BoundingBox.From3D(20d, 20d, 20d, 30d, 30d, 30d));
+
+        plan.CoveringBounds.Should().BeNull();
+        plan.IndexRanges.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DistanceUsesEuclidean3D()
+    {
+        var engine = new Cartesian3DEngine();
+        var left = new GeoPoint3D(0d, 0d, 0d);
+        var right = new GeoPoint3D(1d, 2d, 2d);
+
+        engine.Distance.Distance(left, right).Should().Be(3d);
+    }
+
+    [Fact]
+    public void MapperReadsArrayCoordinates()
+    {
+        var engine = new Cartesian3DEngine();
+        var mapper = engine.Mapper;
+        var document = new BaseLiteDB.BsonDocument
+        {
+            [SpatialCollectionDescriptor.DefaultGeometryFieldName] = new BaseLiteDB.BsonArray { 1d, 2d, 3d }
+        };
+
+        mapper.TryReadPoint(document, out GeoPoint3D point).Should().BeTrue();
+        point.X.Should().Be(1d);
+        point.Y.Should().Be(2d);
+        point.Z.Should().Be(3d);
+
+        mapper.Invoking(m => m.Encode(point)).Should().NotThrow();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/GeographicEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/GeographicEngineTests.cs
@@ -1,0 +1,91 @@
+extern alias LiteDbBase;
+
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class GeographicEngineTests
+{
+    [Fact]
+    public void PlanNearProducesCoveringBounds()
+    {
+        var engine = new GeographicEngine();
+        var center = new GeoPoint(13.4050, 52.5200); // Berlin
+
+        var plan = engine.PlanNear(center, 1_000);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.ExactPredicateDescription.Should().Contain("distance");
+
+        plan.CoveringBounds.Should().NotBeNull();
+        var bounds = plan.CoveringBounds!.Value;
+
+        bounds.MinX.Should().BeLessThan(bounds.MaxX);
+        bounds.MinY.Should().BeLessThan(bounds.MaxY);
+        bounds.MinY.Should().BeLessOrEqualTo(center.Latitude);
+        bounds.MaxY.Should().BeGreaterOrEqualTo(center.Latitude);
+    }
+
+    [Fact]
+    public void PlanWithinSpanningAntiMeridianExpandsCovering()
+    {
+        var engine = new GeographicEngine();
+        var plan = engine.PlanWithin(BoundingBox.From2D(170d, -10d, 190d, 10d));
+
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().BeApproximately(-180d, 1e-3);
+        bounds.MaxX.Should().BeApproximately(180d, 1e-3);
+    }
+
+    [Fact]
+    public void PlanNearAtHighLatitudeCoversAllLongitudes()
+    {
+        var engine = new GeographicEngine();
+        var plan = engine.PlanNear(new GeoPoint(0d, 89.0), 300_000);
+
+        plan.CoveringBounds.Should().NotBeNull();
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().Be(-180d);
+        bounds.MaxX.Should().Be(180d);
+    }
+
+    [Fact]
+    public void DistanceMatchesKnownCities()
+    {
+        var engine = new GeographicEngine();
+        var berlin = new GeoPoint(13.4050, 52.5200);
+        var paris = new GeoPoint(2.3522, 48.8566);
+
+        var distance = engine.Distance.Distance(berlin, paris);
+
+        distance.Should().BeApproximately(878_446d, 1_000d);
+    }
+
+    [Fact]
+    public void MapperReadsGeoJsonPoint()
+    {
+        var engine = new GeographicEngine();
+        var mapper = engine.Mapper;
+        var document = new BaseLiteDB.BsonDocument
+        {
+            [SpatialCollectionDescriptor.DefaultGeometryFieldName] = new BaseLiteDB.BsonDocument
+            {
+                ["type"] = "Point",
+                ["coordinates"] = new BaseLiteDB.BsonArray { 13.4050, 52.5200 }
+            }
+        };
+
+        mapper.TryReadPoint(document, out GeoPoint point).Should().BeTrue();
+        point.Longitude.Should().BeApproximately(13.4050, 1e-6);
+        point.Latitude.Should().BeApproximately(52.5200, 1e-6);
+
+        var encoded = mapper.Encode(point);
+        encoded.Should().NotBe(0UL);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -19,6 +19,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Geographic\LiteDB.Spatial.Geographic.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Cartesian2D\LiteDB.Spatial.Cartesian2D.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Cartesian3D\LiteDB.Spatial.Cartesian3D.csproj" />
     <ProjectReference Include="..\LiteDB\LiteDB.csproj">
       <Aliases>LiteDbBase</Aliases>
     </ProjectReference>

--- a/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
@@ -1,0 +1,50 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a concrete spatial query plan combining index ranges and optional exact filtering metadata.
+/// </summary>
+public sealed class SpatialQueryPlan : ISpatialQueryPlan
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialQueryPlan"/> class.
+    /// </summary>
+    /// <param name="dimensions">The dimensionality of the underlying spatial index.</param>
+    /// <param name="coveringBounds">Optional coarse bounds applied before precise predicates.</param>
+    /// <param name="indexRanges">The ordered set of Morton index ranges to scan.</param>
+    /// <param name="exactPredicateDescription">Optional description of the exact predicate used after index filtering.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="dimensions"/> is outside the supported 2D/3D range.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="indexRanges"/> is <c>null</c>.</exception>
+    public SpatialQueryPlan(
+        int dimensions,
+        BoundingBox? coveringBounds,
+        IReadOnlyList<SpatialIndexRange> indexRanges,
+        string? exactPredicateDescription)
+    {
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial query plans must describe either two or three dimensions.");
+        }
+
+        IndexRanges = indexRanges ?? throw new ArgumentNullException(nameof(indexRanges));
+        Dimensions = dimensions;
+        CoveringBounds = coveringBounds;
+        ExactPredicateDescription = exactPredicateDescription;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <inheritdoc />
+    public string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Geographic/GeographicDistance.cs
+++ b/LiteDB.Spatial.Geographic/GeographicDistance.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes great-circle distances between geographic points using the Haversine formula.
+/// </summary>
+internal sealed class GeographicDistance : ISpatialDistance
+{
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        return GeographicMath.HaversineDistance(left, right);
+    }
+
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        throw new NotSupportedException("Geographic distance is defined for two-dimensional coordinates only.");
+    }
+}

--- a/LiteDB.Spatial.Geographic/GeographicEngine.cs
+++ b/LiteDB.Spatial.Geographic/GeographicEngine.cs
@@ -1,0 +1,120 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Spatial engine specialized for geographic (longitude/latitude) coordinates.
+/// </summary>
+public sealed class GeographicEngine : ISpatialEngine
+{
+    public const string EngineName = "Geographic2D";
+
+    private readonly string _geometryFieldName;
+
+    public GeographicEngine(
+        SpatialIndexOptions? options = null,
+        string geometryFieldName = SpatialCollectionDescriptor.DefaultGeometryFieldName)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryFieldName;
+        Mapper = new GeographicMapper(IndexEncoder, _geometryFieldName);
+        Distance = new GeographicDistance();
+    }
+
+    public string Name => EngineName;
+
+    public int Dimensions => 2;
+
+    public SpatialIndexOptions Options { get; }
+
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    public ISpatialMapper Mapper { get; }
+
+    public ISpatialDistance Distance { get; }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+        var boxes = GeographicMath.BuildCircleCovering(center, effectiveRadius);
+        var covering = boxes.Count == 1 ? boxes[0] : ComputeCoveringBounds(boxes);
+        return BuildPlan(boxes,
+            covering,
+            string.Format(CultureInfo.InvariantCulture, "distance <= {0} m (Haversine)", effectiveRadius));
+    }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Geographic engine only supports two-dimensional near queries.");
+    }
+
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic engine requires a 2D bounding box.", nameof(bounds));
+        }
+
+        var boxes = GeographicMath.BuildBoundsCovering(bounds);
+        var covering = boxes.Count == 1 ? boxes[0] : ComputeCoveringBounds(boxes);
+
+        return BuildPlan(boxes, covering, "within geographic bounding box");
+    }
+
+    private ISpatialQueryPlan BuildPlan(IReadOnlyList<BoundingBox> boxes, BoundingBox covering, string predicate)
+    {
+        var ranges = new List<SpatialIndexRange>();
+
+        foreach (var box in boxes)
+        {
+            var normalized = BoundingBox.From2D(
+                GeographicMath.LongitudeToUnit(box.MinX),
+                GeographicMath.LatitudeToUnit(box.MinY),
+                GeographicMath.LongitudeToUnit(box.MaxX),
+                GeographicMath.LatitudeToUnit(box.MaxY));
+
+            var cover = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+            if (cover.Count > 0)
+            {
+                ranges.AddRange(cover);
+            }
+        }
+
+        var merged = ranges.Count > 1
+            ? MortonIndexEncoder.UnionAdjacentRanges(ranges)
+            : ranges;
+
+        return new SpatialQueryPlan(Dimensions, covering, merged, predicate);
+    }
+
+    private static BoundingBox ComputeCoveringBounds(IReadOnlyList<BoundingBox> boxes)
+    {
+        if (boxes.Count == 0)
+        {
+            throw new ArgumentException("At least one bounding box is required.", nameof(boxes));
+        }
+
+        var minLat = double.MaxValue;
+        var maxLat = double.MinValue;
+
+        foreach (var box in boxes)
+        {
+            minLat = Math.Min(minLat, box.MinY);
+            maxLat = Math.Max(maxLat, box.MaxY);
+        }
+
+        return BoundingBox.From2D(-180d, minLat, 180d, maxLat);
+    }
+}

--- a/LiteDB.Spatial.Geographic/GeographicMapper.cs
+++ b/LiteDB.Spatial.Geographic/GeographicMapper.cs
@@ -1,0 +1,178 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Projects geographic coordinates into Morton index space and extracts them from stored documents.
+/// </summary>
+internal sealed class GeographicMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+
+    public GeographicMapper(ISpatialIndexEncoder encoder, string geometryFieldName)
+    {
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryFieldName;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        var longitude = GeographicMath.NormalizeLongitude(point.Longitude);
+        var latitude = GeographicMath.NormalizeLatitude(point.Latitude);
+        return BoundingBox.From2D(longitude, latitude, longitude, latitude);
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper does not support three-dimensional coordinates.");
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = GeographicMath.LongitudeToUnit(point.Longitude);
+        coordinates[1] = GeographicMath.LatitudeToUnit(point.Latitude);
+        return _encoder.Encode(coordinates);
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper does not support three-dimensional coordinates.");
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var value))
+        {
+            point = default;
+            return false;
+        }
+
+        if (TryReadPoint(value, out point))
+        {
+            point = new GeoPoint(
+                GeographicMath.NormalizeLongitude(point.Longitude),
+                GeographicMath.NormalizeLatitude(point.Latitude));
+            return true;
+        }
+
+        point = default;
+        return false;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadPoint(BaseLiteDB.BsonValue value, out GeoPoint point)
+    {
+        if (value.IsArray)
+        {
+            var array = value.AsArray;
+            if (array.Count >= 2 && TryReadDouble(array[0], out var lon) && TryReadDouble(array[1], out var lat))
+            {
+                point = new GeoPoint(lon, lat);
+                return true;
+            }
+        }
+        else if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+
+            if (doc.TryGetValue("coordinates", out var coordinates) && coordinates.IsArray)
+            {
+                var array = coordinates.AsArray;
+                if (array.Count >= 2 && TryReadDouble(array[0], out var lon) && TryReadDouble(array[1], out var lat))
+                {
+                    point = new GeoPoint(lon, lat);
+                    return true;
+                }
+            }
+
+            if (TryReadDouble(doc, out var lonValue, out var latValue))
+            {
+                point = new GeoPoint(lonValue, latValue);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonDocument document, out double lon, out double lat)
+    {
+        lon = 0d;
+        lat = 0d;
+
+        if (!TryReadDouble(document, new[] { "longitude", "lon", "lng", "x" }, out lon))
+        {
+            return false;
+        }
+
+        if (!TryReadDouble(document, new[] { "latitude", "lat", "y" }, out lat))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonDocument document, IReadOnlyList<string> keys, out double value)
+    {
+        foreach (var key in keys)
+        {
+            if (document.TryGetValue(key, out var candidate) && TryReadDouble(candidate, out value))
+            {
+                return true;
+            }
+        }
+
+        value = 0d;
+        return false;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonValue value, out double result)
+    {
+        if (value.IsInt32)
+        {
+            result = value.AsInt32;
+            return true;
+        }
+
+        if (value.IsInt64)
+        {
+            result = value.AsInt64;
+            return true;
+        }
+
+        if (value.IsDecimal)
+        {
+            result = (double)value.AsDecimal;
+            return true;
+        }
+
+        if (value.IsDouble)
+        {
+            result = value.AsDouble;
+            return true;
+        }
+
+        result = 0d;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Geographic/GeographicMath.cs
+++ b/LiteDB.Spatial.Geographic/GeographicMath.cs
@@ -1,0 +1,189 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides math helpers for geographic (longitude/latitude) computations.
+/// </summary>
+internal static class GeographicMath
+{
+    public const double EarthRadiusMeters = 6_378_137d;
+    private const double HalfPi = Math.PI / 2d;
+
+    public static double NormalizeLongitude(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Longitude must be a finite value.", nameof(value));
+        }
+
+        var normalized = (value + 180d) % 360d;
+        if (normalized < 0d)
+        {
+            normalized += 360d;
+        }
+
+        normalized -= 180d;
+
+        if (normalized == -180d && value > 0d)
+        {
+            return 180d;
+        }
+
+        return normalized;
+    }
+
+    public static double NormalizeLatitude(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Latitude must be a finite value.", nameof(value));
+        }
+
+        if (value > 90d)
+        {
+            return 90d;
+        }
+
+        if (value < -90d)
+        {
+            return -90d;
+        }
+
+        return value;
+    }
+
+    public static double LongitudeToUnit(double longitude)
+    {
+        return (NormalizeLongitude(longitude) + 180d) / 360d;
+    }
+
+    public static double LatitudeToUnit(double latitude)
+    {
+        return (NormalizeLatitude(latitude) + 90d) / 180d;
+    }
+
+    public static double DegreesToRadians(double degrees)
+    {
+        return degrees * Math.PI / 180d;
+    }
+
+    public static double RadiansToDegrees(double radians)
+    {
+        return radians * 180d / Math.PI;
+    }
+
+    public static double HaversineDistance(GeoPoint left, GeoPoint right)
+    {
+        var lat1 = DegreesToRadians(left.Latitude);
+        var lat2 = DegreesToRadians(right.Latitude);
+        var deltaLat = lat2 - lat1;
+        var deltaLon = DegreesToRadians(right.Longitude - left.Longitude);
+
+        var sinLat = Math.Sin(deltaLat / 2d);
+        var sinLon = Math.Sin(deltaLon / 2d);
+        var a = (sinLat * sinLat) + (Math.Cos(lat1) * Math.Cos(lat2) * sinLon * sinLon);
+        var c = 2d * Math.Atan2(Math.Sqrt(a), Math.Sqrt(Math.Max(0d, 1d - a)));
+        return EarthRadiusMeters * c;
+    }
+
+    public static IReadOnlyList<BoundingBox> BuildCircleCovering(GeoPoint center, double radiusMeters)
+    {
+        var latitude = NormalizeLatitude(center.Latitude);
+        var longitude = NormalizeLongitude(center.Longitude);
+        var angularDistance = radiusMeters / EarthRadiusMeters;
+
+        var latRad = DegreesToRadians(latitude);
+        var minLat = latRad - angularDistance;
+        var maxLat = latRad + angularDistance;
+
+        minLat = Math.Max(minLat, -HalfPi);
+        maxLat = Math.Min(maxLat, HalfPi);
+
+        double minLon;
+        double maxLon;
+
+        if (minLat <= -HalfPi || maxLat >= HalfPi)
+        {
+            minLon = -Math.PI;
+            maxLon = Math.PI;
+        }
+        else
+        {
+            var deltaLon = Math.Asin(Math.Sin(angularDistance) / Math.Cos(latRad));
+            if (double.IsNaN(deltaLon) || double.IsInfinity(deltaLon))
+            {
+                deltaLon = Math.PI;
+            }
+
+            minLon = DegreesToRadians(longitude) - deltaLon;
+            maxLon = DegreesToRadians(longitude) + deltaLon;
+        }
+
+        var minLatDeg = RadiansToDegrees(minLat);
+        var maxLatDeg = RadiansToDegrees(maxLat);
+
+        var spans = SplitLongitudeRange(RadiansToDegrees(minLon), RadiansToDegrees(maxLon));
+        var boxes = new List<BoundingBox>(spans.Count);
+
+        foreach (var span in spans)
+        {
+            boxes.Add(BoundingBox.From2D(span.min, minLatDeg, span.max, maxLatDeg));
+        }
+
+        return boxes;
+    }
+
+    public static IReadOnlyList<BoundingBox> BuildBoundsCovering(BoundingBox bounds)
+    {
+        var minLat = NormalizeLatitude(bounds.MinY);
+        var maxLat = NormalizeLatitude(bounds.MaxY);
+
+        if (maxLat < minLat)
+        {
+            (minLat, maxLat) = (maxLat, minLat);
+        }
+
+        var spans = SplitLongitudeRange(bounds.MinX, bounds.MaxX);
+        var boxes = new List<BoundingBox>(spans.Count);
+
+        foreach (var span in spans)
+        {
+            boxes.Add(BoundingBox.From2D(span.min, minLat, span.max, maxLat));
+        }
+
+        return boxes;
+    }
+
+    private static IReadOnlyList<(double min, double max)> SplitLongitudeRange(double minLon, double maxLon)
+    {
+        if (double.IsNaN(minLon) || double.IsInfinity(minLon) || double.IsNaN(maxLon) || double.IsInfinity(maxLon))
+        {
+            throw new ArgumentException("Longitude bounds must be finite values.");
+        }
+
+        var width = maxLon - minLon;
+
+        if (width >= 360d)
+        {
+            return new[] { (-180d, 180d) };
+        }
+
+        var normalizedMin = NormalizeLongitude(minLon);
+        var normalizedMax = NormalizeLongitude(maxLon);
+
+        if (normalizedMin <= normalizedMax && width <= 360d)
+        {
+            return new[] { (normalizedMin, normalizedMax) };
+        }
+
+        return new[]
+        {
+            (normalizedMin, 180d),
+            (-180d, normalizedMax)
+        };
+    }
+}

--- a/LiteDB.Spatial.Geographic/LiteDB.Spatial.Geographic.csproj
+++ b/LiteDB.Spatial.Geographic/LiteDB.Spatial.Geographic.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Geographic</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Geographic.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Geographic/SpatialGeographic.cs
+++ b/LiteDB.Spatial.Geographic/SpatialGeographic.cs
@@ -1,0 +1,25 @@
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Convenience helpers for configuring collections that rely on the geographic engine.
+/// </summary>
+public static class SpatialGeographic
+{
+    public static GeographicEngine CreateEngine(
+        SpatialIndexOptions? options = null,
+        string geometryFieldName = SpatialCollectionDescriptor.DefaultGeometryFieldName)
+    {
+        return new GeographicEngine(options, geometryFieldName);
+    }
+
+    public static SpatialCollectionDescriptor CreateDescriptor(
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        var engine = CreateEngine(options, geometryFieldName);
+        return new SpatialCollectionDescriptor(collectionName, GeographicEngine.EngineName, engine.Dimensions, geometryFieldName, engine.Options, engine);
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -44,6 +44,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core", "Lite
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core.Tests", "LiteDB.Spatial.Core.Tests\LiteDB.Spatial.Core.Tests.csproj", "{99F2946D-65FB-4FC8-827D-C3241FB5EF93}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Geographic", "LiteDB.Spatial.Geographic\LiteDB.Spatial.Geographic.csproj", "{5F035545-6989-4243-BE80-85A4D160A9EF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Cartesian2D", "LiteDB.Spatial.Cartesian2D\LiteDB.Spatial.Cartesian2D.csproj", "{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Cartesian3D", "LiteDB.Spatial.Cartesian3D\LiteDB.Spatial.Cartesian3D.csproj", "{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -186,6 +192,42 @@ Global
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.Build.0 = Release|Any CPU
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.ActiveCfg = Release|Any CPU
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.Build.0 = Release|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Release|x64.Build.0 = Release|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F035545-6989-4243-BE80-85A4D160A9EF}.Release|x86.Build.0 = Release|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Debug|x64.Build.0 = Debug|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Debug|x86.Build.0 = Debug|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Release|x64.ActiveCfg = Release|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Release|x64.Build.0 = Release|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Release|x86.ActiveCfg = Release|Any CPU
+		{56B6E8DE-330F-4FF2-954B-0BA9B2F16ADA}.Release|x86.Build.0 = Release|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Debug|x64.Build.0 = Debug|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Debug|x86.Build.0 = Debug|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Release|Any CPU.Build.0 = Release|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Release|x64.ActiveCfg = Release|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Release|x64.Build.0 = Release|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Release|x86.ActiveCfg = Release|Any CPU
+		{07F161F3-EAD8-48F9-A333-B1B2E7DB0157}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -96,16 +96,29 @@ LiteDB.Spatial
 
 ### S5 — Geographic engine (2D)
 
-- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
-- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+- [x] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [x] Handle wraparound and polar helpers with tests for real-world coordinates.
+
+**Notes**
+
+- Implemented a dedicated geographic engine that plans near and bounding-box queries, handles anti-meridian wrapping, and exposes a `SpatialGeographic` facade alongside document mappers and Haversine distance calculations.
+- Added unit tests that verify covering bounds for Berlin, polar searches, anti-meridian spanning boxes, and GeoJSON parsing.
 
 ### S6 — Cartesian 2D engine
 
-- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+- [x] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+
+**Notes**
+
+- Added a configurable coordinate-space aware Cartesian 2D engine with Euclidean planning, mapper support for common document layouts, and facade helpers; tests cover near planning, out-of-bounds boxes, and mapper extraction.
 
 ### S7 — Cartesian 3D engine (points)
 
-- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+- [x] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+
+**Notes**
+
+- Delivered a Morton-backed 3D engine for point searches with Euclidean distance, document mapping (array and object shapes), and tests covering near planning, empty intersections, and mapper behavior.
 
 ### S8 — LINQ resolver
 


### PR DESCRIPTION
## Summary
- add a reusable `SpatialQueryPlan` implementation for spatial engines
- implement geographic, Cartesian 2D, and Cartesian 3D engines with their mappers, distance helpers, and facades
- cover the new engines with dedicated unit tests and mark the corresponding documentation tasks complete

## Testing
- dotnet build LiteDB.sln
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj --no-build --framework net8.0

------
https://chatgpt.com/codex/tasks/task_e_68e75fa2f94c8326ad2b426f3de99ecd