### PR TITLE
Implement geographic and cartesian spatial engines

### DIFF
--- a/LiteDB.Spatial.Cartesian2D/Engine/Cartesian2DEngine.cs
+++ b/LiteDB.Spatial.Cartesian2D/Engine/Cartesian2DEngine.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+#nullable enable
+
+/// <summary>
+/// Spatial engine for two-dimensional Cartesian data.
+/// </summary>
+public sealed class Cartesian2DEngine : ISpatialEngine
+{
+    /// <summary>
+    /// Canonical engine name stored in metadata.
+    /// </summary>
+    public const string EngineName = "Cartesian2D";
+
+    private readonly Euclidean2DDistance _distance = new();
+
+    public Cartesian2DEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        Mapper = new Cartesian2DMapper(IndexEncoder, geometryFieldName);
+    }
+
+    public string Name => EngineName;
+
+    public int Dimensions => 2;
+
+    public SpatialIndexOptions Options { get; }
+
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    public ISpatialMapper Mapper { get; }
+
+    public ISpatialDistance Distance => _distance;
+
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        var expanded = Expand(radius);
+        var minX = center.Longitude - expanded;
+        var maxX = center.Longitude + expanded;
+        var minY = center.Latitude - expanded;
+        var maxY = center.Latitude + expanded;
+        var bounds = BoundingBox.From2D(minX, minY, maxX, maxY);
+        var normalized = Normalize(bounds);
+        var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        var description = string.Format(CultureInfo.InvariantCulture, "Euclidean distance <= {0:F6}", radius);
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, description);
+    }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Cartesian2D engine does not support 3D near queries.");
+    }
+
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Cartesian2D engine expects 2D bounding boxes.", nameof(bounds));
+        }
+
+        var normalized = Normalize(bounds);
+        var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        var description = string.Format(
+            CultureInfo.InvariantCulture,
+            "Within bounding box [{0:F6}, {1:F6}, {2:F6}, {3:F6}]",
+            bounds.MinX,
+            bounds.MinY,
+            bounds.MaxX,
+            bounds.MaxY);
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, description);
+    }
+
+    private BoundingBox Normalize(BoundingBox bounds)
+    {
+        var values = bounds.ToArray();
+        values[0] = CartesianIndexing.Normalize(values[0]);
+        values[1] = CartesianIndexing.Normalize(values[1]);
+        values[2] = CartesianIndexing.Normalize(values[2]);
+        values[3] = CartesianIndexing.Normalize(values[3]);
+        return BoundingBox.Create(values);
+    }
+
+    private double Expand(double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        return radius * (1d + Options.DistanceTolerance);
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/Engine/Cartesian2DMapper.cs
+++ b/LiteDB.Spatial.Cartesian2D/Engine/Cartesian2DMapper.cs
@@ -1,0 +1,97 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps Cartesian 2D points for indexing and persistence.
+/// </summary>
+public sealed class Cartesian2DMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+
+    public Cartesian2DMapper(ISpatialIndexEncoder encoder, string geometryFieldName)
+    {
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryFieldName;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper does not support 3D points.");
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = CartesianIndexing.Normalize(point.Longitude);
+        coordinates[1] = CartesianIndexing.Normalize(point.Latitude);
+        return _encoder.Encode(coordinates);
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper does not support 3D points.");
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var value) || value.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (value.IsArray && value.AsArray.Count >= 2 && value.AsArray[0].IsNumber && value.AsArray[1].IsNumber)
+        {
+            point = new GeoPoint(value.AsArray[0].AsDouble, value.AsArray[1].AsDouble);
+            return true;
+        }
+
+        if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+            if (TryGet(doc, "x", out var x) && TryGet(doc, "y", out var y))
+            {
+                point = new GeoPoint(x, y);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryGet(BaseLiteDB.BsonDocument document, string name, out double value)
+    {
+        if (document.TryGetValue(name, out var bson) && bson.IsNumber)
+        {
+            value = bson.AsDouble;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/Engine/CartesianIndexing.cs
+++ b/LiteDB.Spatial.Cartesian2D/Engine/CartesianIndexing.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helpers shared by Cartesian engines.
+/// </summary>
+internal static class CartesianIndexing
+{
+    public static double Normalize(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Coordinates must be finite numbers.", nameof(value));
+        }
+
+#if NET8_0_OR_GREATER
+        return Math.Clamp(value, 0d, 1d);
+#else
+        if (value < 0d)
+        {
+            return 0d;
+        }
+
+        if (value > 1d)
+        {
+            return 1d;
+        }
+
+        return value;
+#endif
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/Engine/Euclidean2DDistance.cs
+++ b/LiteDB.Spatial.Cartesian2D/Engine/Euclidean2DDistance.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes Euclidean distances for two-dimensional Cartesian coordinates.
+/// </summary>
+public sealed class Euclidean2DDistance : ISpatialDistance
+{
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var dx = left.Longitude - right.Longitude;
+        var dy = left.Latitude - right.Latitude;
+        return Math.Sqrt(dx * dx + dy * dy);
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        throw new NotSupportedException("Euclidean2DDistance supports only two-dimensional points.");
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/LiteDB.Spatial.Cartesian2D.csproj
+++ b/LiteDB.Spatial.Cartesian2D/LiteDB.Spatial.Cartesian2D.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Cartesian2D</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Cartesian2D.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/LiteDB.Spatial.Cartesian2D/SpatialCartesian2D.cs
+++ b/LiteDB.Spatial.Cartesian2D/SpatialCartesian2D.cs
@@ -1,0 +1,90 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+#nullable enable
+
+/// <summary>
+/// Facade for configuring and planning Cartesian 2D spatial queries.
+/// </summary>
+public static class SpatialCartesian2D
+{
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var resolvedOptions = options ?? new SpatialIndexOptions();
+        var descriptor = new SpatialCollectionDescriptor(
+            collectionName,
+            Cartesian2DEngine.EngineName,
+            2,
+            geometryFieldName,
+            resolvedOptions);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(resolvedOptions.IndexFieldName, BaseLiteDB.BsonExpression.Create("$." + resolvedOptions.IndexFieldName));
+        collection.EnsureIndex(resolvedOptions.BoundingBoxFieldName, BaseLiteDB.BsonExpression.Create("$." + resolvedOptions.BoundingBoxFieldName));
+
+        return descriptor.WithEngine(new Cartesian2DEngine(geometryFieldName, resolvedOptions));
+    }
+
+    public static ISpatialQueryPlan Near(SpatialCollectionDescriptor descriptor, GeoPoint center, double radius)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (descriptor.Dimensions != 2)
+        {
+            throw new SpatialMetadataException("Descriptor does not describe a 2D collection.");
+        }
+
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanNear(center, radius);
+    }
+
+    public static ISpatialQueryPlan WithinBoundingBox(SpatialCollectionDescriptor descriptor, BoundingBox bounds)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Cartesian 2D bounding boxes must contain four values.", nameof(bounds));
+        }
+
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static Cartesian2DEngine ResolveEngine(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor.Engine is Cartesian2DEngine engine)
+        {
+            return engine;
+        }
+
+        return new Cartesian2DEngine(descriptor.GeometryFieldName, descriptor.Options);
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Engine/Cartesian3DEngine.cs
+++ b/LiteDB.Spatial.Cartesian3D/Engine/Cartesian3DEngine.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+#nullable enable
+
+/// <summary>
+/// Spatial engine for three-dimensional Cartesian point data.
+/// </summary>
+public sealed class Cartesian3DEngine : ISpatialEngine
+{
+    public const string EngineName = "Cartesian3D";
+
+    private readonly Euclidean3DDistance _distance = new();
+
+    public Cartesian3DEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(3, Options.PrecisionBits);
+        Mapper = new Cartesian3DMapper(IndexEncoder, geometryFieldName);
+    }
+
+    public string Name => EngineName;
+
+    public int Dimensions => 3;
+
+    public SpatialIndexOptions Options { get; }
+
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    public ISpatialMapper Mapper { get; }
+
+    public ISpatialDistance Distance => _distance;
+
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        throw new NotSupportedException("Cartesian3D engine expects three-dimensional points for near queries.");
+    }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        var expanded = Expand(radius);
+        var bounds = BoundingBox.From3D(
+            center.X - expanded,
+            center.Y - expanded,
+            center.Z - expanded,
+            center.X + expanded,
+            center.Y + expanded,
+            center.Z + expanded);
+
+        var normalized = Normalize(bounds);
+        var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        var description = string.Format(CultureInfo.InvariantCulture, "Euclidean3D distance <= {0:F6}", radius);
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, description);
+    }
+
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 3)
+        {
+            throw new ArgumentException("Cartesian3D engine expects 3D bounding boxes.", nameof(bounds));
+        }
+
+        var normalized = Normalize(bounds);
+        var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        var description = string.Format(
+            CultureInfo.InvariantCulture,
+            "Within bounding box [{0:F6}, {1:F6}, {2:F6}, {3:F6}, {4:F6}, {5:F6}]",
+            bounds.MinX,
+            bounds.MinY,
+            bounds.MinZ,
+            bounds.MaxX,
+            bounds.MaxY,
+            bounds.MaxZ);
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, description);
+    }
+
+    private BoundingBox Normalize(BoundingBox bounds)
+    {
+        var values = bounds.ToArray();
+        values[0] = Clamp(values[0]);
+        values[1] = Clamp(values[1]);
+        values[2] = Clamp(values[2]);
+        values[3] = Clamp(values[3]);
+        values[4] = Clamp(values[4]);
+        values[5] = Clamp(values[5]);
+        return BoundingBox.Create(values);
+    }
+
+    private static double Clamp(double value)
+    {
+#if NET8_0_OR_GREATER
+        return Math.Clamp(value, 0d, 1d);
+#else
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Coordinates must be finite numbers.");
+        }
+
+        if (value < 0d)
+        {
+            return 0d;
+        }
+
+        if (value > 1d)
+        {
+            return 1d;
+        }
+
+        return value;
+#endif
+    }
+
+    private double Expand(double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        return radius * (1d + Options.DistanceTolerance);
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Engine/Cartesian3DMapper.cs
+++ b/LiteDB.Spatial.Cartesian3D/Engine/Cartesian3DMapper.cs
@@ -1,0 +1,122 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps three-dimensional Cartesian points to index representations.
+/// </summary>
+public sealed class Cartesian3DMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+
+    public Cartesian3DMapper(ISpatialIndexEncoder encoder, string geometryFieldName)
+    {
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryFieldName;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper expects three-dimensional points.");
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper expects three-dimensional points.");
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        Span<double> coordinates = stackalloc double[3];
+        coordinates[0] = CartesianIndexing(point.X);
+        coordinates[1] = CartesianIndexing(point.Y);
+        coordinates[2] = CartesianIndexing(point.Z);
+        return _encoder.Encode(coordinates);
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+        return false;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var value) || value.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (value.IsArray && value.AsArray.Count >= 3 && value.AsArray[0].IsNumber && value.AsArray[1].IsNumber && value.AsArray[2].IsNumber)
+        {
+            point = new GeoPoint3D(value.AsArray[0].AsDouble, value.AsArray[1].AsDouble, value.AsArray[2].AsDouble);
+            return true;
+        }
+
+        if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+            if (TryGet(doc, "x", out var x) && TryGet(doc, "y", out var y) && TryGet(doc, "z", out var z))
+            {
+                point = new GeoPoint3D(x, y, z);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryGet(BaseLiteDB.BsonDocument document, string name, out double value)
+    {
+        if (document.TryGetValue(name, out var bson) && bson.IsNumber)
+        {
+            value = bson.AsDouble;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static double CartesianIndexing(double value)
+    {
+#if NET8_0_OR_GREATER
+        return Math.Clamp(value, 0d, 1d);
+#else
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Coordinates must be finite numbers.");
+        }
+
+        if (value < 0d)
+        {
+            return 0d;
+        }
+
+        if (value > 1d)
+        {
+            return 1d;
+        }
+
+        return value;
+#endif
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Engine/Euclidean3DDistance.cs
+++ b/LiteDB.Spatial.Cartesian3D/Engine/Euclidean3DDistance.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes Euclidean distances for three-dimensional Cartesian coordinates.
+/// </summary>
+public sealed class Euclidean3DDistance : ISpatialDistance
+{
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        throw new NotSupportedException("Euclidean3DDistance expects 3D points.");
+    }
+
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        var dz = left.Z - right.Z;
+        return Math.Sqrt(dx * dx + dy * dy + dz * dz);
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/LiteDB.Spatial.Cartesian3D.csproj
+++ b/LiteDB.Spatial.Cartesian3D/LiteDB.Spatial.Cartesian3D.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Cartesian3D</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Cartesian3D.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/LiteDB.Spatial.Cartesian3D/SpatialCartesian3D.cs
+++ b/LiteDB.Spatial.Cartesian3D/SpatialCartesian3D.cs
@@ -1,0 +1,90 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+#nullable enable
+
+/// <summary>
+/// Facade for configuring and querying three-dimensional Cartesian spatial data.
+/// </summary>
+public static class SpatialCartesian3D
+{
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var resolvedOptions = options ?? new SpatialIndexOptions();
+        var descriptor = new SpatialCollectionDescriptor(
+            collectionName,
+            Cartesian3DEngine.EngineName,
+            3,
+            geometryFieldName,
+            resolvedOptions);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(resolvedOptions.IndexFieldName, BaseLiteDB.BsonExpression.Create("$." + resolvedOptions.IndexFieldName));
+        collection.EnsureIndex(resolvedOptions.BoundingBoxFieldName, BaseLiteDB.BsonExpression.Create("$." + resolvedOptions.BoundingBoxFieldName));
+
+        return descriptor.WithEngine(new Cartesian3DEngine(geometryFieldName, resolvedOptions));
+    }
+
+    public static ISpatialQueryPlan Near(SpatialCollectionDescriptor descriptor, GeoPoint3D center, double radius)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (descriptor.Dimensions != 3)
+        {
+            throw new SpatialMetadataException("Descriptor does not describe a 3D collection.");
+        }
+
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanNear(center, radius);
+    }
+
+    public static ISpatialQueryPlan WithinBoundingBox(SpatialCollectionDescriptor descriptor, BoundingBox bounds)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (bounds.Dimensions != 3)
+        {
+            throw new ArgumentException("Bounding boxes must contain six values for 3D queries.", nameof(bounds));
+        }
+
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static Cartesian3DEngine ResolveEngine(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor.Engine is Cartesian3DEngine engine)
+        {
+            return engine;
+        }
+
+        return new Cartesian3DEngine(descriptor.GeometryFieldName, descriptor.Options);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian2D/Cartesian2DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian2D/Cartesian2DEngineTests.cs
@@ -1,0 +1,70 @@
+extern alias LiteDbBase;
+
+using System.IO;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Cartesian2D;
+
+public class Cartesian2DEngineTests
+{
+    [Fact]
+    public void PlanNear_ShouldProduceAxisAlignedBoundingBox()
+    {
+        var engine = new Cartesian2DEngine("position", new SpatialIndexOptions(distanceTolerance: 0.05));
+        var center = new GeoPoint(0.25, 0.75);
+
+        var plan = engine.PlanNear(center, 0.1);
+
+        plan.Dimensions.Should().Be(2);
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.MinX.Should().BeApproximately(0.25 - 0.105, 1e-6);
+        plan.CoveringBounds.Value.MaxX.Should().BeApproximately(0.25 + 0.105, 1e-6);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void PlanWithin_ShouldRespectInputBounds()
+    {
+        var engine = new Cartesian2DEngine("position");
+        var bounds = BoundingBox.From2D(0.1, 0.2, 0.4, 0.6);
+
+        var plan = engine.PlanWithin(bounds);
+
+        plan.CoveringBounds.Should().Be(bounds);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Mapper_ShouldReadArrayPoints()
+    {
+        var engine = new Cartesian2DEngine("position");
+        var mapper = engine.Mapper;
+
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["position"] = new BaseLiteDB.BsonArray { 0.1, 0.2 }
+        };
+
+        mapper.TryReadPoint(document, out GeoPoint point).Should().BeTrue();
+        point.Longitude.Should().BeApproximately(0.1, 1e-9);
+        point.Latitude.Should().BeApproximately(0.2, 1e-9);
+    }
+
+    [Fact]
+    public void EnsurePointIndex_ShouldPersistMetadata()
+    {
+        using var stream = new MemoryStream();
+        using var database = new BaseLiteDB.LiteDatabase(stream);
+
+        var descriptor = SpatialCartesian2D.EnsurePointIndex(database, "points2d", "position");
+
+        descriptor.EngineName.Should().Be(Cartesian2DEngine.EngineName);
+        descriptor.Dimensions.Should().Be(2);
+
+        var store = new SpatialMetadataStore(database);
+        store.GetRequiredDescriptor("points2d").Should().Be(descriptor);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian3D/Cartesian3DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian3D/Cartesian3DEngineTests.cs
@@ -1,0 +1,71 @@
+extern alias LiteDbBase;
+
+using System.IO;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Cartesian3D;
+
+public class Cartesian3DEngineTests
+{
+    [Fact]
+    public void PlanNear_ShouldProduceCubeAroundCenter()
+    {
+        var engine = new Cartesian3DEngine("position", new SpatialIndexOptions(distanceTolerance: 0.1));
+        var center = new GeoPoint3D(0.3, 0.4, 0.5);
+
+        var plan = engine.PlanNear(center, 0.05);
+
+        plan.Dimensions.Should().Be(3);
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.MinX.Should().BeApproximately(0.3 - 0.055, 1e-6);
+        plan.CoveringBounds.Value.MaxZ.Should().BeApproximately(0.5 + 0.055, 1e-6);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void PlanWithin_ShouldRespect3DBounds()
+    {
+        var engine = new Cartesian3DEngine("position");
+        var bounds = BoundingBox.From3D(0.1, 0.2, 0.3, 0.6, 0.7, 0.8);
+
+        var plan = engine.PlanWithin(bounds);
+
+        plan.CoveringBounds.Should().Be(bounds);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Mapper_ShouldReadThreeDimensionalArray()
+    {
+        var engine = new Cartesian3DEngine("position");
+        var mapper = engine.Mapper;
+
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["position"] = new BaseLiteDB.BsonArray { 0.1, 0.2, 0.3 }
+        };
+
+        mapper.TryReadPoint(document, out GeoPoint3D point).Should().BeTrue();
+        point.X.Should().BeApproximately(0.1, 1e-9);
+        point.Y.Should().BeApproximately(0.2, 1e-9);
+        point.Z.Should().BeApproximately(0.3, 1e-9);
+    }
+
+    [Fact]
+    public void EnsurePointIndex_ShouldPersist3DMetadata()
+    {
+        using var stream = new MemoryStream();
+        using var database = new BaseLiteDB.LiteDatabase(stream);
+
+        var descriptor = SpatialCartesian3D.EnsurePointIndex(database, "points3d", "position");
+
+        descriptor.EngineName.Should().Be(Cartesian3DEngine.EngineName);
+        descriptor.Dimensions.Should().Be(3);
+
+        var store = new SpatialMetadataStore(database);
+        store.GetRequiredDescriptor("points3d").Should().Be(descriptor);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Geographic/GeographicEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Geographic/GeographicEngineTests.cs
@@ -1,0 +1,108 @@
+extern alias LiteDbBase;
+
+using System.IO;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Geographic;
+
+public class GeographicEngineTests
+{
+    [Fact]
+    public void PlanNear_ShouldProduceCoveringForCityScaleQuery()
+    {
+        var options = new SpatialIndexOptions(precisionBits: 20, maxCoveringCells: 128);
+        var engine = new GeographicEngine("location", options);
+        var center = new GeoPoint(13.4050, 52.5200);
+
+        var plan = engine.PlanNear(center, 5_000);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.ExactPredicateDescription.Should().Contain("5000");
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.MinX.Should().BeLessThan(center.Longitude);
+        plan.CoveringBounds.Value.MaxX.Should().BeGreaterThan(center.Longitude);
+        plan.CoveringBounds.Value.MinY.Should().BeLessThan(center.Latitude);
+        plan.CoveringBounds.Value.MaxY.Should().BeGreaterThan(center.Latitude);
+    }
+
+    [Fact]
+    public void PlanNear_ShouldHandleAntiMeridianWrap()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions(precisionBits: 18));
+        var center = new GeoPoint(179.5, 0);
+
+        var plan = engine.PlanNear(center, 300_000);
+
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.MinX.Should().BeApproximately(-180d, 1e-6);
+        plan.CoveringBounds.Value.MaxX.Should().BeApproximately(180d, 1e-6);
+        plan.IndexRanges.Count.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void PlanNear_ShouldExpandToPolesWhenCircleTouchesPole()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions());
+        var center = new GeoPoint(40, 89.5);
+
+        var plan = engine.PlanNear(center, 120_000);
+
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.MinX.Should().Be(-180d);
+        plan.CoveringBounds.Value.MaxX.Should().Be(180d);
+        plan.CoveringBounds.Value.MaxY.Should().BeLessOrEqualTo(90d);
+    }
+
+    [Fact]
+    public void Mapper_ShouldReadGeoJsonPoint()
+    {
+        var engine = new GeographicEngine("location");
+        var mapper = engine.Mapper;
+
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["location"] = new BaseLiteDB.BsonDocument
+            {
+                ["type"] = "Point",
+                ["coordinates"] = new BaseLiteDB.BsonArray { 10.123, 20.456 }
+            }
+        };
+
+        mapper.TryReadPoint(document, out GeoPoint point).Should().BeTrue();
+        point.Longitude.Should().BeApproximately(10.123, 1e-9);
+        point.Latitude.Should().BeApproximately(20.456, 1e-9);
+    }
+
+    [Fact]
+    public void EnsurePointIndex_ShouldPersistMetadata()
+    {
+        using var stream = new MemoryStream();
+        using var database = new BaseLiteDB.LiteDatabase(stream);
+
+        var descriptor = SpatialGeographic.EnsurePointIndex(database, "places", "location", new SpatialIndexOptions(precisionBits: 18));
+
+        descriptor.Engine.Should().NotBeNull();
+        descriptor.EngineName.Should().Be(GeographicEngine.EngineName);
+        descriptor.Dimensions.Should().Be(2);
+
+        var store = new SpatialMetadataStore(database);
+        var loaded = store.GetRequiredDescriptor("places");
+        loaded.Should().Be(descriptor);
+    }
+
+    [Fact]
+    public void Distance_ShouldApproximateKnownCities()
+    {
+        var distance = new GeographicDistance();
+        var berlin = new GeoPoint(13.4050, 52.5200);
+        var paris = new GeoPoint(2.3522, 48.8566);
+
+        var result = distance.Distance(berlin, paris);
+
+        result.Should().BeApproximately(878_000, 5_000); // ~878 km between Berlin and Paris
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -19,6 +19,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Geographic\LiteDB.Spatial.Geographic.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Cartesian2D\LiteDB.Spatial.Cartesian2D.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Cartesian3D\LiteDB.Spatial.Cartesian3D.csproj" />
     <ProjectReference Include="..\LiteDB\LiteDB.csproj">
       <Aliases>LiteDbBase</Aliases>
     </ProjectReference>

--- a/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
@@ -1,0 +1,55 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a concrete implementation of <see cref="ISpatialQueryPlan"/>.
+/// </summary>
+public sealed class SpatialQueryPlan : ISpatialQueryPlan
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialQueryPlan"/> class.
+    /// </summary>
+    /// <param name="dimensions">The spatial dimensionality handled by the plan.</param>
+    /// <param name="coveringBounds">The coarse bounding box applied before exact predicates.</param>
+    /// <param name="indexRanges">The ordered set of index ranges to scan.</param>
+    /// <param name="exactPredicateDescription">Optional human readable description of the precise predicate.</param>
+    public SpatialQueryPlan(
+        int dimensions,
+        BoundingBox? coveringBounds,
+        IReadOnlyList<SpatialIndexRange> indexRanges,
+        string? exactPredicateDescription)
+    {
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial query plans must target 2D or 3D indexes.");
+        }
+
+        if (indexRanges == null)
+        {
+            throw new ArgumentNullException(nameof(indexRanges));
+        }
+
+        Dimensions = dimensions;
+        CoveringBounds = coveringBounds;
+        IndexRanges = indexRanges.Count == 0
+            ? Array.Empty<SpatialIndexRange>()
+            : indexRanges;
+        ExactPredicateDescription = exactPredicateDescription;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <inheritdoc />
+    public string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Geographic/Engine/GeographicDistance.cs
+++ b/LiteDB.Spatial.Geographic/Engine/GeographicDistance.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes geodesic distances between two-dimensional geographic points.
+/// </summary>
+public sealed class GeographicDistance : ISpatialDistance
+{
+    /// <summary>
+    /// Mean Earth radius in meters according to IUGG.
+    /// </summary>
+    public const double EarthRadiusMeters = 6_371_008.8d;
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var lat1 = ToRadians(left.Latitude);
+        var lat2 = ToRadians(right.Latitude);
+        var deltaLat = lat2 - lat1;
+        var deltaLon = ToRadians(right.Longitude - left.Longitude);
+
+        var sinHalfLat = Math.Sin(deltaLat / 2d);
+        var sinHalfLon = Math.Sin(deltaLon / 2d);
+
+        var a = sinHalfLat * sinHalfLat
+            + Math.Cos(lat1) * Math.Cos(lat2) * sinHalfLon * sinHalfLon;
+
+        var clamped = Math.Min(1d, Math.Max(0d, a));
+        var c = 2d * Math.Asin(Math.Sqrt(clamped));
+
+        return EarthRadiusMeters * c;
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        throw new NotSupportedException("Geographic distance only supports two-dimensional points.");
+    }
+
+    private static double ToRadians(double degrees)
+    {
+        return degrees * (Math.PI / 180d);
+    }
+}

--- a/LiteDB.Spatial.Geographic/Engine/GeographicEngine.cs
+++ b/LiteDB.Spatial.Geographic/Engine/GeographicEngine.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+#nullable enable
+
+/// <summary>
+/// Spatial engine that operates on geographic (longitude/latitude) coordinates.
+/// </summary>
+public sealed class GeographicEngine : ISpatialEngine
+{
+    /// <summary>
+    /// Gets the canonical engine name persisted in metadata.
+    /// </summary>
+    public const string EngineName = "Geographic";
+
+    private readonly GeographicDistance _distance = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicEngine"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">The field that stores coordinates on documents.</param>
+    /// <param name="options">Optional index configuration.</param>
+    public GeographicEngine(string geometryFieldName, SpatialIndexOptions? options = null)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        Mapper = new GeographicMapper(IndexEncoder, geometryFieldName);
+    }
+
+    /// <inheritdoc />
+    public string Name => EngineName;
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance => _distance;
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        var expandedRadius = ExpandRadius(radius);
+        var cover = GeographicIndexing.BuildNearCover(center, expandedRadius);
+        var ranges = BuildRanges(cover.Segments);
+        var description = string.Format(CultureInfo.InvariantCulture, "Haversine distance <= {0:F2} m", radius);
+        return new SpatialQueryPlan(Dimensions, cover.CoveringBounds, ranges, description);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Geographic engine only handles two-dimensional near queries.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic engine expects 2D bounding boxes.", nameof(bounds));
+        }
+
+        var normalized = GeographicIndexing.NormalizeBoundingBox(bounds);
+        var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        var description = string.Format(
+            CultureInfo.InvariantCulture,
+            "Within bounding box [{0:F6}, {1:F6}, {2:F6}, {3:F6}]",
+            bounds.MinX,
+            bounds.MinY,
+            bounds.MaxX,
+            bounds.MaxY);
+
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, description);
+    }
+
+    private IReadOnlyList<SpatialIndexRange> BuildRanges(IReadOnlyList<BoundingBox> segments)
+    {
+        var allRanges = new List<SpatialIndexRange>();
+
+        foreach (var segment in segments)
+        {
+            var normalized = GeographicIndexing.NormalizeBoundingBox(segment);
+            var ranges = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+            allRanges.AddRange(ranges);
+        }
+
+        return MortonIndexEncoder.UnionAdjacentRanges(allRanges);
+    }
+
+    private double ExpandRadius(double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        return radius * (1d + Options.DistanceTolerance);
+    }
+}

--- a/LiteDB.Spatial.Geographic/Engine/GeographicIndexing.cs
+++ b/LiteDB.Spatial.Geographic/Engine/GeographicIndexing.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helpers for geographic indexing and wrap-around aware coverings.
+/// </summary>
+internal static class GeographicIndexing
+{
+    private const double DegreesToRadians = Math.PI / 180d;
+    private const double RadiansToDegrees = 180d / Math.PI;
+
+    /// <summary>
+    /// Normalizes a longitude expressed in degrees to the [0,1] range used by the Morton encoder.
+    /// </summary>
+    public static double NormalizeLongitude(double longitude)
+    {
+        var normalized = NormalizeLongitudeDegrees(longitude);
+        return (normalized + 180d) / 360d;
+    }
+
+    /// <summary>
+    /// Normalizes a latitude expressed in degrees to the [0,1] range used by the Morton encoder.
+    /// </summary>
+    public static double NormalizeLatitude(double latitude)
+    {
+        var clamped = Math.Max(-90d, Math.Min(90d, latitude));
+        return (clamped + 90d) / 180d;
+    }
+
+    /// <summary>
+    /// Builds a near query covering using geodesic math while accounting for wrap-around and poles.
+    /// </summary>
+    /// <param name="center">The circle center in decimal degrees.</param>
+    /// <param name="radiusMeters">The radius in meters.</param>
+    /// <returns>A covering describing the coarse bounds to evaluate.</returns>
+    public static GeographicCover BuildNearCover(GeoPoint center, double radiusMeters)
+    {
+        if (radiusMeters < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radiusMeters), "Radius must be non-negative.");
+        }
+
+        if (radiusMeters == 0d)
+        {
+            var bbox = BoundingBox.From2D(center.Longitude, center.Latitude, center.Longitude, center.Latitude);
+            return new GeographicCover(bbox, new[] { bbox });
+        }
+
+        var angularDistance = radiusMeters / GeographicDistance.EarthRadiusMeters;
+
+        var centerLatRad = center.Latitude * DegreesToRadians;
+        var centerLonRad = center.Longitude * DegreesToRadians;
+
+        var minLat = centerLatRad - angularDistance;
+        var maxLat = centerLatRad + angularDistance;
+
+        minLat = Math.Max(minLat, -Math.PI / 2d);
+        maxLat = Math.Min(maxLat, Math.PI / 2d);
+
+        double minLon;
+        double maxLon;
+
+        if (maxLat >= Math.PI / 2d || minLat <= -Math.PI / 2d)
+        {
+            // Circles touching the poles span the entire longitude range.
+            minLon = -Math.PI;
+            maxLon = Math.PI;
+        }
+        else
+        {
+            var deltaLon = Math.Asin(Math.Sin(angularDistance) / Math.Cos(centerLatRad));
+            minLon = centerLonRad - deltaLon;
+            maxLon = centerLonRad + deltaLon;
+
+            // Normalise so min <= max in the unwrapped domain.
+            if (maxLon - minLon >= 2d * Math.PI)
+            {
+                minLon = -Math.PI;
+                maxLon = Math.PI;
+            }
+        }
+
+        var minLatDeg = minLat * RadiansToDegrees;
+        var maxLatDeg = maxLat * RadiansToDegrees;
+        var rawMinLonDeg = minLon * RadiansToDegrees;
+        var rawMaxLonDeg = maxLon * RadiansToDegrees;
+
+        var segments = BuildLongitudeSegments(rawMinLonDeg, rawMaxLonDeg, minLatDeg, maxLatDeg);
+        var covering = MergeSegments(segments);
+        return covering;
+    }
+
+    /// <summary>
+    /// Converts a geographic bounding box into a normalized representation suitable for Morton encoding.
+    /// </summary>
+    public static BoundingBox NormalizeBoundingBox(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Only 2D bounding boxes can be normalized for the geographic encoder.", nameof(bounds));
+        }
+
+        var values = bounds.ToArray();
+        values[0] = NormalizeLongitude(values[0]);
+        values[1] = NormalizeLatitude(values[1]);
+        values[2] = NormalizeLongitude(values[2]);
+        values[3] = NormalizeLatitude(values[3]);
+        return BoundingBox.Create(values);
+    }
+
+    private static double NormalizeLongitudeDegrees(double longitude)
+    {
+        var result = longitude;
+        while (result < -180d)
+        {
+            result += 360d;
+        }
+
+        while (result > 180d)
+        {
+            result -= 360d;
+        }
+
+        return result;
+    }
+
+    private static GeographicCover MergeSegments(List<BoundingBox> segments)
+    {
+        if (segments.Count == 0)
+        {
+            throw new InvalidOperationException("At least one segment must be produced for a geographic covering.");
+        }
+
+        if (segments.Count == 1)
+        {
+            return new GeographicCover(segments[0], segments);
+        }
+
+        var latMin = segments.Min(s => s.MinY);
+        var latMax = segments.Max(s => s.MaxY);
+        var bounds = BoundingBox.From2D(-180d, latMin, 180d, latMax);
+        return new GeographicCover(bounds, segments);
+    }
+
+    private static List<BoundingBox> BuildLongitudeSegments(double rawMinLon, double rawMaxLon, double minLat, double maxLat)
+    {
+        var normalizedMin = NormalizeLongitudeDegrees(rawMinLon);
+        var normalizedMax = NormalizeLongitudeDegrees(rawMaxLon);
+
+        if (rawMaxLon - rawMinLon >= 360d - 1e-9)
+        {
+            return new List<BoundingBox> { BoundingBox.From2D(-180d, minLat, 180d, maxLat) };
+        }
+
+        if (normalizedMax >= normalizedMin)
+        {
+            return new List<BoundingBox> { BoundingBox.From2D(normalizedMin, minLat, normalizedMax, maxLat) };
+        }
+
+        // Wrap-around: split into two segments.
+        var first = BoundingBox.From2D(normalizedMin, minLat, 180d, maxLat);
+        var second = BoundingBox.From2D(-180d, minLat, normalizedMax, maxLat);
+        return new List<BoundingBox> { first, second };
+    }
+}
+
+/// <summary>
+/// Represents a covering for a geographic query and its associated bounding boxes.
+/// </summary>
+internal readonly struct GeographicCover
+{
+    public GeographicCover(BoundingBox coveringBounds, IReadOnlyList<BoundingBox> segments)
+    {
+        CoveringBounds = coveringBounds;
+        Segments = segments;
+    }
+
+    /// <summary>
+    /// Gets the coarse bounding box applied before exact predicates.
+    /// </summary>
+    public BoundingBox CoveringBounds { get; }
+
+    /// <summary>
+    /// Gets the longitude segments that should be individually converted to Morton ranges.
+    /// </summary>
+    public IReadOnlyList<BoundingBox> Segments { get; }
+}

--- a/LiteDB.Spatial.Geographic/Engine/GeographicMapper.cs
+++ b/LiteDB.Spatial.Geographic/Engine/GeographicMapper.cs
@@ -1,0 +1,130 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps geographic points from application documents into index-friendly representations.
+/// </summary>
+public sealed class GeographicMapper : ISpatialMapper
+{
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly string _geometryFieldName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicMapper"/> class.
+    /// </summary>
+    /// <param name="encoder">The index encoder used to translate coordinates.</param>
+    /// <param name="geometryFieldName">The field that contains geographic coordinates.</param>
+    public GeographicMapper(ISpatialIndexEncoder encoder, string geometryFieldName)
+    {
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryFieldName = string.IsNullOrWhiteSpace(geometryFieldName)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryFieldName;
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper only handles two-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = GeographicIndexing.NormalizeLongitude(point.Longitude);
+        coordinates[1] = GeographicIndexing.NormalizeLatitude(point.Latitude);
+        return _encoder.Encode(coordinates);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper only handles two-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (TryFromArray(geometry, out point))
+        {
+            return true;
+        }
+
+        if (geometry.IsDocument)
+        {
+            var geoDoc = geometry.AsDocument;
+
+            if (geoDoc.TryGetValue("coordinates", out var coordinates) && TryFromArray(coordinates, out point))
+            {
+                return true;
+            }
+
+            if (TryGetNumber(geoDoc, "longitude", out var lon) || TryGetNumber(geoDoc, "lon", out lon) || TryGetNumber(geoDoc, "x", out lon))
+            {
+                if (TryGetNumber(geoDoc, "latitude", out var lat) || TryGetNumber(geoDoc, "lat", out lat) || TryGetNumber(geoDoc, "y", out lat))
+                {
+                    point = new GeoPoint(lon, lat);
+                    return true;
+                }
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryFromArray(BaseLiteDB.BsonValue value, out GeoPoint point)
+    {
+        if (value.IsArray && value.AsArray.Count >= 2 && value.AsArray[0].IsNumber && value.AsArray[1].IsNumber)
+        {
+            var lon = value.AsArray[0].AsDouble;
+            var lat = value.AsArray[1].AsDouble;
+            point = new GeoPoint(lon, lat);
+            return true;
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryGetNumber(BaseLiteDB.BsonDocument document, string name, out double result)
+    {
+        if (document.TryGetValue(name, out var value) && value.IsNumber)
+        {
+            result = value.AsDouble;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Geographic/LiteDB.Spatial.Geographic.csproj
+++ b/LiteDB.Spatial.Geographic/LiteDB.Spatial.Geographic.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Geographic</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Geographic.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/LiteDB.Spatial.Geographic/SpatialGeographic.cs
+++ b/LiteDB.Spatial.Geographic/SpatialGeographic.cs
@@ -1,0 +1,104 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+#nullable enable
+
+/// <summary>
+/// Provides helpers for configuring and planning geographic spatial queries.
+/// </summary>
+public static class SpatialGeographic
+{
+    /// <summary>
+    /// Configures a collection for geographic indexing and persists metadata describing the engine.
+    /// </summary>
+    /// <param name="database">The database hosting the collection.</param>
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <param name="geometryFieldName">The field that stores geographic points.</param>
+    /// <param name="options">Optional index configuration.</param>
+    /// <returns>A descriptor describing the spatial configuration.</returns>
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var resolvedOptions = options ?? new SpatialIndexOptions();
+        var descriptor = new SpatialCollectionDescriptor(
+            collectionName,
+            GeographicEngine.EngineName,
+            2,
+            geometryFieldName,
+            resolvedOptions);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(resolvedOptions.IndexFieldName, BaseLiteDB.BsonExpression.Create("$." + resolvedOptions.IndexFieldName));
+        collection.EnsureIndex(resolvedOptions.BoundingBoxFieldName, BaseLiteDB.BsonExpression.Create("$." + resolvedOptions.BoundingBoxFieldName));
+
+        return descriptor.WithEngine(new GeographicEngine(geometryFieldName, resolvedOptions));
+    }
+
+    /// <summary>
+    /// Builds an index-aware near query plan using the stored descriptor.
+    /// </summary>
+    public static ISpatialQueryPlan Near(SpatialCollectionDescriptor descriptor, GeoPoint center, double radius)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (descriptor.Dimensions != 2)
+        {
+            throw new SpatialMetadataException("Descriptor does not describe a 2D collection.");
+        }
+
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Builds an index-aware bounding box query plan using the stored descriptor.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(SpatialCollectionDescriptor descriptor, BoundingBox bounds)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Bounding boxes must be two-dimensional for geographic queries.", nameof(bounds));
+        }
+
+        var engine = ResolveEngine(descriptor);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static GeographicEngine ResolveEngine(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor.Engine is GeographicEngine geographic)
+        {
+            return geographic;
+        }
+
+        return new GeographicEngine(descriptor.GeometryFieldName, descriptor.Options);
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -44,6 +44,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core", "Lite
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core.Tests", "LiteDB.Spatial.Core.Tests\LiteDB.Spatial.Core.Tests.csproj", "{99F2946D-65FB-4FC8-827D-C3241FB5EF93}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Geographic", "LiteDB.Spatial.Geographic\LiteDB.Spatial.Geographic.csproj", "{565C6587-1138-4CFF-912F-99471D2BB1E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Cartesian2D", "LiteDB.Spatial.Cartesian2D\LiteDB.Spatial.Cartesian2D.csproj", "{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Cartesian3D", "LiteDB.Spatial.Cartesian3D\LiteDB.Spatial.Cartesian3D.csproj", "{12867525-4777-44AF-8723-8E92E8BEDE4B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -186,6 +192,42 @@ Global
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.Build.0 = Release|Any CPU
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.ActiveCfg = Release|Any CPU
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.Build.0 = Release|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Debug|x64.Build.0 = Debug|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Debug|x86.Build.0 = Debug|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Release|x64.ActiveCfg = Release|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Release|x64.Build.0 = Release|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Release|x86.ActiveCfg = Release|Any CPU
+		{565C6587-1138-4CFF-912F-99471D2BB1E8}.Release|x86.Build.0 = Release|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Debug|x86.Build.0 = Debug|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Release|x64.Build.0 = Release|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Release|x86.ActiveCfg = Release|Any CPU
+		{D0AC4003-184D-4A71-9F2F-9E9B50EDA23A}.Release|x86.Build.0 = Release|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Debug|x64.Build.0 = Debug|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Debug|x86.Build.0 = Debug|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Release|x64.ActiveCfg = Release|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Release|x64.Build.0 = Release|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Release|x86.ActiveCfg = Release|Any CPU
+		{12867525-4777-44AF-8723-8E92E8BEDE4B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -96,16 +96,16 @@ LiteDB.Spatial
 
 ### S5 — Geographic engine (2D)
 
-- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
-- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+- [x] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [x] Handle wraparound and polar helpers with tests for real-world coordinates.
 
 ### S6 — Cartesian 2D engine
 
-- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+- [x] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
 
 ### S7 — Cartesian 3D engine (points)
 
-- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+- [x] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
 
 ### S8 — LINQ resolver
 


### PR DESCRIPTION
## Summary
- add the geographic engine with wrap-aware near/box planning, mapper, facade, and coverage tests
- introduce dedicated Cartesian 2D/3D spatial engines with Euclidean planning, mappers, facades, and unit tests
- add a reusable spatial query plan type and mark the spatial revamp checklist items as complete

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e75fa2f94c8326ad2b426f3de99ecd