### PR TITLE
Add geographic and cartesian spatial engines

### DIFF
--- a/LiteDB.Spatial.Cartesian2D/Cartesian2DEngine.cs
+++ b/LiteDB.Spatial.Cartesian2D/Cartesian2DEngine.cs
@@ -1,0 +1,93 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+public sealed class Cartesian2DEngine : ISpatialEngine
+{
+    public const string EngineName = "Cartesian2D";
+
+    private readonly Cartesian2DMapper _mapper;
+    private readonly CartesianDistance _distance = new();
+
+    public Cartesian2DEngine(string geometryField, SpatialIndexOptions? options = null)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        _mapper = new Cartesian2DMapper(string.IsNullOrWhiteSpace(geometryField)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryField, IndexEncoder);
+        Mapper = _mapper;
+    }
+
+    public string Name => EngineName;
+
+    public int Dimensions => 2;
+
+    public SpatialIndexOptions Options { get; }
+
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    public ISpatialMapper Mapper { get; }
+
+    public ISpatialDistance Distance => _distance;
+
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (double.IsNaN(radius) || double.IsInfinity(radius) || radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be a non-negative finite number.");
+        }
+
+        var expanded = radius + Options.DistanceTolerance;
+        var bounds = BoundingBox.From2D(
+            center.Longitude - expanded,
+            center.Latitude - expanded,
+            center.Longitude + expanded,
+            center.Latitude + expanded);
+
+        var ranges = BuildIndexRanges(bounds);
+        var predicate = string.Format(
+            CultureInfo.InvariantCulture,
+            "distance<= {0:F3} around ({1:F6},{2:F6})",
+            radius,
+            center.Longitude,
+            center.Latitude);
+
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, predicate);
+    }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Cartesian2D engine cannot plan three-dimensional radius queries.");
+    }
+
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Cartesian2D engine requires two-dimensional bounds.", nameof(bounds));
+        }
+
+        var ranges = BuildIndexRanges(bounds);
+        var predicate = string.Format(
+            CultureInfo.InvariantCulture,
+            "within [{0:F6},{1:F6}]..[{2:F6},{3:F6}]",
+            bounds.MinX,
+            bounds.MinY,
+            bounds.MaxX,
+            bounds.MaxY);
+
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, predicate);
+    }
+
+    private IReadOnlyList<SpatialIndexRange> BuildIndexRanges(BoundingBox bounds)
+    {
+        var normalized = CartesianHelpers.NormalizeBox2D(bounds);
+        var cover = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        return MortonIndexEncoder.UnionAdjacentRanges(cover);
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/Cartesian2DMapper.cs
+++ b/LiteDB.Spatial.Cartesian2D/Cartesian2DMapper.cs
@@ -1,0 +1,123 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian2DMapper : ISpatialMapper
+{
+    private readonly string _geometryField;
+    private readonly ISpatialIndexEncoder _encoder;
+
+    public Cartesian2DMapper(string geometryField, ISpatialIndexEncoder encoder)
+    {
+        if (string.IsNullOrWhiteSpace(geometryField))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryField));
+        }
+
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryField = geometryField;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper does not handle three-dimensional points.");
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = CartesianHelpers.Clamp01(point.Longitude);
+        coordinates[1] = CartesianHelpers.Clamp01(point.Latitude);
+        return _encoder.Encode(coordinates);
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Cartesian2D mapper does not handle three-dimensional points.");
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryField, out var value) || value.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (value.IsDocument)
+        {
+            var geometry = value.AsDocument;
+            if (TryReadComponents(geometry, out var x, out var y))
+            {
+                point = new GeoPoint(x, y);
+                return true;
+            }
+        }
+        else if (value.IsArray)
+        {
+            var array = value.AsArray;
+            if (array.Count >= 2 && array[0].IsNumber && array[1].IsNumber)
+            {
+                point = new GeoPoint(array[0].AsDouble, array[1].AsDouble);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadComponents(BaseLiteDB.BsonDocument document, out double x, out double y)
+    {
+        if (TryGetNumeric(document, "x", out x) && TryGetNumeric(document, "y", out y))
+        {
+            return true;
+        }
+
+        if (TryGetNumeric(document, "lon", out x) && TryGetNumeric(document, "lat", out y))
+        {
+            return true;
+        }
+
+        if (TryGetNumeric(document, "longitude", out x) && TryGetNumeric(document, "latitude", out y))
+        {
+            return true;
+        }
+
+        y = default;
+        return false;
+    }
+
+    private static bool TryGetNumeric(BaseLiteDB.BsonDocument document, string key, out double value)
+    {
+        if (document.TryGetValue(key, out var bsonValue) && bsonValue.IsNumber)
+        {
+            value = bsonValue.AsDouble;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/CartesianDistance.cs
+++ b/LiteDB.Spatial.Cartesian2D/CartesianDistance.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+internal sealed class CartesianDistance : ISpatialDistance
+{
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var dx = left.Longitude - right.Longitude;
+        var dy = left.Latitude - right.Latitude;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        var dz = left.Z - right.Z;
+        return Math.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/CartesianHelpers.cs
+++ b/LiteDB.Spatial.Cartesian2D/CartesianHelpers.cs
@@ -1,0 +1,37 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+internal static class CartesianHelpers
+{
+    internal static double Clamp01(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Coordinates must be finite numbers.", nameof(value));
+        }
+
+        if (value < 0d)
+        {
+            return 0d;
+        }
+
+        if (value > 1d)
+        {
+            return 1d;
+        }
+
+        return value;
+    }
+
+    internal static BoundingBox NormalizeBox2D(BoundingBox box)
+    {
+        return BoundingBox.From2D(
+            Clamp01(box.MinX),
+            Clamp01(box.MinY),
+            Clamp01(box.MaxX),
+            Clamp01(box.MaxY));
+    }
+}

--- a/LiteDB.Spatial.Cartesian2D/LiteDB.Spatial.Cartesian2D.csproj
+++ b/LiteDB.Spatial.Cartesian2D/LiteDB.Spatial.Cartesian2D.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Cartesian2D</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Cartesian2D.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Cartesian2D/SpatialCartesian2D.cs
+++ b/LiteDB.Spatial.Cartesian2D/SpatialCartesian2D.cs
@@ -1,0 +1,70 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+public static class SpatialCartesian2D
+{
+    public static Cartesian2DEngine CreateEngine(string geometryField, SpatialIndexOptions? options = null)
+    {
+        return new Cartesian2DEngine(geometryField, options);
+    }
+
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryField,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var resolvedOptions = options ?? new SpatialIndexOptions();
+        var engine = new Cartesian2DEngine(geometryField, resolvedOptions);
+        var descriptor = new SpatialCollectionDescriptor(
+            collectionName,
+            engine.Name,
+            engine.Dimensions,
+            string.IsNullOrWhiteSpace(geometryField) ? SpatialCollectionDescriptor.DefaultGeometryFieldName : geometryField,
+            resolvedOptions).WithEngine(engine);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        SpatialBackfill.Run(collection, descriptor, engine);
+
+        return descriptor;
+    }
+
+    public static ISpatialQueryPlan Near(Cartesian2DEngine engine, GeoPoint center, double radius)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanNear(center, radius);
+    }
+
+    public static ISpatialQueryPlan WithinBoundingBox(Cartesian2DEngine engine, BoundingBox bounds)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanWithin(bounds);
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Cartesian3DEngine.cs
+++ b/LiteDB.Spatial.Cartesian3D/Cartesian3DEngine.cs
@@ -1,0 +1,98 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+public sealed class Cartesian3DEngine : ISpatialEngine
+{
+    public const string EngineName = "Cartesian3D";
+
+    private readonly Cartesian3DMapper _mapper;
+    private readonly CartesianDistance _distance = new();
+
+    public Cartesian3DEngine(string geometryField, SpatialIndexOptions? options = null)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(3, Options.PrecisionBits);
+        _mapper = new Cartesian3DMapper(string.IsNullOrWhiteSpace(geometryField)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryField, IndexEncoder);
+        Mapper = _mapper;
+    }
+
+    public string Name => EngineName;
+
+    public int Dimensions => 3;
+
+    public SpatialIndexOptions Options { get; }
+
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    public ISpatialMapper Mapper { get; }
+
+    public ISpatialDistance Distance => _distance;
+
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        throw new NotSupportedException("Cartesian3D engine requires three-dimensional coordinates for near queries.");
+    }
+
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        if (double.IsNaN(radius) || double.IsInfinity(radius) || radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be a non-negative finite number.");
+        }
+
+        var expanded = radius + Options.DistanceTolerance;
+        var bounds = BoundingBox.From3D(
+            center.X - expanded,
+            center.Y - expanded,
+            center.Z - expanded,
+            center.X + expanded,
+            center.Y + expanded,
+            center.Z + expanded);
+
+        var ranges = BuildIndexRanges(bounds);
+        var predicate = string.Format(
+            CultureInfo.InvariantCulture,
+            "distance<= {0:F3} around ({1:F6},{2:F6},{3:F6})",
+            radius,
+            center.X,
+            center.Y,
+            center.Z);
+
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, predicate);
+    }
+
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 3)
+        {
+            throw new ArgumentException("Cartesian3D engine requires three-dimensional bounds.", nameof(bounds));
+        }
+
+        var ranges = BuildIndexRanges(bounds);
+        var predicate = string.Format(
+            CultureInfo.InvariantCulture,
+            "within [{0:F6},{1:F6},{2:F6}]..[{3:F6},{4:F6},{5:F6}]",
+            bounds.MinX,
+            bounds.MinY,
+            bounds.MinZ,
+            bounds.MaxX,
+            bounds.MaxY,
+            bounds.MaxZ);
+
+        return new SpatialQueryPlan(Dimensions, bounds, ranges, predicate);
+    }
+
+    private IReadOnlyList<SpatialIndexRange> BuildIndexRanges(BoundingBox bounds)
+    {
+        var normalized = Cartesian3DHelpers.NormalizeBox3D(bounds);
+        var cover = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+        return MortonIndexEncoder.UnionAdjacentRanges(cover);
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Cartesian3DHelpers.cs
+++ b/LiteDB.Spatial.Cartesian3D/Cartesian3DHelpers.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+internal static class Cartesian3DHelpers
+{
+    internal static double Clamp01(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            throw new ArgumentException("Coordinates must be finite numbers.", nameof(value));
+        }
+
+        if (value < 0d)
+        {
+            return 0d;
+        }
+
+        if (value > 1d)
+        {
+            return 1d;
+        }
+
+        return value;
+    }
+
+    internal static BoundingBox NormalizeBox3D(BoundingBox box)
+    {
+        return BoundingBox.From3D(
+            Clamp01(box.MinX),
+            Clamp01(box.MinY),
+            Clamp01(box.MinZ),
+            Clamp01(box.MaxX),
+            Clamp01(box.MaxY),
+            Clamp01(box.MaxZ));
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/Cartesian3DMapper.cs
+++ b/LiteDB.Spatial.Cartesian3D/Cartesian3DMapper.cs
@@ -1,0 +1,126 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+internal sealed class Cartesian3DMapper : ISpatialMapper
+{
+    private readonly string _geometryField;
+    private readonly ISpatialIndexEncoder _encoder;
+
+    public Cartesian3DMapper(string geometryField, ISpatialIndexEncoder encoder)
+    {
+        if (string.IsNullOrWhiteSpace(geometryField))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryField));
+        }
+
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryField = geometryField;
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper does not support two-dimensional points.");
+    }
+
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        return BoundingBox.From3D(point.X, point.Y, point.Z, point.X, point.Y, point.Z);
+    }
+
+    public ulong Encode(GeoPoint point)
+    {
+        throw new NotSupportedException("Cartesian3D mapper does not support two-dimensional points.");
+    }
+
+    public ulong Encode(GeoPoint3D point)
+    {
+        Span<double> coordinates = stackalloc double[3];
+        coordinates[0] = Cartesian3DHelpers.Clamp01(point.X);
+        coordinates[1] = Cartesian3DHelpers.Clamp01(point.Y);
+        coordinates[2] = Cartesian3DHelpers.Clamp01(point.Z);
+        return _encoder.Encode(coordinates);
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        point = default;
+        return false;
+    }
+
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryField, out var value) || value.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (value.IsDocument)
+        {
+            var geometry = value.AsDocument;
+            if (TryReadComponents(geometry, out var x, out var y, out var z))
+            {
+                point = new GeoPoint3D(x, y, z);
+                return true;
+            }
+        }
+        else if (value.IsArray)
+        {
+            var array = value.AsArray;
+            if (array.Count >= 3 && array[0].IsNumber && array[1].IsNumber && array[2].IsNumber)
+            {
+                point = new GeoPoint3D(array[0].AsDouble, array[1].AsDouble, array[2].AsDouble);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadComponents(BaseLiteDB.BsonDocument document, out double x, out double y, out double z)
+    {
+        if (TryGetNumeric(document, "x", out x) && TryGetNumeric(document, "y", out y) && TryGetNumeric(document, "z", out z))
+        {
+            return true;
+        }
+
+        if (TryGetNumeric(document, "lon", out x) && TryGetNumeric(document, "lat", out y) && TryGetNumeric(document, "alt", out z))
+        {
+            return true;
+        }
+
+        if (TryGetNumeric(document, "longitude", out x) && TryGetNumeric(document, "latitude", out y) && TryGetNumeric(document, "elevation", out z))
+        {
+            return true;
+        }
+
+        x = default;
+        y = default;
+        z = default;
+        return false;
+    }
+
+    private static bool TryGetNumeric(BaseLiteDB.BsonDocument document, string key, out double value)
+    {
+        if (document.TryGetValue(key, out var bsonValue) && bsonValue.IsNumber)
+        {
+            value = bsonValue.AsDouble;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/CartesianDistance.cs
+++ b/LiteDB.Spatial.Cartesian3D/CartesianDistance.cs
@@ -1,0 +1,23 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+internal sealed class CartesianDistance : ISpatialDistance
+{
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var dx = left.Longitude - right.Longitude;
+        var dy = left.Latitude - right.Latitude;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        var dz = left.Z - right.Z;
+        return Math.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
+    }
+}

--- a/LiteDB.Spatial.Cartesian3D/LiteDB.Spatial.Cartesian3D.csproj
+++ b/LiteDB.Spatial.Cartesian3D/LiteDB.Spatial.Cartesian3D.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Cartesian3D</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Cartesian3D.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Cartesian3D/SpatialCartesian3D.cs
+++ b/LiteDB.Spatial.Cartesian3D/SpatialCartesian3D.cs
@@ -1,0 +1,70 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+public static class SpatialCartesian3D
+{
+    public static Cartesian3DEngine CreateEngine(string geometryField, SpatialIndexOptions? options = null)
+    {
+        return new Cartesian3DEngine(geometryField, options);
+    }
+
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryField,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var resolvedOptions = options ?? new SpatialIndexOptions();
+        var engine = new Cartesian3DEngine(geometryField, resolvedOptions);
+        var descriptor = new SpatialCollectionDescriptor(
+            collectionName,
+            engine.Name,
+            engine.Dimensions,
+            string.IsNullOrWhiteSpace(geometryField) ? SpatialCollectionDescriptor.DefaultGeometryFieldName : geometryField,
+            resolvedOptions).WithEngine(engine);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        SpatialBackfill.Run(collection, descriptor, engine);
+
+        return descriptor;
+    }
+
+    public static ISpatialQueryPlan Near(Cartesian3DEngine engine, GeoPoint3D center, double radius)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanNear(center, radius);
+    }
+
+    public static ISpatialQueryPlan WithinBoundingBox(Cartesian3DEngine engine, BoundingBox bounds)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanWithin(bounds);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian2DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian2DEngineTests.cs
@@ -1,0 +1,77 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class Cartesian2DEngineTests
+{
+    [Fact]
+    public void PlanNearProducesExpectedBounds()
+    {
+        var engine = new Cartesian2DEngine("position", new SpatialIndexOptions(precisionBits: 8, distanceTolerance: 0.0));
+        var center = new GeoPoint(0.5d, 0.5d);
+        var plan = engine.PlanNear(center, 0.25d);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().BeApproximately(0.25d, 1e-6);
+        bounds.MaxX.Should().BeApproximately(0.75d, 1e-6);
+        bounds.MinY.Should().BeApproximately(0.25d, 1e-6);
+        bounds.MaxY.Should().BeApproximately(0.75d, 1e-6);
+    }
+
+    [Fact]
+    public void PlanNearThreeDimensionalThrows()
+    {
+        var engine = new Cartesian2DEngine("position");
+        var center3D = new GeoPoint3D(0.5d, 0.5d, 0.5d);
+
+        var action = () => engine.PlanNear(center3D, 0.1d);
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void EnsurePointIndexBackfillsDocuments()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("points");
+        collection.Insert(new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 1,
+            ["position"] = new BaseLiteDB.BsonDocument
+            {
+                ["x"] = 0.25d,
+                ["y"] = 0.75d
+            }
+        });
+
+        var descriptor = SpatialCartesian2D.EnsurePointIndex(database, "points", "position", new SpatialIndexOptions(precisionBits: 10));
+
+        descriptor.EngineName.Should().Be(Cartesian2DEngine.EngineName);
+        var stored = collection.FindById(1);
+        ((object?)stored).Should().NotBeNull();
+        stored![descriptor.Options.IndexFieldName].IsNull.Should().BeFalse();
+        stored[descriptor.Options.BoundingBoxFieldName].AsArray.Count.Should().Be(4);
+    }
+
+    [Fact]
+    public void PlanWithinRespectsProvidedBounds()
+    {
+        var engine = new Cartesian2DEngine("position");
+        var bounds = BoundingBox.From2D(0.1d, 0.2d, 0.4d, 0.6d);
+        var plan = engine.PlanWithin(bounds);
+
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().Be(bounds);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Cartesian3DEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Cartesian3DEngineTests.cs
@@ -1,0 +1,79 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class Cartesian3DEngineTests
+{
+    [Fact]
+    public void PlanNearProducesExpectedBounds()
+    {
+        var engine = new Cartesian3DEngine("position", new SpatialIndexOptions(precisionBits: 8, distanceTolerance: 0.0));
+        var center = new GeoPoint3D(0.3d, 0.4d, 0.5d);
+        var plan = engine.PlanNear(center, 0.1d);
+
+        plan.Dimensions.Should().Be(3);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+
+        var bounds = plan.CoveringBounds!.Value;
+        bounds.MinX.Should().BeApproximately(0.2d, 1e-6);
+        bounds.MaxX.Should().BeApproximately(0.4d, 1e-6);
+        bounds.MinY.Should().BeApproximately(0.3d, 1e-6);
+        bounds.MaxY.Should().BeApproximately(0.5d, 1e-6);
+        bounds.MinZ.Should().BeApproximately(0.4d, 1e-6);
+        bounds.MaxZ.Should().BeApproximately(0.6d, 1e-6);
+    }
+
+    [Fact]
+    public void PlanNearTwoDimensionalThrows()
+    {
+        var engine = new Cartesian3DEngine("position");
+        var center2D = new GeoPoint(0.1d, 0.2d);
+
+        var action = () => engine.PlanNear(center2D, 0.1d);
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void EnsurePointIndexBackfillsDocuments()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("cloud");
+        collection.Insert(new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 1,
+            ["position"] = new BaseLiteDB.BsonDocument
+            {
+                ["x"] = 0.1d,
+                ["y"] = 0.2d,
+                ["z"] = 0.3d
+            }
+        });
+
+        var descriptor = SpatialCartesian3D.EnsurePointIndex(database, "cloud", "position", new SpatialIndexOptions(precisionBits: 9));
+
+        descriptor.EngineName.Should().Be(Cartesian3DEngine.EngineName);
+        var stored = collection.FindById(1);
+        ((object?)stored).Should().NotBeNull();
+        stored![descriptor.Options.IndexFieldName].IsNull.Should().BeFalse();
+        stored[descriptor.Options.BoundingBoxFieldName].AsArray.Count.Should().Be(6);
+    }
+
+    [Fact]
+    public void PlanWithinRequiresThreeDimensionalBox()
+    {
+        var engine = new Cartesian3DEngine("position");
+        var twoDimensional = BoundingBox.From2D(0d, 0d, 1d, 1d);
+
+        var action = () => engine.PlanWithin(twoDimensional);
+        action.Should().Throw<ArgumentException>();
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/GeographicEngineTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/GeographicEngineTests.cs
@@ -1,0 +1,81 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System.IO;
+using FluentAssertions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine;
+
+public sealed class GeographicEngineTests
+{
+    [Fact]
+    public void PlanNearExpandsWhenTouchingPole()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions(precisionBits: 12));
+        var plan = engine.PlanNear(new GeoPoint(0d, 89.9d), 50_000d);
+
+        plan.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+
+        var box = plan.CoveringBounds!.Value;
+        box.MaxY.Should().Be(90d);
+        box.MinX.Should().BeLessOrEqualTo(-180d);
+        box.MaxX.Should().BeGreaterOrEqualTo(180d);
+    }
+
+    [Fact]
+    public void PlanWithinSplitsAntiMeridian()
+    {
+        var engine = new GeographicEngine("location", new SpatialIndexOptions(precisionBits: 10));
+        var bounds = BoundingBox.From2D(170d, -10d, 190d, 10d);
+        var plan = engine.PlanWithin(bounds);
+
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.CoveringBounds!.Value.MaxX.Should().BeGreaterThan(180d);
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void DistanceMatchesKnownCities()
+    {
+        var distance = new GeographicDistance();
+        var london = new GeoPoint(-0.1278d, 51.5074d);
+        var paris = new GeoPoint(2.3522d, 48.8566d);
+
+        var result = distance.Distance(london, paris);
+
+        result.Should().BeApproximately(343_941d, 1_000d);
+    }
+
+    [Fact]
+    public void EnsurePointIndexPersistsMetadataAndBackfills()
+    {
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection("places");
+        collection.Insert(new BaseLiteDB.BsonDocument
+        {
+            ["_id"] = 1,
+            ["location"] = new BaseLiteDB.BsonDocument
+            {
+                ["longitude"] = -0.1278d,
+                ["latitude"] = 51.5074d
+            }
+        });
+
+        var descriptor = SpatialGeographic.EnsurePointIndex(database, "places", "location", new SpatialIndexOptions(precisionBits: 12));
+
+        descriptor.EngineName.Should().Be(GeographicEngine.EngineName);
+        var storedDocument = collection.FindById(1);
+        ((object?)storedDocument).Should().NotBeNull();
+        storedDocument![descriptor.Options.IndexFieldName].IsNull.Should().BeFalse();
+        storedDocument[descriptor.Options.BoundingBoxFieldName].AsArray.Count.Should().Be(4);
+
+        var store = new SpatialMetadataStore(database);
+        store.TryGetDescriptor("places", out var persisted).Should().BeTrue();
+        persisted!.EngineName.Should().Be(GeographicEngine.EngineName);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -19,6 +19,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Geographic\LiteDB.Spatial.Geographic.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Cartesian2D\LiteDB.Spatial.Cartesian2D.csproj" />
+    <ProjectReference Include="..\LiteDB.Spatial.Cartesian3D\LiteDB.Spatial.Cartesian3D.csproj" />
     <ProjectReference Include="..\LiteDB\LiteDB.csproj">
       <Aliases>LiteDbBase</Aliases>
     </ProjectReference>

--- a/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
@@ -1,0 +1,64 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Default implementation of <see cref="ISpatialQueryPlan"/>.
+/// </summary>
+public sealed class SpatialQueryPlan : ISpatialQueryPlan
+{
+    private readonly IReadOnlyList<SpatialIndexRange> _indexRanges;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialQueryPlan"/> class.
+    /// </summary>
+    /// <param name="dimensions">The dimensionality of the underlying spatial index.</param>
+    /// <param name="coveringBounds">Optional bounding box describing the coarse search area.</param>
+    /// <param name="indexRanges">The index ranges that should be scanned.</param>
+    /// <param name="exactPredicateDescription">Human readable description of the precise predicate.</param>
+    public SpatialQueryPlan(
+        int dimensions,
+        BoundingBox? coveringBounds,
+        IEnumerable<SpatialIndexRange> indexRanges,
+        string? exactPredicateDescription)
+    {
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial plans must target 2D or 3D indexes.");
+        }
+
+        if (indexRanges == null)
+        {
+            throw new ArgumentNullException(nameof(indexRanges));
+        }
+
+        Dimensions = dimensions;
+        CoveringBounds = coveringBounds;
+        ExactPredicateDescription = exactPredicateDescription;
+
+        var materialized = new List<SpatialIndexRange>();
+
+        foreach (var range in indexRanges)
+        {
+            materialized.Add(range);
+        }
+
+        _indexRanges = new ReadOnlyCollection<SpatialIndexRange>(materialized);
+    }
+
+    /// <inheritdoc />
+    public int Dimensions { get; }
+
+    /// <inheritdoc />
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<SpatialIndexRange> IndexRanges => _indexRanges;
+
+    /// <inheritdoc />
+    public string? ExactPredicateDescription { get; }
+}

--- a/LiteDB.Spatial.Geographic/GeographicDistance.cs
+++ b/LiteDB.Spatial.Geographic/GeographicDistance.cs
@@ -1,0 +1,40 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Computes geographic distances using the haversine formula.
+/// </summary>
+public sealed class GeographicDistance : ISpatialDistance
+{
+    /// <inheritdoc />
+    public double Distance(GeoPoint left, GeoPoint right)
+    {
+        var lon1 = GeographicHelpers.DegreesToRadians(left.Longitude);
+        var lon2 = GeographicHelpers.DegreesToRadians(right.Longitude);
+        var lat1 = GeographicHelpers.DegreesToRadians(left.Latitude);
+        var lat2 = GeographicHelpers.DegreesToRadians(right.Latitude);
+
+        var deltaLat = lat2 - lat1;
+        var deltaLon = lon2 - lon1;
+
+        var sinLat = Math.Sin(deltaLat / 2d);
+        var sinLon = Math.Sin(deltaLon / 2d);
+
+        var a = (sinLat * sinLat) + Math.Cos(lat1) * Math.Cos(lat2) * (sinLon * sinLon);
+        var c = 2d * Math.Asin(Math.Min(1d, Math.Sqrt(a)));
+
+        return GeographicHelpers.EarthRadiusMeters * c;
+    }
+
+    /// <inheritdoc />
+    public double Distance(GeoPoint3D left, GeoPoint3D right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        var dz = left.Z - right.Z;
+        return Math.Sqrt((dx * dx) + (dy * dy) + (dz * dz));
+    }
+}

--- a/LiteDB.Spatial.Geographic/GeographicEngine.cs
+++ b/LiteDB.Spatial.Geographic/GeographicEngine.cs
@@ -1,0 +1,114 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Geographic (WGS84) spatial engine providing index-aware planners for point data.
+/// </summary>
+public sealed class GeographicEngine : ISpatialEngine
+{
+    /// <summary>
+    /// The registered engine name.
+    /// </summary>
+    public const string EngineName = "Geographic";
+
+    private readonly GeographicMapper _mapper;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicEngine"/> class.
+    /// </summary>
+    /// <param name="geometryField">Name of the field that stores the geometry payload.</param>
+    /// <param name="options">Optional index options overriding the defaults.</param>
+    public GeographicEngine(string geometryField, SpatialIndexOptions? options = null)
+    {
+        Options = options ?? new SpatialIndexOptions();
+        IndexEncoder = new MortonIndexEncoder(2, Options.PrecisionBits);
+        _mapper = new GeographicMapper(string.IsNullOrWhiteSpace(geometryField)
+            ? SpatialCollectionDescriptor.DefaultGeometryFieldName
+            : geometryField, IndexEncoder);
+        Mapper = _mapper;
+        Distance = new GeographicDistance();
+    }
+
+    /// <inheritdoc />
+    public string Name => EngineName;
+
+    /// <inheritdoc />
+    public int Dimensions => 2;
+
+    /// <inheritdoc />
+    public SpatialIndexOptions Options { get; }
+
+    /// <inheritdoc />
+    public ISpatialIndexEncoder IndexEncoder { get; }
+
+    /// <inheritdoc />
+    public ISpatialMapper Mapper { get; }
+
+    /// <inheritdoc />
+    public ISpatialDistance Distance { get; }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
+    {
+        if (double.IsNaN(radius) || double.IsInfinity(radius) || radius < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radius), "Radius must be a non-negative finite number.");
+        }
+
+        var expandedRadius = radius + Options.DistanceTolerance;
+        var bounds = GeographicHelpers.CreateBounds(center, expandedRadius);
+        var ranges = BuildIndexRanges(bounds);
+
+        var predicate = string.Format(
+            CultureInfo.InvariantCulture,
+            "distance<= {0:F3}m around ({1:F6},{2:F6})",
+            radius,
+            center.Longitude,
+            center.Latitude);
+
+        return new SpatialQueryPlan(Dimensions, bounds.ToBoundingBox(), ranges, predicate);
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
+    {
+        throw new NotSupportedException("Geographic engine is limited to two-dimensional coordinates.");
+    }
+
+    /// <inheritdoc />
+    public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
+    {
+        var geographicBounds = GeographicHelpers.FromBoundingBox(bounds);
+        var ranges = BuildIndexRanges(geographicBounds);
+
+        var predicate = string.Format(
+            CultureInfo.InvariantCulture,
+            "within [{0:F6},{1:F6}]..[{2:F6},{3:F6}]",
+            geographicBounds.MinLongitude,
+            geographicBounds.MinLatitude,
+            geographicBounds.MaxLongitude,
+            geographicBounds.MaxLatitude);
+
+        return new SpatialQueryPlan(Dimensions, geographicBounds.ToBoundingBox(), ranges, predicate);
+    }
+
+    private IReadOnlyList<SpatialIndexRange> BuildIndexRanges(GeographicBounds bounds)
+    {
+        var segments = bounds.SplitForCover();
+        var ranges = new List<SpatialIndexRange>();
+
+        foreach (var segment in segments)
+        {
+            var normalized = segment.ToNormalizedBoundingBox();
+            var cover = IndexEncoder.Cover(normalized, Options.MaxCoveringCells);
+            ranges.AddRange(cover);
+        }
+
+        return MortonIndexEncoder.UnionAdjacentRanges(ranges);
+    }
+}

--- a/LiteDB.Spatial.Geographic/GeographicHelpers.cs
+++ b/LiteDB.Spatial.Geographic/GeographicHelpers.cs
@@ -1,0 +1,221 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+internal static class GeographicHelpers
+{
+    internal const double EarthRadiusMeters = 6_378_137d;
+    internal const double MinLatitude = -90d;
+    internal const double MaxLatitude = 90d;
+
+    internal static double DegreesToRadians(double degrees) => degrees * (Math.PI / 180d);
+
+    internal static double RadiansToDegrees(double radians) => radians * (180d / Math.PI);
+
+    internal static double NormalizeLongitude(double longitude)
+    {
+        if (double.IsNaN(longitude) || double.IsInfinity(longitude))
+        {
+            throw new ArgumentException("Longitude must be a finite number.", nameof(longitude));
+        }
+
+        var result = longitude % 360d;
+
+        if (result < -180d)
+        {
+            result += 360d;
+        }
+        else if (result > 180d)
+        {
+            result -= 360d;
+        }
+
+        return result;
+    }
+
+    internal static double ClampLatitude(double latitude)
+    {
+        if (double.IsNaN(latitude) || double.IsInfinity(latitude))
+        {
+            throw new ArgumentException("Latitude must be a finite number.", nameof(latitude));
+        }
+
+        if (latitude < MinLatitude)
+        {
+            return MinLatitude;
+        }
+
+        if (latitude > MaxLatitude)
+        {
+            return MaxLatitude;
+        }
+
+        return latitude;
+    }
+
+    internal static double LongitudeToUnit(double longitude)
+    {
+        return (NormalizeLongitude(longitude) + 180d) / 360d;
+    }
+
+    internal static double LatitudeToUnit(double latitude)
+    {
+        return (ClampLatitude(latitude) + 90d) / 180d;
+    }
+
+    internal static GeographicBounds CreateBounds(GeoPoint center, double radiusMeters)
+    {
+        if (double.IsNaN(radiusMeters) || double.IsInfinity(radiusMeters) || radiusMeters < 0d)
+        {
+            throw new ArgumentOutOfRangeException(nameof(radiusMeters), "Radius must be a non-negative finite number.");
+        }
+
+        var angularDistance = radiusMeters / EarthRadiusMeters;
+        var centerLatRad = DegreesToRadians(center.Latitude);
+
+        var minLat = ClampLatitude(RadiansToDegrees(centerLatRad - angularDistance));
+        var maxLat = ClampLatitude(RadiansToDegrees(centerLatRad + angularDistance));
+
+        double deltaLonDegrees;
+
+        if (minLat <= MinLatitude || maxLat >= MaxLatitude)
+        {
+            deltaLonDegrees = 180d;
+        }
+        else
+        {
+            var sinAngular = Math.Sin(angularDistance);
+            var cosLat = Math.Cos(centerLatRad);
+            var ratio = sinAngular / cosLat;
+
+            if (ratio > 1d)
+            {
+                ratio = 1d;
+            }
+            else if (ratio < -1d)
+            {
+                ratio = -1d;
+            }
+
+            deltaLonDegrees = RadiansToDegrees(Math.Asin(ratio));
+        }
+
+        var minLon = center.Longitude - deltaLonDegrees;
+        var maxLon = center.Longitude + deltaLonDegrees;
+
+        if (deltaLonDegrees >= 180d || maxLon - minLon >= 360d)
+        {
+            minLon = -180d;
+            maxLon = 180d;
+        }
+
+        return new GeographicBounds(minLon, maxLon, minLat, maxLat, isNormalized: false);
+    }
+
+    internal static GeographicBounds FromBoundingBox(BoundingBox bounds)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic bounds must be two-dimensional.", nameof(bounds));
+        }
+
+        var minLat = ClampLatitude(bounds.MinY);
+        var maxLat = ClampLatitude(bounds.MaxY);
+
+        return new GeographicBounds(bounds.MinX, bounds.MaxX, minLat, maxLat, isNormalized: false);
+    }
+}
+
+internal readonly struct GeographicBounds
+{
+    public GeographicBounds(double minLongitude, double maxLongitude, double minLatitude, double maxLatitude, bool isNormalized)
+    {
+        if (double.IsNaN(minLongitude) || double.IsNaN(maxLongitude) || double.IsNaN(minLatitude) || double.IsNaN(maxLatitude))
+        {
+            throw new ArgumentException("Bounds must be described using finite numbers.");
+        }
+
+        if (double.IsInfinity(minLongitude) || double.IsInfinity(maxLongitude) || double.IsInfinity(minLatitude) || double.IsInfinity(maxLatitude))
+        {
+            throw new ArgumentException("Bounds must be described using finite numbers.");
+        }
+
+        if (maxLatitude < minLatitude)
+        {
+            throw new ArgumentException("Maximum latitude must be greater than or equal to minimum latitude.");
+        }
+
+        if (maxLongitude < minLongitude)
+        {
+            throw new ArgumentException("Maximum longitude must be greater than or equal to minimum longitude.");
+        }
+
+        MinLongitude = minLongitude;
+        MaxLongitude = maxLongitude;
+        MinLatitude = minLatitude;
+        MaxLatitude = maxLatitude;
+        IsNormalized = isNormalized;
+    }
+
+    public double MinLongitude { get; }
+
+    public double MaxLongitude { get; }
+
+    public double MinLatitude { get; }
+
+    public double MaxLatitude { get; }
+
+    public bool IsNormalized { get; }
+
+    public BoundingBox ToBoundingBox()
+    {
+        return BoundingBox.From2D(MinLongitude, MinLatitude, MaxLongitude, MaxLatitude);
+    }
+
+    public IReadOnlyList<GeographicBounds> SplitForCover()
+    {
+        if (CoversEntireWorld)
+        {
+            return new[]
+            {
+                new GeographicBounds(-180d, 180d, MinLatitude, MaxLatitude, isNormalized: true)
+            };
+        }
+
+        var minWrapped = GeographicHelpers.NormalizeLongitude(MinLongitude);
+        var maxWrapped = GeographicHelpers.NormalizeLongitude(MaxLongitude);
+
+        if (maxWrapped >= minWrapped)
+        {
+            return new[]
+            {
+                new GeographicBounds(minWrapped, maxWrapped, MinLatitude, MaxLatitude, isNormalized: true)
+            };
+        }
+
+        return new[]
+        {
+            new GeographicBounds(minWrapped, 180d, MinLatitude, MaxLatitude, isNormalized: true),
+            new GeographicBounds(-180d, maxWrapped, MinLatitude, MaxLatitude, isNormalized: true)
+        };
+    }
+
+    public BoundingBox ToNormalizedBoundingBox()
+    {
+        if (!IsNormalized)
+        {
+            throw new InvalidOperationException("Bounds must be normalized before converting to the unit interval.");
+        }
+
+        return BoundingBox.From2D(
+            GeographicHelpers.LongitudeToUnit(MinLongitude),
+            GeographicHelpers.LatitudeToUnit(MinLatitude),
+            GeographicHelpers.LongitudeToUnit(MaxLongitude),
+            GeographicHelpers.LatitudeToUnit(MaxLatitude));
+    }
+
+    private bool CoversEntireWorld => MaxLongitude - MinLongitude >= 360d || (MinLongitude <= -180d && MaxLongitude >= 180d);
+}

--- a/LiteDB.Spatial.Geographic/GeographicMapper.cs
+++ b/LiteDB.Spatial.Geographic/GeographicMapper.cs
@@ -1,0 +1,180 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Maps application level geographic data into index friendly representations.
+/// </summary>
+public sealed class GeographicMapper : ISpatialMapper
+{
+    private readonly string _geometryField;
+    private readonly ISpatialIndexEncoder _encoder;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeographicMapper"/> class.
+    /// </summary>
+    public GeographicMapper(string geometryField, ISpatialIndexEncoder encoder)
+    {
+        if (string.IsNullOrWhiteSpace(geometryField))
+        {
+            throw new ArgumentException("Geometry field name must be provided.", nameof(geometryField));
+        }
+
+        _encoder = encoder ?? throw new ArgumentNullException(nameof(encoder));
+        _geometryField = geometryField;
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint point)
+    {
+        return BoundingBox.From2D(point.Longitude, point.Latitude, point.Longitude, point.Latitude);
+    }
+
+    /// <inheritdoc />
+    public BoundingBox GetBoundingBox(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper only supports two-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint point)
+    {
+        Span<double> coordinates = stackalloc double[2];
+        coordinates[0] = GeographicHelpers.LongitudeToUnit(point.Longitude);
+        coordinates[1] = GeographicHelpers.LatitudeToUnit(point.Latitude);
+        return _encoder.Encode(coordinates);
+    }
+
+    /// <inheritdoc />
+    public ulong Encode(GeoPoint3D point)
+    {
+        throw new NotSupportedException("Geographic mapper only supports two-dimensional points.");
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document == null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        if (!document.TryGetValue(_geometryField, out var value) || value.IsNull)
+        {
+            point = default;
+            return false;
+        }
+
+        if (TryReadPoint(value, out point))
+        {
+            return true;
+        }
+
+        point = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryReadPoint(BaseLiteDB.BsonDocument document, out GeoPoint3D point)
+    {
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadPoint(BaseLiteDB.BsonValue value, out GeoPoint point)
+    {
+        if (value.IsDocument)
+        {
+            var document = value.AsDocument;
+
+            if (TryReadGeoJsonPoint(document, out point))
+            {
+                return true;
+            }
+
+            if (TryReadCoordinatePair(document, out point))
+            {
+                return true;
+            }
+        }
+        else if (value.IsArray)
+        {
+            var array = value.AsArray;
+            if (array.Count >= 2 && array[0].IsNumber && array[1].IsNumber)
+            {
+                point = new GeoPoint(array[0].AsDouble, array[1].AsDouble);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadGeoJsonPoint(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (document.TryGetValue("type", out var typeValue)
+            && typeValue.IsString
+            && string.Equals(typeValue.AsString, "Point", StringComparison.OrdinalIgnoreCase)
+            && document.TryGetValue("coordinates", out var coordinatesValue)
+            && coordinatesValue.IsArray)
+        {
+            var coordinates = coordinatesValue.AsArray;
+            if (coordinates.Count >= 2 && coordinates[0].IsNumber && coordinates[1].IsNumber)
+            {
+                point = new GeoPoint(coordinates[0].AsDouble, coordinates[1].AsDouble);
+                return true;
+            }
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryReadCoordinatePair(BaseLiteDB.BsonDocument document, out GeoPoint point)
+    {
+        if (TryGetNumeric(document, "longitude", out var lon) && TryGetNumeric(document, "latitude", out var lat))
+        {
+            point = new GeoPoint(lon, lat);
+            return true;
+        }
+
+        if (TryGetNumeric(document, "lon", out lon) && TryGetNumeric(document, "lat", out lat))
+        {
+            point = new GeoPoint(lon, lat);
+            return true;
+        }
+
+        if (TryGetNumeric(document, "lng", out lon) && TryGetNumeric(document, "lat", out lat))
+        {
+            point = new GeoPoint(lon, lat);
+            return true;
+        }
+
+        if (TryGetNumeric(document, "x", out lon) && TryGetNumeric(document, "y", out lat))
+        {
+            point = new GeoPoint(lon, lat);
+            return true;
+        }
+
+        point = default;
+        return false;
+    }
+
+    private static bool TryGetNumeric(BaseLiteDB.BsonDocument document, string key, out double value)
+    {
+        if (document.TryGetValue(key, out var bsonValue) && bsonValue.IsNumber)
+        {
+            value = bsonValue.AsDouble;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/LiteDB.Spatial.Geographic/LiteDB.Spatial.Geographic.csproj
+++ b/LiteDB.Spatial.Geographic/LiteDB.Spatial.Geographic.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <RootNamespace>LiteDB.Spatial</RootNamespace>
+    <AssemblyName>LiteDB.Spatial.Geographic</AssemblyName>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591;0618</NoWarn>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LiteDB.Spatial.Geographic.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\LICENSE" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB.Spatial.Core\LiteDB.Spatial.Core.csproj" />
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj">
+      <Aliases>LiteDbBase</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Spatial.Geographic/SpatialGeographic.cs
+++ b/LiteDB.Spatial.Geographic/SpatialGeographic.cs
@@ -1,0 +1,85 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Convenience helpers for configuring and querying geographic collections.
+/// </summary>
+public static class SpatialGeographic
+{
+    /// <summary>
+    /// Creates a geographic engine bound to the specified geometry field.
+    /// </summary>
+    public static GeographicEngine CreateEngine(string geometryField, SpatialIndexOptions? options = null)
+    {
+        return new GeographicEngine(geometryField, options);
+    }
+
+    /// <summary>
+    /// Ensures a point-based geographic index exists for the collection, persisting metadata and backfilling documents.
+    /// </summary>
+    public static SpatialCollectionDescriptor EnsurePointIndex(
+        BaseLiteDB.ILiteDatabase database,
+        string collectionName,
+        string geometryField,
+        SpatialIndexOptions? options = null)
+    {
+        if (database == null)
+        {
+            throw new ArgumentNullException(nameof(database));
+        }
+
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        var resolvedOptions = options ?? new SpatialIndexOptions();
+        var engine = new GeographicEngine(geometryField, resolvedOptions);
+        var descriptor = new SpatialCollectionDescriptor(
+            collectionName,
+            engine.Name,
+            engine.Dimensions,
+            string.IsNullOrWhiteSpace(geometryField) ? SpatialCollectionDescriptor.DefaultGeometryFieldName : geometryField,
+            resolvedOptions).WithEngine(engine);
+
+        var store = new SpatialMetadataStore(database);
+        store.SaveDescriptor(collectionName, descriptor);
+
+        var collection = database.GetCollection(collectionName);
+        SpatialBackfill.Run(collection, descriptor, engine);
+
+        return descriptor;
+    }
+
+    /// <summary>
+    /// Creates a near query plan using the provided engine instance.
+    /// </summary>
+    public static ISpatialQueryPlan Near(GeographicEngine engine, GeoPoint center, double radiusMeters)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanNear(center, radiusMeters);
+    }
+
+    /// <summary>
+    /// Creates a bounding-box query plan using the provided engine instance.
+    /// </summary>
+    public static ISpatialQueryPlan WithinBoundingBox(GeographicEngine engine, BoundingBox bounds)
+    {
+        if (engine == null)
+        {
+            throw new ArgumentNullException(nameof(engine));
+        }
+
+        return engine.PlanWithin(bounds);
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -44,6 +44,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core", "Lite
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Core.Tests", "LiteDB.Spatial.Core.Tests\LiteDB.Spatial.Core.Tests.csproj", "{99F2946D-65FB-4FC8-827D-C3241FB5EF93}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Geographic", "LiteDB.Spatial.Geographic\LiteDB.Spatial.Geographic.csproj", "{1C94796E-C155-4333-9C93-B9449B5FCA8B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Cartesian2D", "LiteDB.Spatial.Cartesian2D\LiteDB.Spatial.Cartesian2D.csproj", "{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Spatial.Cartesian3D", "LiteDB.Spatial.Cartesian3D\LiteDB.Spatial.Cartesian3D.csproj", "{09F3D625-6450-4298-8C6B-3AA2F809AE72}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -186,6 +192,42 @@ Global
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x64.Build.0 = Release|Any CPU
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.ActiveCfg = Release|Any CPU
 		{99F2946D-65FB-4FC8-827D-C3241FB5EF93}.Release|x86.Build.0 = Release|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Debug|x86.Build.0 = Debug|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Release|x64.Build.0 = Release|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C94796E-C155-4333-9C93-B9449B5FCA8B}.Release|x86.Build.0 = Release|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Debug|x64.Build.0 = Debug|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Debug|x86.Build.0 = Debug|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Release|x64.ActiveCfg = Release|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Release|x64.Build.0 = Release|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Release|x86.ActiveCfg = Release|Any CPU
+		{E2159D7E-7B0D-4B39-AAC5-74A0B8DAE2C1}.Release|x86.Build.0 = Release|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Debug|x64.Build.0 = Debug|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Debug|x86.Build.0 = Debug|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Release|x64.ActiveCfg = Release|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Release|x64.Build.0 = Release|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Release|x86.ActiveCfg = Release|Any CPU
+		{09F3D625-6450-4298-8C6B-3AA2F809AE72}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -96,16 +96,16 @@ LiteDB.Spatial
 
 ### S5 — Geographic engine (2D)
 
-- [ ] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
-- [ ] Handle wraparound and polar helpers with tests for real-world coordinates.
+- [x] Deliver `GeographicEngine` with near/box planners, mapper, and facade helpers.
+- [x] Handle wraparound and polar helpers with tests for real-world coordinates.
 
 ### S6 — Cartesian 2D engine
 
-- [ ] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
+- [x] Provide `Cartesian2DEngine` and facade with Euclidean planning and mapping.
 
 ### S7 — Cartesian 3D engine (points)
 
-- [ ] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
+- [x] Implement `Cartesian3DEngine` and facade for point-based 3D queries.
 
 ### S8 — LINQ resolver
 


### PR DESCRIPTION
## Summary
- add a reusable `SpatialQueryPlan` implementation for engines to describe index work
- introduce geographic, 2D cartesian, and 3D cartesian spatial engines with mappers, facades, and supporting helpers
- cover the new engines with dedicated core tests and update the spatial revamp checklist

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
- dotnet test LiteDB.sln --settings tests.runsettings *(fails: .NET Framework targets require mono and an existing vector index test assertion fails in the current baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68e75fa2f94c8326ad2b426f3de99ecd