### PR TITLE
Implement geographic and Cartesian spatial engines

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian/CartesianEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian/CartesianEngineTests.cs
@@ -1,0 +1,39 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Cartesian;
+
+public sealed class CartesianEngineTests
+{
+    [Fact]
+    public void Cartesian2DPlanNearProducesRanges()
+    {
+        var engine = new LiteDB.Spatial.Cartesian2DEngine("position");
+        var plan = engine.PlanNear(new LiteDB.Spatial.GeoPoint(10, 15), 5);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Cartesian3DPlanNearProducesRanges()
+    {
+        var engine = new LiteDB.Spatial.Cartesian3DEngine("position");
+        var plan = engine.PlanNear(new LiteDB.Spatial.GeoPoint3D(1, 2, 3), 2);
+
+        plan.Dimensions.Should().Be(3);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void CartesianMapperRejectsOutOfExtentValues()
+    {
+        var engine = new LiteDB.Spatial.Cartesian2DEngine("position", xExtent: new LiteDB.Spatial.AxisExtent(-1, 1), yExtent: new LiteDB.Spatial.AxisExtent(-1, 1));
+
+        var action = () => engine.Mapper.Encode(new LiteDB.Spatial.GeoPoint(2, 0));
+        action.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*falls outside the configured extent*");
+    }
+}
+

--- a/LiteDB.Spatial.Core.Tests/Engine/Geographic/GeographicEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Geographic/GeographicEngineTests.cs
@@ -1,0 +1,42 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Geographic;
+
+public sealed class GeographicEngineTests
+{
+    [Fact]
+    public void PlanNearReturnsMortonRanges()
+    {
+        var engine = new LiteDB.Spatial.GeographicEngine("location");
+        var plan = engine.PlanNear(new LiteDB.Spatial.GeoPoint(13.4050, 52.5200), 1000);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.ExactPredicateDescription.Should().Contain("1000");
+    }
+
+    [Fact]
+    public void PlanWithinHandlesAntiMeridianBoundingBoxes()
+    {
+        var engine = new LiteDB.Spatial.GeographicEngine("location");
+        var bounds = LiteDB.Spatial.BoundingBox.From2D(170, -10, 190, 10);
+
+        var plan = engine.PlanWithin(bounds);
+
+        plan.IndexRanges.Count.Should().BeGreaterThan(0);
+        plan.CoveringBounds.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapperValidatesLatitudeRange()
+    {
+        var engine = new LiteDB.Spatial.GeographicEngine("location");
+
+        var action = () => engine.Mapper.Encode(new LiteDB.Spatial.GeoPoint(0, 95));
+        action.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*Latitude must be within [-90, 90]*");
+    }
+}
+

--- a/LiteDB.Spatial.Core.Tests/Facades/SpatialFacadeTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Facades/SpatialFacadeTests.cs
@@ -1,0 +1,48 @@
+extern alias LiteDbBase;
+
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Facades;
+
+public sealed class SpatialFacadeTests
+{
+    [Fact]
+    public void GeographicFacadePersistsMetadataAndPlansNearQueries()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+
+        var descriptor = LiteDB.Spatial.SpatialGeographic.EnsurePointIndex(database, "places", "location");
+
+        descriptor.EngineName.Should().Contain("Geographic");
+
+        var plan = LiteDB.Spatial.SpatialGeographic.Near(database, "places", new LiteDB.Spatial.GeoPoint(0, 0), 500);
+        plan.Dimensions.Should().Be(2);
+    }
+
+    [Fact]
+    public void Cartesian2DFacadeConfiguresCollection()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+
+        var descriptor = LiteDB.Spatial.SpatialCartesian2D.EnsurePointIndex(database, "points", "position");
+        descriptor.EngineName.Should().Be(LiteDB.Spatial.Cartesian2DEngine.EngineName);
+
+        var plan = LiteDB.Spatial.SpatialCartesian2D.WithinBoundingBox(database, "points", LiteDB.Spatial.BoundingBox.From2D(-1, -1, 1, 1));
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Cartesian3DFacadeSupportsNearQueries()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+
+        LiteDB.Spatial.SpatialCartesian3D.EnsurePointIndex(database, "cloud", "position");
+
+        var plan = LiteDB.Spatial.SpatialCartesian3D.Near(database, "cloud", new LiteDB.Spatial.GeoPoint3D(0, 0, 0), 5);
+        plan.Dimensions.Should().Be(3);
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/Cartesian/AxisExtent.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/AxisExtent.cs
@@ -1,0 +1,104 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents the valid extent of a Cartesian axis and provides normalization helpers.
+/// </summary>
+public readonly struct AxisExtent
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AxisExtent"/> struct.
+    /// </summary>
+    /// <param name="minimum">Minimum supported value.</param>
+    /// <param name="maximum">Maximum supported value.</param>
+    public AxisExtent(double minimum, double maximum)
+    {
+        if (double.IsNaN(minimum) || double.IsInfinity(minimum))
+        {
+            throw new ArgumentException("Axis minimum must be a finite number.", nameof(minimum));
+        }
+
+        if (double.IsNaN(maximum) || double.IsInfinity(maximum))
+        {
+            throw new ArgumentException("Axis maximum must be a finite number.", nameof(maximum));
+        }
+
+        if (maximum <= minimum)
+        {
+            throw new ArgumentException("Axis maximum must be greater than the minimum.", nameof(maximum));
+        }
+
+        Minimum = minimum;
+        Maximum = maximum;
+    }
+
+    /// <summary>
+    /// Gets the minimum supported value.
+    /// </summary>
+    public double Minimum { get; }
+
+    /// <summary>
+    /// Gets the maximum supported value.
+    /// </summary>
+    public double Maximum { get; }
+
+    /// <summary>
+    /// Gets the span covered by the extent.
+    /// </summary>
+    public double Span => Maximum - Minimum;
+
+    /// <summary>
+    /// Normalizes the provided coordinate into the unit interval.
+    /// </summary>
+    /// <param name="value">Coordinate to normalize.</param>
+    /// <returns>Normalized coordinate between 0 and 1.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when value lies outside the extent.</exception>
+    public double Normalize(double value)
+    {
+        if (value < Minimum || value > Maximum)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), $"Coordinate {value} falls outside the configured extent [{Minimum}, {Maximum}].");
+        }
+
+        var normalized = (value - Minimum) / Span;
+
+        if (normalized < 0d)
+        {
+            return 0d;
+        }
+
+        if (normalized > 1d)
+        {
+            return 1d;
+        }
+
+        return normalized;
+    }
+
+    /// <summary>
+    /// Clamps the provided value to the configured extent.
+    /// </summary>
+    public double Clamp(double value)
+    {
+        if (value < Minimum)
+        {
+            return Minimum;
+        }
+
+        if (value > Maximum)
+        {
+            return Maximum;
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Gets a default extent suitable for many engineering scenarios.
+    /// </summary>
+    public static AxisExtent Default => new AxisExtent(-1_000_000d, 1_000_000d);
+}
+

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian2DEngine.cs
@@ -1,0 +1,146 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Spatial engine dedicated to two-dimensional Cartesian coordinates.
+/// </summary>
+public sealed class Cartesian2DEngine : ISpatialEngine
+{
+    /// <summary>
+    /// The engine name persisted with metadata.
+    /// </summary>
+    public const string EngineName = "Cartesian2D";
+
+    private readonly AxisExtent _xExtent;
+    private readonly AxisExtent _yExtent;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian2DEngine"/> class.
+    /// </summary>
+    public Cartesian2DEngine(
+        string geometryFieldName,
+        SpatialIndexOptions? options = null,
+        AxisExtent? xExtent = null,
+        AxisExtent? yExtent = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        _xExtent = xExtent ?? AxisExtent.Default;
+        _yExtent = yExtent ?? AxisExtent.Default;
+
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        Mapper = new CartesianMapper(geometryFieldName, IndexEncoder, _xExtent, _yExtent);
+        Distance = new CartesianDistance();
+    }
+
+    /// <inheritdoc />
+    public string Name => EngineName;
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance { get; }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+        var minX = _xExtent.Clamp(center.Longitude - effectiveRadius);
+        var minY = _yExtent.Clamp(center.Latitude - effectiveRadius);
+        var maxX = _xExtent.Clamp(center.Longitude + effectiveRadius);
+        var maxY = _yExtent.Clamp(center.Latitude + effectiveRadius);
+
+        var ranges = CoverBounds(minX, minY, maxX, maxY);
+        var coveringBounds = BoundingBox.From2D(
+            _xExtent.Normalize(minX),
+            _yExtent.Normalize(minY),
+            _xExtent.Normalize(maxX),
+            _yExtent.Normalize(maxY));
+
+        var description = string.Format(CultureInfo.InvariantCulture, "Euclidean distance <= {0}", radius);
+        return new SpatialQueryPlan(Dimensions, coveringBounds, ranges, description);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Cartesian2D engine does not support three-dimensional near queries.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Cartesian2D engine expects a two-dimensional bounding box.", nameof(bounds));
+        }
+
+        var minX = _xExtent.Clamp(bounds.MinX);
+        var minY = _yExtent.Clamp(bounds.MinY);
+        var maxX = _xExtent.Clamp(bounds.MaxX);
+        var maxY = _yExtent.Clamp(bounds.MaxY);
+
+        var ranges = CoverBounds(minX, minY, maxX, maxY);
+        var coveringBounds = BoundingBox.From2D(
+            _xExtent.Normalize(minX),
+            _yExtent.Normalize(minY),
+            _xExtent.Normalize(maxX),
+            _yExtent.Normalize(maxY));
+
+        return new SpatialQueryPlan(Dimensions, coveringBounds, ranges, "Within Cartesian bounding box");
+    }
+
+    /// <summary>
+    /// Instantiates an engine from a stored descriptor.
+    /// </summary>
+    public static Cartesian2DEngine FromDescriptor(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (!string.Equals(descriptor.EngineName, EngineName, StringComparison.Ordinal))
+        {
+            throw new SpatialMetadataException($"Collection '{descriptor.CollectionName}' is configured with engine '{descriptor.EngineName}' which is incompatible with Cartesian2D facade operations.");
+        }
+
+        return new Cartesian2DEngine(descriptor.GeometryFieldName, descriptor.Options);
+    }
+
+    private IReadOnlyList<SpatialIndexRange> CoverBounds(double minX, double minY, double maxX, double maxY)
+    {
+        var normalized = BoundingBox.From2D(
+            _xExtent.Normalize(minX),
+            _yExtent.Normalize(minY),
+            _xExtent.Normalize(maxX),
+            _yExtent.Normalize(maxY));
+
+        return IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/Cartesian3DEngine.cs
@@ -1,0 +1,157 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Spatial engine for three-dimensional Cartesian coordinates.
+/// </summary>
+public sealed class Cartesian3DEngine : ISpatialEngine
+{
+    /// <summary>
+    /// The engine name persisted with metadata.
+    /// </summary>
+    public const string EngineName = "Cartesian3D";
+
+    private readonly AxisExtent _xExtent;
+    private readonly AxisExtent _yExtent;
+    private readonly AxisExtent _zExtent;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cartesian3DEngine"/> class.
+    /// </summary>
+    public Cartesian3DEngine(
+        string geometryFieldName,
+        SpatialIndexOptions? options = null,
+        AxisExtent? xExtent = null,
+        AxisExtent? yExtent = null,
+        AxisExtent? zExtent = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        _xExtent = xExtent ?? AxisExtent.Default;
+        _yExtent = yExtent ?? AxisExtent.Default;
+        _zExtent = zExtent ?? AxisExtent.Default;
+
+        IndexEncoder = new MortonIndexEncoder(3, Options.PrecisionBits);
+        Mapper = new CartesianMapper(geometryFieldName, IndexEncoder, _xExtent, _yExtent, _zExtent);
+        Distance = new CartesianDistance();
+    }
+
+    /// <inheritdoc />
+    public string Name => EngineName;
+
+    /// <inheritdoc />
+    public int Dimensions => 3;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance { get; }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        throw new NotSupportedException("Cartesian3D engine requires three-dimensional coordinates.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+        var minX = _xExtent.Clamp(center.X - effectiveRadius);
+        var minY = _yExtent.Clamp(center.Y - effectiveRadius);
+        var minZ = _zExtent.Clamp(center.Z - effectiveRadius);
+        var maxX = _xExtent.Clamp(center.X + effectiveRadius);
+        var maxY = _yExtent.Clamp(center.Y + effectiveRadius);
+        var maxZ = _zExtent.Clamp(center.Z + effectiveRadius);
+
+        var ranges = CoverBounds(minX, minY, minZ, maxX, maxY, maxZ);
+        var coveringBounds = BoundingBox.From3D(
+            _xExtent.Normalize(minX),
+            _yExtent.Normalize(minY),
+            _zExtent.Normalize(minZ),
+            _xExtent.Normalize(maxX),
+            _yExtent.Normalize(maxY),
+            _zExtent.Normalize(maxZ));
+
+        return new SpatialQueryPlan(Dimensions, coveringBounds, ranges, "Within Cartesian radius");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 3)
+        {
+            throw new ArgumentException("Cartesian3D engine expects a three-dimensional bounding box.", nameof(bounds));
+        }
+
+        var minX = _xExtent.Clamp(bounds.MinX);
+        var minY = _yExtent.Clamp(bounds.MinY);
+        var minZ = _zExtent.Clamp(bounds.MinZ);
+        var maxX = _xExtent.Clamp(bounds.MaxX);
+        var maxY = _yExtent.Clamp(bounds.MaxY);
+        var maxZ = _zExtent.Clamp(bounds.MaxZ);
+
+        var ranges = CoverBounds(minX, minY, minZ, maxX, maxY, maxZ);
+        var coveringBounds = BoundingBox.From3D(
+            _xExtent.Normalize(minX),
+            _yExtent.Normalize(minY),
+            _zExtent.Normalize(minZ),
+            _xExtent.Normalize(maxX),
+            _yExtent.Normalize(maxY),
+            _zExtent.Normalize(maxZ));
+
+        return new SpatialQueryPlan(Dimensions, coveringBounds, ranges, "Within 3D Cartesian bounding box");
+    }
+
+    /// <summary>
+    /// Instantiates an engine from persisted metadata.
+    /// </summary>
+    public static Cartesian3DEngine FromDescriptor(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (!string.Equals(descriptor.EngineName, EngineName, StringComparison.Ordinal))
+        {
+            throw new SpatialMetadataException($"Collection '{descriptor.CollectionName}' is configured with engine '{descriptor.EngineName}' which is incompatible with Cartesian3D facade operations.");
+        }
+
+        return new Cartesian3DEngine(descriptor.GeometryFieldName, descriptor.Options);
+    }
+
+    private IReadOnlyList<SpatialIndexRange> CoverBounds(double minX, double minY, double minZ, double maxX, double maxY, double maxZ)
+    {
+        var normalized = BoundingBox.From3D(
+            _xExtent.Normalize(minX),
+            _yExtent.Normalize(minY),
+            _zExtent.Normalize(minZ),
+            _xExtent.Normalize(maxX),
+            _yExtent.Normalize(maxY),
+            _zExtent.Normalize(maxZ));
+
+        return IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/Cartesian/CartesianDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/CartesianDistance.cs
@@ -1,0 +1,29 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes Euclidean distances for Cartesian coordinates.
+/// </summary>
+public sealed class CartesianDistance : ISpatialDistance
+{
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var dx = right.Longitude - left.Longitude;
+        var dy = right.Latitude - left.Latitude;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = right.X - left.X;
+        var dy = right.Y - left.Y;
+        var dz = right.Z - left.Z;
+        return Math.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/Cartesian/CartesianMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Cartesian/CartesianMapper.cs
@@ -1,0 +1,227 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps Cartesian coordinates into Morton encoded values.
+/// </summary>
+public sealed class CartesianMapper : ISpatialMapper
+{
+    private readonly string _geometryFieldName;
+    private readonly ISpatialIndexEncoder _encoder;
+    private readonly AxisExtent _xExtent;
+    private readonly AxisExtent _yExtent;
+    private readonly AxisExtent? _zExtent;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CartesianMapper"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">Field that stores the coordinate.</param>
+    /// <param name="encoder">Index encoder.</param>
+    /// <param name="xExtent">Extent for the X axis.</param>
+    /// <param name="yExtent">Extent for the Y axis.</param>
+    /// <param name="zExtent">Optional Z extent for 3D configurations.</param>
+    public CartesianMapper(
+        string geometryFieldName,
+        ISpatialIndexEncoder encoder,
+        AxisExtent xExtent,
+        AxisExtent yExtent,
+        AxisExtent? zExtent = null)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        _geometryFieldName = geometryFieldName;
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _xExtent = xExtent;
+        _yExtent = yExtent;
+        _zExtent = zExtent;
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> values = stackalloc double[2];
+        values[0] = _xExtent.Normalize(point.Longitude);
+        values[1] = _yExtent.Normalize(point.Latitude);
+        return _encoder.Encode(values);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint3D point)
+    {
+        if (_zExtent is null)
+        {
+            throw new NotSupportedException("The mapper is configured for two-dimensional coordinates.");
+        }
+
+        Span<double> values = stackalloc double[3];
+        values[0] = _xExtent.Normalize(point.X);
+        values[1] = _yExtent.Normalize(point.Y);
+        values[2] = _zExtent.Value.Normalize(point.Z);
+        return _encoder.Encode(values);
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            return false;
+        }
+
+        if (!TryExtractComponents(geometry, out var x, out var y, out var z, expectZ: false))
+        {
+            return false;
+        }
+
+        point = new GeoPoint(x, y);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+
+        if (_zExtent is null)
+        {
+            return false;
+        }
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            return false;
+        }
+
+        if (!TryExtractComponents(geometry, out var x, out var y, out var z, expectZ: true))
+        {
+            return false;
+        }
+
+        point = new GeoPoint3D(x, y, z);
+        return true;
+    }
+
+    private static bool TryExtractComponents(BaseLiteDB.BsonValue value, out double x, out double y, out double z, bool expectZ)
+    {
+        x = 0d;
+        y = 0d;
+        z = 0d;
+
+        if (value.IsDocument)
+        {
+            var doc = value.AsDocument;
+
+            if (TryReadDouble(doc, "x", out x) && TryReadDouble(doc, "y", out y))
+            {
+                if (expectZ)
+                {
+                    return TryReadDouble(doc, "z", out z);
+                }
+
+                return true;
+            }
+
+            if (doc.TryGetValue("coordinates", out var coords) && coords.IsArray)
+            {
+                return TryExtractFromArray(coords.AsArray, out x, out y, out z, expectZ);
+            }
+        }
+        else if (value.IsArray)
+        {
+            return TryExtractFromArray(value.AsArray, out x, out y, out z, expectZ);
+        }
+
+        return false;
+    }
+
+    private static bool TryExtractFromArray(BaseLiteDB.BsonArray array, out double x, out double y, out double z, bool expectZ)
+    {
+        x = 0d;
+        y = 0d;
+        z = 0d;
+
+        var expectedCount = expectZ ? 3 : 2;
+        if (array.Count < expectedCount)
+        {
+            return false;
+        }
+
+        if (!TryReadDouble(array[0], out x) || !TryReadDouble(array[1], out y))
+        {
+            return false;
+        }
+
+        if (expectZ)
+        {
+            return TryReadDouble(array[2], out z);
+        }
+
+        return true;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonDocument document, string field, out double value)
+    {
+        value = 0d;
+
+        if (!document.TryGetValue(field, out var bson) || bson.IsNull)
+        {
+            return false;
+        }
+
+        return TryReadDouble(bson, out value);
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonValue value, out double result)
+    {
+        if (value.IsDouble)
+        {
+            result = value.AsDouble;
+            return true;
+        }
+
+        if (value.IsDecimal)
+        {
+            result = (double)value.AsDecimal;
+            return true;
+        }
+
+        if (value.IsInt32)
+        {
+            result = value.AsInt32;
+            return true;
+        }
+
+        if (value.IsInt64)
+        {
+            result = value.AsInt64;
+            return true;
+        }
+
+        result = 0d;
+        return false;
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistance.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicDistance.cs
@@ -1,0 +1,59 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides distance calculations for geographic coordinates.
+/// </summary>
+public sealed class GeographicDistance : ISpatialDistance
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicDistance"/> class.
+    /// </summary>
+    /// <param name="mode">The distance mode used to calculate the arc length.</param>
+    public GeographicDistance(GeographicDistanceMode mode)
+    {
+        Mode = mode;
+    }
+
+    /// <summary>
+    /// Gets the configured distance mode.
+    /// </summary>
+    public GeographicDistanceMode Mode { get; }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        return Mode switch
+        {
+            GeographicDistanceMode.Haversine => GeographicMath.HaversineDistance(left, right),
+            GeographicDistanceMode.Vincenty => GeographicMath.VincentyDistance(left, right),
+            _ => GeographicMath.HaversineDistance(left, right)
+        };
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        throw new NotSupportedException("Geographic distance is defined only for two-dimensional coordinates.");
+    }
+}
+
+/// <summary>
+/// Distance formulas supported by the geographic engine.
+/// </summary>
+public enum GeographicDistanceMode
+{
+    /// <summary>
+    /// Uses a spherical Haversine approximation.
+    /// </summary>
+    Haversine,
+
+    /// <summary>
+    /// Uses the WGS84 Vincenty iterative solution.
+    /// </summary>
+    Vincenty
+}
+

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicEngine.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicEngine.cs
@@ -1,0 +1,225 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides geographic spatial planning against Morton encoded indexes.
+/// </summary>
+public sealed class GeographicEngine : ISpatialEngine
+{
+    /// <summary>
+    /// The engine family name used when persisting metadata.
+    /// </summary>
+    public const string EngineFamilyName = "Geographic";
+
+    private readonly GeographicDistanceMode _distanceMode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicEngine"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">The document field that contains the coordinate.</param>
+    /// <param name="options">Index options.</param>
+    /// <param name="distanceMode">Distance calculation mode.</param>
+    public GeographicEngine(
+        string geometryFieldName,
+        SpatialIndexOptions? options = null,
+        GeographicDistanceMode distanceMode = GeographicDistanceMode.Haversine)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        Mapper = new GeographicMapper(geometryFieldName, IndexEncoder);
+        Distance = new GeographicDistance(distanceMode);
+        _distanceMode = distanceMode;
+    }
+
+    /// <inheritdoc />
+    public string Name => GetEngineName(_distanceMode);
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance { get; }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be non-negative.");
+        }
+
+        var effectiveRadius = radius + Options.DistanceTolerance;
+        var (minLon, minLat, maxLon, maxLat) = GeographicMath.BoundingBoxForCircle(center, effectiveRadius);
+
+        var ranges = CoverGeographicBounds(minLon, minLat, maxLon, maxLat);
+        var coveringBounds = CreateCoveringBounds(minLon, minLat, maxLon, maxLat, ranges.Count);
+        var description = string.Format(CultureInfo.InvariantCulture, "Distance <= {0} m ({1})", radius, _distanceMode);
+
+        return new SpatialQueryPlan(Dimensions, coveringBounds, ranges, description);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Geographic engine does not support three-dimensional near queries.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic engine expects a two-dimensional bounding box.", nameof(bounds));
+        }
+
+        var minLat = GeographicMath.ClampLatitude(bounds.MinY);
+        var maxLat = GeographicMath.ClampLatitude(bounds.MaxY);
+        var minLon = bounds.MinX;
+        var maxLon = bounds.MaxX;
+
+        var ranges = CoverGeographicBounds(minLon, minLat, maxLon, maxLat);
+        var coveringBounds = CreateCoveringBounds(minLon, minLat, maxLon, maxLat, ranges.Count);
+        var description = "Within geographic bounding box";
+
+        return new SpatialQueryPlan(Dimensions, coveringBounds, ranges, description);
+    }
+
+    /// <summary>
+    /// Converts the stored engine name into the distance mode and constructs a concrete engine.
+    /// </summary>
+    public static GeographicEngine FromDescriptor(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (!TryParseMode(descriptor.EngineName, out var mode))
+        {
+            throw new SpatialMetadataException($"Collection '{descriptor.CollectionName}' is configured with engine '{descriptor.EngineName}' that is not compatible with the geographic engine facade.");
+        }
+
+        return new GeographicEngine(descriptor.GeometryFieldName, descriptor.Options, mode);
+    }
+
+    /// <summary>
+    /// Produces the persisted engine name for the supplied distance mode.
+    /// </summary>
+    public static string GetEngineName(GeographicDistanceMode mode)
+    {
+        return mode switch
+        {
+            GeographicDistanceMode.Haversine => EngineFamilyName + " (Haversine)",
+            GeographicDistanceMode.Vincenty => EngineFamilyName + " (Vincenty)",
+            _ => EngineFamilyName
+        };
+    }
+
+    /// <summary>
+    /// Attempts to parse the persisted engine name into a distance mode.
+    /// </summary>
+    public static bool TryParseMode(string engineName, out GeographicDistanceMode mode)
+    {
+        mode = GeographicDistanceMode.Haversine;
+
+        if (string.IsNullOrWhiteSpace(engineName))
+        {
+            return false;
+        }
+
+        if (!engineName.StartsWith(EngineFamilyName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (engineName.Contains("Vincenty", StringComparison.OrdinalIgnoreCase))
+        {
+            mode = GeographicDistanceMode.Vincenty;
+        }
+        else
+        {
+            mode = GeographicDistanceMode.Haversine;
+        }
+
+        return true;
+    }
+
+    private IReadOnlyList<SpatialIndexRange> CoverGeographicBounds(double minLon, double minLat, double maxLon, double maxLat)
+    {
+        var latMin = GeographicMath.ClampLatitude(minLat);
+        var latMax = GeographicMath.ClampLatitude(maxLat);
+        var segments = GeographicMath.SplitLongitudeRange(minLon, maxLon);
+        var ranges = new List<SpatialIndexRange>();
+
+        foreach (var segment in segments)
+        {
+            var minLonUnit = GeographicMath.NormalizeLongitudeToUnit(segment.Min);
+            var maxLonUnit = GeographicMath.NormalizeLongitudeToUnit(segment.Max);
+
+            if (maxLonUnit < minLonUnit)
+            {
+                (minLonUnit, maxLonUnit) = (maxLonUnit, minLonUnit);
+            }
+
+            var normalizedBounds = BoundingBox.From2D(
+                minLonUnit,
+                GeographicMath.NormalizeLatitudeToUnit(latMin),
+                maxLonUnit,
+                GeographicMath.NormalizeLatitudeToUnit(latMax));
+
+            var segmentRanges = IndexEncoder.Cover(normalizedBounds, Options.MaxCoveringCells);
+            ranges.AddRange(segmentRanges);
+        }
+
+        return MortonIndexEncoder.UnionAdjacentRanges(ranges);
+    }
+
+    private BoundingBox? CreateCoveringBounds(double minLon, double minLat, double maxLon, double maxLat, int rangeCount)
+    {
+        if (rangeCount == 0)
+        {
+            return null;
+        }
+
+        var segments = GeographicMath.SplitLongitudeRange(minLon, maxLon);
+        if (segments.Count > 1)
+        {
+            return null;
+        }
+
+        var segment = segments[0];
+        var minLonUnit = GeographicMath.NormalizeLongitudeToUnit(segment.Min);
+        var maxLonUnit = GeographicMath.NormalizeLongitudeToUnit(segment.Max);
+
+        if (maxLonUnit < minLonUnit)
+        {
+            (minLonUnit, maxLonUnit) = (maxLonUnit, minLonUnit);
+        }
+
+        return BoundingBox.From2D(
+            minLonUnit,
+            GeographicMath.NormalizeLatitudeToUnit(minLat),
+            maxLonUnit,
+            GeographicMath.NormalizeLatitudeToUnit(maxLat));
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicMapper.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicMapper.cs
@@ -1,0 +1,212 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps geographic values from documents into Morton encoded index entries.
+/// </summary>
+public sealed class GeographicMapper : ISpatialMapper
+{
+    private readonly string _geometryFieldName;
+    private readonly ISpatialIndexEncoder _encoder;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicMapper"/> class.
+    /// </summary>
+    /// <param name="geometryFieldName">The document field that stores the coordinate.</param>
+    /// <param name="encoder">The encoder responsible for quantising coordinates.</param>
+    public GeographicMapper(string geometryFieldName, ISpatialIndexEncoder encoder)
+    {
+        if (string.IsNullOrWhiteSpace(geometryFieldName))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryFieldName));
+        }
+
+        _geometryFieldName = geometryFieldName;
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        ValidateCoordinate(point.Longitude, point.Latitude);
+        var lon = GeographicMath.NormalizeLongitude(point.Longitude);
+        var lat = GeographicMath.ClampLatitude(point.Latitude);
+        return BoundingBox.From2D(lon, lat, lon, lat);
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapping is limited to two-dimensional coordinates.");
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint point)
+    {
+        ValidateCoordinate(point.Longitude, point.Latitude);
+        Span<double> values = stackalloc double[2];
+        values[0] = GeographicMath.NormalizeLongitudeToUnit(point.Longitude);
+        values[1] = GeographicMath.NormalizeLatitudeToUnit(point.Latitude);
+        return _encoder.Encode(values);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapping is limited to two-dimensional coordinates.");
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+
+        if (!document.TryGetValue(_geometryFieldName, out var geometry) || geometry.IsNull)
+        {
+            return false;
+        }
+
+        if (!TryParseLongitudeLatitude(geometry, out var longitude, out var latitude))
+        {
+            return false;
+        }
+
+        ValidateCoordinate(longitude, latitude);
+        point = new GeoPoint(longitude, latitude);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static void ValidateCoordinate(double longitude, double latitude)
+    {
+        if (double.IsNaN(longitude) || double.IsInfinity(longitude))
+        {
+            throw new ArgumentOutOfRangeException(nameof(longitude), "Longitude must be a finite number.");
+        }
+
+        if (double.IsNaN(latitude) || double.IsInfinity(latitude))
+        {
+            throw new ArgumentOutOfRangeException(nameof(latitude), "Latitude must be a finite number.");
+        }
+
+        if (latitude < -90d || latitude > 90d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(latitude), "Latitude must be within [-90, 90] degrees.");
+        }
+
+        if (longitude < -720d || longitude > 720d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(longitude), "Longitude exceeds supported wraparound bounds.");
+        }
+    }
+
+    private static bool TryParseLongitudeLatitude(BaseLiteDB.BsonValue geometry, out double longitude, out double latitude)
+    {
+        longitude = 0d;
+        latitude = 0d;
+
+        if (geometry.IsDocument)
+        {
+            var doc = geometry.AsDocument;
+
+            if (TryReadDouble(doc, "longitude", out longitude) && TryReadDouble(doc, "latitude", out latitude))
+            {
+                return true;
+            }
+
+            if (TryReadDouble(doc, "lon", out longitude) && TryReadDouble(doc, "lat", out latitude))
+            {
+                return true;
+            }
+
+            if (TryReadDouble(doc, "lng", out longitude) && TryReadDouble(doc, "lat", out latitude))
+            {
+                return true;
+            }
+
+            if (doc.TryGetValue("coordinates", out var coordinates) && coordinates.IsArray && coordinates.AsArray.Count >= 2)
+            {
+                return TryReadArray(coordinates.AsArray, out longitude, out latitude);
+            }
+        }
+        else if (geometry.IsArray)
+        {
+            return TryReadArray(geometry.AsArray, out longitude, out latitude);
+        }
+
+        return false;
+    }
+
+    private static bool TryReadArray(BaseLiteDB.BsonArray array, out double longitude, out double latitude)
+    {
+        longitude = 0d;
+        latitude = 0d;
+
+        if (array.Count < 2)
+        {
+            return false;
+        }
+
+        if (!TryReadDouble(array[0], out longitude) || !TryReadDouble(array[1], out latitude))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonDocument document, string field, out double value)
+    {
+        value = 0d;
+
+        if (!document.TryGetValue(field, out var bson) || bson.IsNull)
+        {
+            return false;
+        }
+
+        return TryReadDouble(bson, out value);
+    }
+
+    private static bool TryReadDouble(BaseLiteDB.BsonValue value, out double result)
+    {
+        if (value.IsDouble)
+        {
+            result = value.AsDouble;
+            return true;
+        }
+
+        if (value.IsDecimal)
+        {
+            result = (double)value.AsDecimal;
+            return true;
+        }
+
+        if (value.IsInt32)
+        {
+            result = value.AsInt32;
+            return true;
+        }
+
+        if (value.IsInt64)
+        {
+            result = value.AsInt64;
+            return true;
+        }
+
+        result = 0d;
+        return false;
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/Geographic/GeographicMath.cs
+++ b/LiteDB.Spatial.Core/Engine/Geographic/GeographicMath.cs
@@ -1,0 +1,294 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helpers for geographic calculations that work in degrees.
+/// </summary>
+internal static class GeographicMath
+{
+    /// <summary>
+    /// Average earth radius expressed in meters (spherical model).
+    /// </summary>
+    public const double EarthRadiusMeters = 6_371_000d;
+
+    private const double DegToRad = Math.PI / 180d;
+    private const double RadToDeg = 180d / Math.PI;
+
+    private const double Wgs84EquatorialRadius = 6_378_137d;
+    private const double Wgs84Flattening = 1d / 298.257223563d;
+    private const double Wgs84PolarRadius = Wgs84EquatorialRadius * (1d - Wgs84Flattening);
+
+    public static double ToRadians(double degrees)
+    {
+        return degrees * DegToRad;
+    }
+
+    public static double ToDegrees(double radians)
+    {
+        return radians * RadToDeg;
+    }
+
+    public static double NormalizeLongitude(double longitude)
+    {
+        if (double.IsNaN(longitude))
+        {
+            return longitude;
+        }
+
+        var wrapped = longitude % 360d;
+        if (wrapped <= -180d)
+        {
+            wrapped += 360d;
+        }
+        else if (wrapped > 180d)
+        {
+            wrapped -= 360d;
+        }
+
+        return wrapped;
+    }
+
+    public static double ClampLatitude(double latitude)
+    {
+        if (double.IsNaN(latitude))
+        {
+            return latitude;
+        }
+
+        if (latitude < -90d)
+        {
+            return -90d;
+        }
+
+        if (latitude > 90d)
+        {
+            return 90d;
+        }
+
+        return latitude;
+    }
+
+    public static double NormalizeLongitudeToUnit(double longitude)
+    {
+        var wrapped = NormalizeLongitude(longitude);
+        return (wrapped + 180d) / 360d;
+    }
+
+    public static double NormalizeLatitudeToUnit(double latitude)
+    {
+        var clamped = ClampLatitude(latitude);
+        return (clamped + 90d) / 180d;
+    }
+
+    public static IReadOnlyList<(double Min, double Max)> SplitLongitudeRange(double minLongitude, double maxLongitude)
+    {
+        if (double.IsNaN(minLongitude) || double.IsInfinity(minLongitude))
+        {
+            throw new ArgumentException("Longitude bounds must be finite numbers.", nameof(minLongitude));
+        }
+
+        if (double.IsNaN(maxLongitude) || double.IsInfinity(maxLongitude))
+        {
+            throw new ArgumentException("Longitude bounds must be finite numbers.", nameof(maxLongitude));
+        }
+
+        if (maxLongitude - minLongitude >= 360d)
+        {
+            return new[] { (-180d, 180d) };
+        }
+
+        var normalizedMin = NormalizeLongitude(minLongitude);
+        var normalizedMax = NormalizeLongitude(maxLongitude);
+
+        if (minLongitude < -180d && maxLongitude > 180d)
+        {
+            return new[] { (-180d, 180d) };
+        }
+
+        if (normalizedMin <= normalizedMax && maxLongitude <= 180d && minLongitude >= -180d)
+        {
+            return new[] { (normalizedMin, normalizedMax) };
+        }
+
+        if (maxLongitude > 180d && minLongitude <= 180d)
+        {
+            return new[]
+            {
+                (NormalizeLongitude(minLongitude), 180d),
+                (-180d, NormalizeLongitude(maxLongitude))
+            };
+        }
+
+        if (minLongitude < -180d && maxLongitude >= -180d)
+        {
+            return new[]
+            {
+                (NormalizeLongitude(minLongitude), 180d),
+                (-180d, NormalizeLongitude(maxLongitude))
+            };
+        }
+
+        if (normalizedMin <= normalizedMax)
+        {
+            return new[] { (normalizedMin, normalizedMax) };
+        }
+
+        return new[]
+        {
+            (normalizedMin, 180d),
+            (-180d, normalizedMax)
+        };
+    }
+
+    public static (double MinLongitude, double MinLatitude, double MaxLongitude, double MaxLatitude) BoundingBoxForCircle(
+        GeoPoint center,
+        double radiusMeters)
+    {
+        if (radiusMeters < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radiusMeters), "Radius must be non-negative.");
+        }
+
+        var angularDistance = radiusMeters / EarthRadiusMeters;
+        var latitudeRadians = ToRadians(center.Latitude);
+
+        var minLatRadians = latitudeRadians - angularDistance;
+        var maxLatRadians = latitudeRadians + angularDistance;
+
+        var minLatitude = ClampLatitude(ToDegrees(minLatRadians));
+        var maxLatitude = ClampLatitude(ToDegrees(maxLatRadians));
+
+        double minLongitude;
+        double maxLongitude;
+
+        if (minLatitude <= -90d || maxLatitude >= 90d)
+        {
+            minLongitude = -180d;
+            maxLongitude = 180d;
+        }
+        else
+        {
+            var deltaLongitude = Math.Asin(Math.Sin(angularDistance) / Math.Cos(latitudeRadians));
+
+            if (double.IsNaN(deltaLongitude))
+            {
+                minLongitude = -180d;
+                maxLongitude = 180d;
+            }
+            else
+            {
+                var longitudeRadians = ToRadians(center.Longitude);
+                minLongitude = ToDegrees(longitudeRadians - deltaLongitude);
+                maxLongitude = ToDegrees(longitudeRadians + deltaLongitude);
+            }
+        }
+
+        return (minLongitude, minLatitude, maxLongitude, maxLatitude);
+    }
+
+    public static double HaversineDistance(GeoPoint left, GeoPoint right)
+    {
+        var lat1 = ToRadians(left.Latitude);
+        var lat2 = ToRadians(right.Latitude);
+        var dLat = lat2 - lat1;
+        var dLon = ToRadians(NormalizeLongitude(right.Longitude - left.Longitude));
+
+        var sinLat = Math.Sin(dLat / 2d);
+        var sinLon = Math.Sin(dLon / 2d);
+        var cosLat1 = Math.Cos(lat1);
+        var cosLat2 = Math.Cos(lat2);
+
+        var hav = sinLat * sinLat + cosLat1 * cosLat2 * sinLon * sinLon;
+        hav = Math.Min(1d, Math.Max(0d, hav));
+
+        var c = 2d * Math.Atan2(Math.Sqrt(hav), Math.Sqrt(Math.Max(0d, 1d - hav)));
+        return EarthRadiusMeters * c;
+    }
+
+    public static double VincentyDistance(GeoPoint left, GeoPoint right)
+    {
+        var phi1 = ToRadians(left.Latitude);
+        var phi2 = ToRadians(right.Latitude);
+        var lambda = ToRadians(NormalizeLongitude(right.Longitude - left.Longitude));
+
+        var f = Wgs84Flattening;
+        var aRadius = Wgs84EquatorialRadius;
+        var bRadius = Wgs84PolarRadius;
+
+        var tanU1 = (1d - f) * Math.Tan(phi1);
+        var cosU1 = 1d / Math.Sqrt(1d + tanU1 * tanU1);
+        var sinU1 = tanU1 * cosU1;
+
+        var tanU2 = (1d - f) * Math.Tan(phi2);
+        var cosU2 = 1d / Math.Sqrt(1d + tanU2 * tanU2);
+        var sinU2 = tanU2 * cosU2;
+
+        var lambdaIter = lambda;
+        double lambdaPrev;
+
+        const int maxIterations = 100;
+        var iteration = 0;
+
+        double sinSigma;
+        double cosSigma;
+        double sigma;
+        double cosSqAlpha = 0d;
+        double cos2SigmaM = 0d;
+
+        do
+        {
+            var sinLambda = Math.Sin(lambdaIter);
+            var cosLambda = Math.Cos(lambdaIter);
+
+            var term1 = cosU2 * sinLambda;
+            var term2 = cosU1 * sinU2 - sinU1 * cosU2 * cosLambda;
+
+            sinSigma = Math.Sqrt(term1 * term1 + term2 * term2);
+
+            if (sinSigma == 0d)
+            {
+                return 0d;
+            }
+
+            cosSigma = sinU1 * sinU2 + cosU1 * cosU2 * cosLambda;
+            sigma = Math.Atan2(sinSigma, cosSigma);
+
+            var sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
+            cosSqAlpha = 1d - sinAlpha * sinAlpha;
+
+            if (cosSqAlpha != 0d)
+            {
+                cos2SigmaM = cosSigma - 2d * sinU1 * sinU2 / cosSqAlpha;
+            }
+            else
+            {
+                cos2SigmaM = 0d;
+            }
+
+            var c = f / 16d * cosSqAlpha * (4d + f * (4d - 3d * cosSqAlpha));
+            lambdaPrev = lambdaIter;
+            lambdaIter = lambda + (1d - c) * f * sinAlpha * (sigma + c * sinSigma * (cos2SigmaM + c * cosSigma * (-1d + 2d * cos2SigmaM * cos2SigmaM)));
+
+            iteration++;
+        }
+        while (Math.Abs(lambdaIter - lambdaPrev) > 1e-12 && iteration < maxIterations);
+
+        if (iteration == maxIterations)
+        {
+            return HaversineDistance(left, right);
+        }
+
+        var uSq = cosSqAlpha * (aRadius * aRadius - bRadius * bRadius) / (bRadius * bRadius);
+        var bigA = 1d + uSq / 16384d * (4096d + uSq * (-768d + uSq * (320d - 175d * uSq)));
+        var bigB = uSq / 1024d * (256d + uSq * (-128d + uSq * (74d - 47d * uSq)));
+
+        var deltaSigma = bigB * sinSigma * (cos2SigmaM + bigB / 4d * (cosSigma * (-1d + 2d * cos2SigmaM * cos2SigmaM) - bigB / 6d * cos2SigmaM * (-3d + 4d * sinSigma * sinSigma) * (-3d + 4d * cos2SigmaM * cos2SigmaM)));
+        var distance = bRadius * bigA * (sigma - deltaSigma);
+        return distance;
+    }
+}
+

--- a/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
@@ -1,0 +1,54 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents an immutable spatial query plan returned by concrete engines.
+/// </summary>
+public sealed class SpatialQueryPlan : ISpatialQueryPlan
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialQueryPlan"/> class.
+    /// </summary>
+    /// <param name="dimensions">The dimensionality supported by the underlying engine.</param>
+    /// <param name="coveringBounds">Optional normalized bounding box applied before exact filtering.</param>
+    /// <param name="indexRanges">The Morton index ranges to scan.</param>
+    /// <param name="exactPredicateDescription">Human readable description of the exact predicate.</param>
+    public SpatialQueryPlan(
+        int dimensions,
+        BoundingBox? coveringBounds,
+        IReadOnlyList<SpatialIndexRange> indexRanges,
+        string? exactPredicateDescription)
+    {
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial query plans must be two or three dimensional.");
+        }
+
+        if (indexRanges == null)
+        {
+            throw new ArgumentNullException(nameof(indexRanges));
+        }
+
+        Dimensions = dimensions;
+        CoveringBounds = coveringBounds;
+        IndexRanges = indexRanges;
+        ExactPredicateDescription = exactPredicateDescription;
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <inheritdoc />
+    public string? ExactPredicateDescription { get; }
+}
+

--- a/LiteDB.Spatial.Core/Facades/SpatialCartesian2D.cs
+++ b/LiteDB.Spatial.Core/Facades/SpatialCartesian2D.cs
@@ -1,0 +1,88 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Facade for configuring and querying two-dimensional Cartesian collections.
+/// </summary>
+public static class SpatialCartesian2D
+{
+    /// <summary>
+    /// Configures a collection for 2D Cartesian indexing.
+    /// </summary>
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var engine = new Cartesian2DEngine(geometryFieldName, options);
+        var descriptor = new SpatialCollectionDescriptor(collectionName, engine.Name, engine.Dimensions, geometryFieldName, engine.Options, engine);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(engine.Options.IndexFieldName);
+
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Creates a near query plan using Euclidean distance.
+    /// </summary>
+    public static ISpatialQueryPlan Near(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        GeoPoint center,
+        double radius)
+    {
+        var engine = ResolveEngine(database, collectionName);
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Creates a query plan for values within an axis-aligned bounding box.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        BoundingBox bounds)
+    {
+        var engine = ResolveEngine(database, collectionName);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static Cartesian2DEngine ResolveEngine(BaseLiteDB.ILiteDatabase database, string collectionName)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var store = new SpatialMetadataStore(database);
+        var descriptor = store.GetRequiredDescriptor(collectionName, "Call SpatialCartesian2D.EnsurePointIndex first.");
+        return Cartesian2DEngine.FromDescriptor(descriptor);
+    }
+}
+

--- a/LiteDB.Spatial.Core/Facades/SpatialCartesian3D.cs
+++ b/LiteDB.Spatial.Core/Facades/SpatialCartesian3D.cs
@@ -1,0 +1,88 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Facade for configuring three-dimensional Cartesian spatial collections.
+/// </summary>
+public static class SpatialCartesian3D
+{
+    /// <summary>
+    /// Configures a collection for 3D Cartesian indexing.
+    /// </summary>
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var engine = new Cartesian3DEngine(geometryFieldName, options);
+        var descriptor = new SpatialCollectionDescriptor(collectionName, engine.Name, engine.Dimensions, geometryFieldName, engine.Options, engine);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(engine.Options.IndexFieldName);
+
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Creates a near query plan using 3D Euclidean distance.
+    /// </summary>
+    public static ISpatialQueryPlan Near(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        GeoPoint3D center,
+        double radius)
+    {
+        var engine = ResolveEngine(database, collectionName);
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Creates a query plan for values within a three-dimensional bounding box.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        BoundingBox bounds)
+    {
+        var engine = ResolveEngine(database, collectionName);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static Cartesian3DEngine ResolveEngine(BaseLiteDB.ILiteDatabase database, string collectionName)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var store = new SpatialMetadataStore(database);
+        var descriptor = store.GetRequiredDescriptor(collectionName, "Call SpatialCartesian3D.EnsurePointIndex first.");
+        return Cartesian3DEngine.FromDescriptor(descriptor);
+    }
+}
+

--- a/LiteDB.Spatial.Core/Facades/SpatialGeographic.cs
+++ b/LiteDB.Spatial.Core/Facades/SpatialGeographic.cs
@@ -1,0 +1,90 @@
+extern alias LiteDbBase;
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+#nullable enable
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides convenience helpers for configuring and querying geographic collections.
+/// </summary>
+public static class SpatialGeographic
+{
+    /// <summary>
+    /// Configures the supplied collection for geographic point indexing.
+    /// </summary>
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryFieldName,
+        GeographicDistanceMode mode = GeographicDistanceMode.Haversine,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var engine = new GeographicEngine(geometryFieldName, options, mode);
+        var descriptor = new SpatialCollectionDescriptor(collectionName, engine.Name, engine.Dimensions, geometryFieldName, engine.Options, engine);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        collection.EnsureIndex(engine.Options.IndexFieldName);
+
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Creates a query plan for documents near the provided geographic coordinate.
+    /// </summary>
+    public static ISpatialQueryPlan Near(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        GeoPoint center,
+        double radius)
+    {
+        var engine = ResolveEngine(database, collectionName);
+        return engine.PlanNear(center, radius);
+    }
+
+    /// <summary>
+    /// Creates a query plan for values contained within the provided bounding box.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        BoundingBox bounds)
+    {
+        var engine = ResolveEngine(database, collectionName);
+        return engine.PlanWithin(bounds);
+    }
+
+    private static GeographicEngine ResolveEngine(BaseLiteDB.ILiteDatabase database, string collectionName)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var store = new SpatialMetadataStore(database);
+        var descriptor = store.GetRequiredDescriptor(collectionName, "Call SpatialGeographic.EnsurePointIndex first.");
+
+        return GeographicEngine.FromDescriptor(descriptor);
+    }
+}
+

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -97,15 +97,48 @@ LiteDB.Spatial
 ### S5 — Geographic engine (2D)
 
 - [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+  - `PlanNear2D` must expose both Haversine and Vincenty distance modes with range coalescing tuned for meter-based tolerances.
+  - `PlanWithinBox2D` needs explicit anti-meridian handling so bounding boxes that cross ±180° still emit coherent `_mbb` filters.
+  - Mapper should quantize lon/lat into Morton2D codes, normalize bounding boxes, and record metadata for subsequent backfills.
 - [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+  - Introduce helpers for longitude wrapping and polar clamping to avoid discontinuities around the poles.
+  - Guard rails for invalid latitude/longitude inputs with actionable error messages surfaced through the facade.
+- [ ] Ship `SpatialGeographic` facade utilities (`EnsurePointIndex`, `Near`, `WithinBoundingBox`) delegating to the engine and wiring common options.
+
+**Testing outline**
+
+- Regression tests for Berlin vicinity distances and tolerance envelopes vs GeographicLib samples.
+- Anti-meridian fixtures (e.g., Aleutian Islands) verifying bounding box queries prune correctly.
+- Polar bounding boxes proving wrap helpers maintain deterministic Morton codes.
+- Facade integration tests ensuring friendly errors when metadata or indexes are missing.
 
 ### S6 — Cartesian 2D engine
 
 - [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+  - `PlanNear2D` should compute Euclidean radii, fall back to bounding-box approximations when `MaxCoveringCells` is exceeded, and reuse Morton2D coverings.
+  - `PlanWithinBox2D` maps axis-aligned bounding boxes directly to `_mbb` predicates with consistent normalization.
+- [ ] Implement mapper to encode points with Morton2D and persist `_mbb` spans without geographic-specific logic.
+- [ ] Ship `SpatialCartesian2D` facade mirroring the geographic API surface for flat-coordinate callers.
+
+**Testing outline**
+
+- Synthetic grid suites confirming near/box queries leverage the index and return precise Euclidean distances.
+- Property-based tests covering randomized bounding boxes to ensure deterministic Morton ordering and pruning.
+- Facade smoke tests validating options propagation and descriptive errors when the index is absent.
 
 ### S7 — Cartesian 3D engine (points)
 
 - [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+  - `PlanNear3D` forms spherical shells via Morton3D coverings, adds `_mbb` pruning, and applies exact Euclidean3D distance filtering.
+  - `PlanWithinBox3D` translates 3D axis-aligned bounding boxes into `_mbb` spans and Morton3D range plans.
+- [ ] Implement mapper to normalize XYZ coordinates, emit Morton3D keys, and maintain six-value `_mbb` arrays respecting descriptor precision.
+- [ ] Ship `SpatialCartesian3D` facade with helpers for ensuring indexes, running near queries, and bulk backfills for point clouds.
+
+**Testing outline**
+
+- 3D lattice fixtures validating near-query shells, range coalescing, and respect for `MaxCoveringCells` fallbacks.
+- Randomized AABB suites checking mapper output and `_mbb` normalization for varied coordinate scales.
+- Euclidean3D parity checks vs MathNet.Spatial (or similar oracle) to guarantee floating-point tolerance targets.
 
 ### S8 — LINQ resolver
 


### PR DESCRIPTION
## Summary
- add concrete Geographic, Cartesian2D, and Cartesian3D engines along with shared math helpers and a query plan implementation
- wire up dedicated mappers and facades so collections can be configured and spatial plans generated
- cover the new engines and facades with unit tests

## Testing
- dotnet test LiteDB.Spatial.Core.Tests

------
https://chatgpt.com/codex/tasks/task_e_68e75d35712c83269d4d1d29133f42c4