### PR TITLE
Implement spatial resolver diagnostics and GeoJSON

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Diagnostics/SpatialDiagnosticsTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Diagnostics/SpatialDiagnosticsTests.cs
@@ -1,0 +1,45 @@
+#nullable enable
+
+using System.Collections.Generic;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Diagnostics;
+
+public sealed class SpatialDiagnosticsTests
+{
+    [Fact]
+    public void ExplainProducesSummary()
+    {
+        var descriptor = new SpatialCollectionDescriptor("points", "Geographic2D", 2, "location", new SpatialIndexOptions(), SpatialEngineSettings.ForGeographic(GeographicDistanceMode.Haversine));
+        var ranges = new List<SpatialIndexRange>
+        {
+            new SpatialIndexRange(10, 20),
+            new SpatialIndexRange(30, 40)
+        };
+        var plan = new SpatialQueryPlan(2, BoundingBox.From2D(-1, -1, 1, 1), ranges, "Haversine <= 1000m");
+
+        var explain = SpatialDiagnostics.Explain(descriptor, plan);
+
+        explain.CollectionName.Should().Be("points");
+        explain.EngineName.Should().Be("Geographic2D");
+        explain.Dimensions.Should().Be(2);
+        explain.IndexRanges.Should().HaveCount(2);
+        explain.CoveringBounds.Should().NotBeNull();
+        explain.ToString().Should().Contain("Collection: points").And.Contain("Index ranges (2)");
+    }
+
+    [Fact]
+    public void ExplainHandlesPlansWithoutCovering()
+    {
+        var descriptor = new SpatialCollectionDescriptor("points3d", "Cartesian3D", 3, "position", new SpatialIndexOptions(), SpatialEngineSettings.ForCartesian(BoundingBox.From3D(-10, -10, -10, 10, 10, 10)));
+        var plan = new SpatialQueryPlan(3, null, new List<SpatialIndexRange>(), null);
+
+        var explain = SpatialDiagnostics.Explain(descriptor, plan);
+
+        explain.CoveringBounds.Should().BeNull();
+        explain.IndexRanges.Should().BeEmpty();
+        explain.ToString().Should().Contain("<none>");
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/GeoJson/GeoJsonSerializerTests.cs
+++ b/LiteDB.Spatial.Core.Tests/GeoJson/GeoJsonSerializerTests.cs
@@ -1,0 +1,78 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial.Core.Tests.GeoJson;
+
+public sealed class GeoJsonSerializerTests
+{
+    [Fact]
+    public void GeoPointRoundTrips()
+    {
+        var point = new GeoPoint(12.5, 48.1);
+        var bson = GeoJsonSerializer.ToBson(point);
+
+        bson.Should().NotBeNull();
+        bson.AsDocument["type"].AsString.Should().Be("Point");
+
+        var roundTripped = GeoJsonSerializer.FromBson<GeoPoint>(bson);
+        roundTripped.Should().Be(point);
+    }
+
+    [Fact]
+    public void LineStringRoundTrips()
+    {
+        var line = new GeoLineString(new[] { new GeoPoint(0, 0), new GeoPoint(1, 1), new GeoPoint(2, 1) });
+        var bson = GeoJsonSerializer.ToBson(line);
+        bson.AsDocument["type"].AsString.Should().Be("LineString");
+
+        var roundTripped = GeoJsonSerializer.FromBson<GeoLineString>(bson);
+        roundTripped.Points.Should().Equal(line.Points);
+    }
+
+    [Fact]
+    public void PolygonRoundTrips()
+    {
+        var outer = new[]
+        {
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 2),
+            new GeoPoint(2, 2),
+            new GeoPoint(0, 0)
+        };
+        var polygon = new GeoPolygon(outer);
+
+        var bson = GeoJsonSerializer.ToBson(polygon);
+        bson.AsDocument["type"].AsString.Should().Be("Polygon");
+
+        var roundTripped = GeoJsonSerializer.FromBson<GeoPolygon>(bson);
+        roundTripped.Outer.Should().Equal(polygon.Outer);
+    }
+
+    [Fact]
+    public void NullPayloadReturnsNull()
+    {
+        var result = GeoJsonSerializer.FromBson(BaseLiteDB.BsonValue.Null);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void InvalidTypeThrows()
+    {
+        var document = new BaseLiteDB.BsonDocument
+        {
+            ["type"] = "Unknown",
+            ["coordinates"] = new BaseLiteDB.BsonArray()
+        };
+
+        BaseLiteDB.BsonValue value = document;
+        Action action = () => GeoJsonSerializer.FromBson(value);
+        action.Should().Throw<ArgumentException>().WithMessage("*Unknown*");
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Linq/SpatialResolverTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Linq/SpatialResolverTests.cs
@@ -1,0 +1,110 @@
+#nullable enable
+
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Linq;
+
+public sealed class SpatialResolverTests
+{
+    [Fact]
+    public void TryResolveNear2DReturnsPlanFromEngine()
+    {
+        var options = new SpatialIndexOptions(precisionBits: 10, maxCoveringCells: 32, distanceTolerance: 5);
+        var descriptor = new SpatialCollectionDescriptor("points", GeographicEngine.EngineName, 2, "location", options, SpatialEngineSettings.ForGeographic(GeographicDistanceMode.Haversine));
+        var engine = new GeographicEngine("location", options, GeographicDistanceMode.Haversine);
+        descriptor = descriptor.WithEngine(engine);
+
+        var resolver = new SpatialResolver(descriptor);
+        var method = typeof(SpatialExpressions).GetMethod(nameof(SpatialExpressions.Near), new[] { typeof(GeoPoint), typeof(GeoPoint), typeof(double) })!;
+        var candidate = Expression.Parameter(typeof(GeoPoint), "candidate");
+        var center = Expression.Constant(new GeoPoint(13.405, 52.52));
+        var radius = Expression.Constant(500d);
+        var call = Expression.Call(method, candidate, center, radius);
+
+        var result = resolver.TryResolve(call, out var plan);
+
+        result.Should().BeTrue();
+        plan.Should().NotBeNull();
+        plan!.Dimensions.Should().Be(2);
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.ExactPredicateDescription.Should().Contain("Haversine");
+    }
+
+    [Fact]
+    public void TryResolveNear3DUsesInjectedEngine()
+    {
+        var options = new SpatialIndexOptions(precisionBits: 8, maxCoveringCells: 16, distanceTolerance: 0.01);
+        var domain = BoundingBox.From3D(-100, -100, -100, 100, 100, 100);
+        var descriptor = new SpatialCollectionDescriptor("points3d", Cartesian3DEngine.EngineName, 3, "position", options, SpatialEngineSettings.ForCartesian(domain));
+        var resolver = new SpatialResolver(descriptor, _ => new Cartesian3DEngine("position", domain, options));
+
+        var method = typeof(SpatialExpressions).GetMethod(nameof(SpatialExpressions.Near), new[] { typeof(GeoPoint3D), typeof(GeoPoint3D), typeof(double) })!;
+        var candidate = Expression.Parameter(typeof(GeoPoint3D), "candidate");
+        var center = Expression.Constant(new GeoPoint3D(1, 2, 3));
+        var radius = Expression.Constant(25d);
+        var call = Expression.Call(method, candidate, center, radius);
+
+        resolver.TryResolve(call, out var plan).Should().BeTrue();
+        plan.Should().NotBeNull();
+        plan!.Dimensions.Should().Be(3);
+        plan.CoveringBounds.Should().NotBeNull();
+        plan.IndexRanges.Should().NotBeEmpty();
+        plan.ExactPredicateDescription.Should().Contain("Euclidean3D");
+    }
+
+    [Fact]
+    public void TryResolveInBoxReturnsPlan()
+    {
+        var options = new SpatialIndexOptions(precisionBits: 9, maxCoveringCells: 16, distanceTolerance: 2);
+        var descriptor = new SpatialCollectionDescriptor("points", GeographicEngine.EngineName, 2, "location", options, SpatialEngineSettings.ForGeographic(GeographicDistanceMode.Haversine));
+        var engine = new GeographicEngine("location", options, GeographicDistanceMode.Haversine);
+        descriptor = descriptor.WithEngine(engine);
+
+        var resolver = new SpatialResolver(descriptor);
+        var method = typeof(SpatialExpressions).GetMethod(nameof(SpatialExpressions.InBox), new[] { typeof(GeoPoint), typeof(BoundingBox) })!;
+        var candidate = Expression.Parameter(typeof(GeoPoint), "candidate");
+        var bounds = Expression.Constant(BoundingBox.From2D(-10, -10, 10, 10));
+        var call = Expression.Call(method, candidate, bounds);
+
+        resolver.TryResolve(call, out var plan).Should().BeTrue();
+        plan.Should().NotBeNull();
+        plan!.CoveringBounds.Should().NotBeNull();
+        plan.IndexRanges.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void MissingEngineThrowsMetadataException()
+    {
+        var descriptor = new SpatialCollectionDescriptor("points", GeographicEngine.EngineName, 2, "location", new SpatialIndexOptions(), SpatialEngineSettings.ForGeographic(GeographicDistanceMode.Haversine));
+        var resolver = new SpatialResolver(descriptor);
+        var method = typeof(SpatialExpressions).GetMethod(nameof(SpatialExpressions.Near), new[] { typeof(GeoPoint), typeof(GeoPoint), typeof(double) })!;
+        var candidate = Expression.Parameter(typeof(GeoPoint), "candidate");
+        var call = Expression.Call(method, candidate, Expression.Constant(new GeoPoint(0, 0)), Expression.Constant(10d));
+
+        Action action = () => resolver.TryResolve(call, out _);
+        action.Should().Throw<SpatialMetadataException>().WithMessage("*runtime spatial engine*");
+    }
+
+    [Fact]
+    public void ParameterBasedArgumentsAreNotSupported()
+    {
+        var options = new SpatialIndexOptions();
+        var descriptor = new SpatialCollectionDescriptor("points", GeographicEngine.EngineName, 2, "location", options, SpatialEngineSettings.ForGeographic(GeographicDistanceMode.Haversine));
+        var engine = new GeographicEngine("location", options, GeographicDistanceMode.Haversine);
+        descriptor = descriptor.WithEngine(engine);
+        var resolver = new SpatialResolver(descriptor);
+
+        var method = typeof(SpatialExpressions).GetMethod(nameof(SpatialExpressions.Near), new[] { typeof(GeoPoint), typeof(GeoPoint), typeof(double) })!;
+        var candidate = Expression.Parameter(typeof(GeoPoint), "candidate");
+        var radiusParameter = Expression.Parameter(typeof(double), "radius");
+        var call = Expression.Call(method, candidate, Expression.Constant(new GeoPoint(0, 0)), radiusParameter);
+
+        Action action = () => resolver.TryResolve(call, out _);
+        action.Should().Throw<NotSupportedException>();
+    }
+}

--- a/LiteDB.Spatial.Core/Diagnostics/SpatialDiagnostics.cs
+++ b/LiteDB.Spatial.Core/Diagnostics/SpatialDiagnostics.cs
@@ -1,0 +1,34 @@
+#nullable enable
+
+using System;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helper methods for inspecting spatial query plans.
+/// </summary>
+public static class SpatialDiagnostics
+{
+    /// <summary>
+    /// Produces a human-readable summary of the supplied query plan.
+    /// </summary>
+    /// <param name="descriptor">The spatial descriptor describing the collection.</param>
+    /// <param name="plan">The query plan to summarize.</param>
+    /// <returns>A <see cref="SpatialExplainResult"/> containing the formatted summary.</returns>
+    public static SpatialExplainResult Explain(SpatialCollectionDescriptor descriptor, ISpatialQueryPlan plan)
+    {
+        if (descriptor is null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (plan is null)
+        {
+            throw new ArgumentNullException(nameof(plan));
+        }
+
+        var ranges = plan.IndexRanges?.ToArray() ?? Array.Empty<SpatialIndexRange>();
+        return new SpatialExplainResult(descriptor.CollectionName, descriptor.EngineName, plan.Dimensions, plan.CoveringBounds, ranges, plan.ExactPredicateDescription);
+    }
+}

--- a/LiteDB.Spatial.Core/Diagnostics/SpatialExplainResult.cs
+++ b/LiteDB.Spatial.Core/Diagnostics/SpatialExplainResult.cs
@@ -1,0 +1,104 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a human-readable summary of a spatial query plan.
+/// </summary>
+public sealed class SpatialExplainResult
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialExplainResult"/> class.
+    /// </summary>
+    /// <param name="collectionName">The name of the collection the plan targets.</param>
+    /// <param name="engineName">The engine that produced the plan.</param>
+    /// <param name="dimensions">The dimensionality of the spatial index.</param>
+    /// <param name="coveringBounds">Optional coarse covering bounds.</param>
+    /// <param name="indexRanges">The index ranges scanned by the plan.</param>
+    /// <param name="predicate">Human readable description of the exact predicate.</param>
+    public SpatialExplainResult(
+        string collectionName,
+        string engineName,
+        int dimensions,
+        BoundingBox? coveringBounds,
+        IReadOnlyList<SpatialIndexRange> indexRanges,
+        string? predicate)
+    {
+        if (string.IsNullOrWhiteSpace(collectionName))
+        {
+            throw new ArgumentException("Collection name must be provided.", nameof(collectionName));
+        }
+
+        if (string.IsNullOrWhiteSpace(engineName))
+        {
+            throw new ArgumentException("Engine name must be provided.", nameof(engineName));
+        }
+
+        if (dimensions is < 2 or > 3)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dimensions), "Spatial plans must describe two or three dimensions.");
+        }
+
+        CollectionName = collectionName;
+        EngineName = engineName;
+        Dimensions = dimensions;
+        CoveringBounds = coveringBounds;
+        IndexRanges = new ReadOnlyCollection<SpatialIndexRange>((indexRanges ?? throw new ArgumentNullException(nameof(indexRanges))).ToList());
+        ExactPredicateDescription = predicate;
+    }
+
+    /// <summary>
+    /// Gets the name of the collection targeted by the plan.
+    /// </summary>
+    public string CollectionName { get; }
+
+    /// <summary>
+    /// Gets the name of the engine that produced the plan.
+    /// </summary>
+    public string EngineName { get; }
+
+    /// <summary>
+    /// Gets the dimensionality of the spatial index.
+    /// </summary>
+    public int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the optional coarse covering bounds.
+    /// </summary>
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <summary>
+    /// Gets the index ranges scanned by the plan.
+    /// </summary>
+    public IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <summary>
+    /// Gets the human-readable description of the exact predicate.
+    /// </summary>
+    public string? ExactPredicateDescription { get; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "Collection: {0}", CollectionName));
+        builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "Engine: {0} ({1}D)", EngineName, Dimensions));
+        builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "Covering bounds: {0}", CoveringBounds?.ToString() ?? "<none>"));
+        builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "Index ranges ({0}):", IndexRanges.Count));
+
+        foreach (var range in IndexRanges)
+        {
+            builder.AppendLine(string.Format(CultureInfo.InvariantCulture, "  - {0}", range));
+        }
+
+        builder.Append(string.Format(CultureInfo.InvariantCulture, "Exact predicate: {0}", ExactPredicateDescription ?? "<none>"));
+        return builder.ToString();
+    }
+}

--- a/LiteDB.Spatial.Core/GeoJson/GeoJsonSerializer.cs
+++ b/LiteDB.Spatial.Core/GeoJson/GeoJsonSerializer.cs
@@ -1,0 +1,221 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Serializes and deserializes geometry objects using the GeoJSON specification.
+/// </summary>
+public static class GeoJsonSerializer
+{
+    /// <summary>
+    /// Converts a geometry object into a GeoJSON <see cref="BaseLiteDB.BsonValue"/> representation.
+    /// </summary>
+    /// <param name="geometry">The geometry instance to serialize.</param>
+    /// <returns>A <see cref="BaseLiteDB.BsonValue"/> describing the geometry.</returns>
+    public static BaseLiteDB.BsonValue ToBson(object? geometry)
+    {
+        return geometry switch
+        {
+            null => BaseLiteDB.BsonValue.Null,
+            GeoPoint point => CreateDocument("Point", BuildPosition(point)),
+            GeoLineString line => CreateDocument("LineString", BuildLineStringCoordinates(line)),
+            GeoPolygon polygon => CreateDocument("Polygon", BuildPolygonCoordinates(polygon)),
+            _ => throw new ArgumentException($"Unsupported geometry type '{geometry.GetType().FullName}'.", nameof(geometry))
+        };
+    }
+
+    /// <summary>
+    /// Deserializes the provided GeoJSON <see cref="BaseLiteDB.BsonValue"/> into a CLR geometry.
+    /// </summary>
+    /// <param name="value">The GeoJSON representation.</param>
+    /// <returns>The CLR geometry instance or <c>null</c> when <paramref name="value"/> is <c>null</c>.</returns>
+    public static object? FromBson(BaseLiteDB.BsonValue value)
+    {
+        if (value.IsNull)
+        {
+            return null;
+        }
+
+        if (!value.IsDocument)
+        {
+            throw new ArgumentException("GeoJSON payload must be a document.", nameof(value));
+        }
+
+        var document = value.AsDocument;
+        if (!document.TryGetValue("type", out var typeValue) || !typeValue.IsString)
+        {
+            throw new ArgumentException("GeoJSON document must contain a string 'type' property.", nameof(value));
+        }
+
+        var type = typeValue.AsString;
+        var coordinates = EnsureArray(document, "coordinates");
+
+        return type switch
+        {
+            "Point" => ParsePoint(coordinates),
+            "LineString" => ParseLineString(coordinates),
+            "Polygon" => ParsePolygon(coordinates),
+            _ => throw new ArgumentException($"Unsupported GeoJSON geometry type '{type}'.", nameof(value))
+        };
+    }
+
+    /// <summary>
+    /// Deserializes the GeoJSON payload into a strongly typed geometry instance.
+    /// </summary>
+    /// <typeparam name="T">The expected geometry type.</typeparam>
+    /// <param name="value">The GeoJSON representation.</param>
+    /// <returns>The typed geometry instance.</returns>
+    public static T FromBson<T>(BaseLiteDB.BsonValue value)
+    {
+        var geometry = FromBson(value);
+        if (geometry is null)
+        {
+            if (default(T) is null)
+            {
+                return default!;
+            }
+
+            throw new ArgumentException("GeoJSON payload is null but the requested type is not nullable.", nameof(value));
+        }
+
+        if (geometry is T typed)
+        {
+            return typed;
+        }
+
+        throw new ArgumentException($"GeoJSON payload describes '{geometry.GetType().Name}' instead of '{typeof(T).Name}'.", nameof(value));
+    }
+
+    private static BaseLiteDB.BsonDocument CreateDocument(string type, BaseLiteDB.BsonValue coordinates)
+    {
+        return new BaseLiteDB.BsonDocument
+        {
+            ["type"] = type,
+            ["coordinates"] = coordinates
+        };
+    }
+
+    private static BaseLiteDB.BsonValue BuildPosition(GeoPoint point)
+    {
+        return new BaseLiteDB.BsonArray { point.Longitude, point.Latitude };
+    }
+
+    private static BaseLiteDB.BsonValue BuildLineStringCoordinates(GeoLineString line)
+    {
+        var array = new BaseLiteDB.BsonArray();
+        foreach (var point in line.Points)
+        {
+            array.Add(BuildPosition(point));
+        }
+
+        return array;
+    }
+
+    private static BaseLiteDB.BsonValue BuildPolygonCoordinates(GeoPolygon polygon)
+    {
+        var rings = new BaseLiteDB.BsonArray
+        {
+            BuildLinearRing(polygon.Outer)
+        };
+
+        foreach (var hole in polygon.Holes)
+        {
+            rings.Add(BuildLinearRing(hole));
+        }
+
+        return rings;
+    }
+
+    private static BaseLiteDB.BsonArray BuildLinearRing(IReadOnlyList<GeoPoint> points)
+    {
+        var ring = new BaseLiteDB.BsonArray();
+        foreach (var point in points)
+        {
+            ring.Add(BuildPosition(point));
+        }
+
+        return ring;
+    }
+
+    private static GeoPoint ParsePoint(BaseLiteDB.BsonArray coordinates)
+    {
+        if (coordinates.Count < 2)
+        {
+            throw new ArgumentException("GeoJSON point coordinates must contain [longitude, latitude].", nameof(coordinates));
+        }
+
+        return new GeoPoint(coordinates[0].AsDouble, coordinates[1].AsDouble);
+    }
+
+    private static GeoLineString ParseLineString(BaseLiteDB.BsonArray coordinates)
+    {
+        var points = new List<GeoPoint>(coordinates.Count);
+        foreach (var value in coordinates)
+        {
+            if (!value.IsArray)
+            {
+                throw new ArgumentException("GeoJSON LineString coordinates must be arrays of positions.", nameof(coordinates));
+            }
+
+            points.Add(ParsePoint(value.AsArray));
+        }
+
+        return new GeoLineString(points);
+    }
+
+    private static GeoPolygon ParsePolygon(BaseLiteDB.BsonArray coordinates)
+    {
+        if (coordinates.Count == 0)
+        {
+            throw new ArgumentException("GeoJSON Polygon requires at least one linear ring.", nameof(coordinates));
+        }
+
+        var outerRing = ParseLinearRing(coordinates[0]);
+        var holes = new List<IReadOnlyList<GeoPoint>>();
+
+        for (var i = 1; i < coordinates.Count; i++)
+        {
+            holes.Add(ParseLinearRing(coordinates[i]));
+        }
+
+        return new GeoPolygon(outerRing, holes);
+    }
+
+    private static IReadOnlyList<GeoPoint> ParseLinearRing(BaseLiteDB.BsonValue value)
+    {
+        if (!value.IsArray)
+        {
+            throw new ArgumentException("GeoJSON linear rings must be arrays of positions.", nameof(value));
+        }
+
+        var coordinates = value.AsArray;
+        var points = new List<GeoPoint>(coordinates.Count);
+        foreach (var position in coordinates)
+        {
+            if (!position.IsArray)
+            {
+                throw new ArgumentException("GeoJSON positions must be arrays of [longitude, latitude].", nameof(value));
+            }
+
+            points.Add(ParsePoint(position.AsArray));
+        }
+
+        return points;
+    }
+
+    private static BaseLiteDB.BsonArray EnsureArray(BaseLiteDB.BsonDocument document, string key)
+    {
+        if (!document.TryGetValue(key, out var value) || !value.IsArray)
+        {
+            throw new ArgumentException($"GeoJSON document must contain an array '{key}'.", key);
+        }
+
+        return value.AsArray;
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoLineString.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoLineString.cs
@@ -1,0 +1,97 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents an ordered set of points describing a GeoJSON LineString geometry.
+/// </summary>
+public sealed class GeoLineString : IEquatable<GeoLineString>
+{
+    private readonly ReadOnlyCollection<GeoPoint> _points;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoLineString"/> class.
+    /// </summary>
+    /// <param name="points">The ordered points that compose the line.</param>
+    public GeoLineString(IEnumerable<GeoPoint> points)
+    {
+        if (points is null)
+        {
+            throw new ArgumentNullException(nameof(points));
+        }
+
+        var materialized = points.ToList();
+        if (materialized.Count < 2)
+        {
+            throw new ArgumentException("LineString requires at least two points.", nameof(points));
+        }
+
+        _points = new ReadOnlyCollection<GeoPoint>(materialized);
+    }
+
+    /// <summary>
+    /// Gets the ordered list of points that compose the line string.
+    /// </summary>
+    public IReadOnlyList<GeoPoint> Points => _points;
+
+    /// <inheritdoc />
+    public bool Equals(GeoLineString? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (_points.Count != other._points.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _points.Count; i++)
+        {
+            if (!_points[i].Equals(other._points[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoLineString line && Equals(line);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            foreach (var point in _points)
+            {
+                hash = (hash * 397) ^ point.GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"LineString({string.Join(", ", _points)})";
+    }
+}

--- a/LiteDB.Spatial.Core/Geometry/GeoPolygon.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPolygon.cs
@@ -1,0 +1,172 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a GeoJSON polygon composed of an outer ring and optional holes.
+/// </summary>
+public sealed class GeoPolygon : IEquatable<GeoPolygon>
+{
+    private readonly ReadOnlyCollection<GeoPoint> _outer;
+    private readonly ReadOnlyCollection<IReadOnlyList<GeoPoint>> _holes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPolygon"/> class.
+    /// </summary>
+    /// <param name="outer">The closed outer ring describing the polygon boundary.</param>
+    /// <param name="holes">Optional closed inner rings describing voids inside the polygon.</param>
+    public GeoPolygon(IReadOnlyList<GeoPoint> outer, IReadOnlyList<IReadOnlyList<GeoPoint>>? holes = null)
+    {
+        if (outer is null)
+        {
+            throw new ArgumentNullException(nameof(outer));
+        }
+
+        _outer = new ReadOnlyCollection<GeoPoint>(ValidateRing(outer, nameof(outer)));
+
+        if (holes is null || holes.Count == 0)
+        {
+            _holes = new ReadOnlyCollection<IReadOnlyList<GeoPoint>>(Array.Empty<IReadOnlyList<GeoPoint>>());
+            return;
+        }
+
+        var materialized = new List<IReadOnlyList<GeoPoint>>(holes.Count);
+        for (var i = 0; i < holes.Count; i++)
+        {
+            var ring = holes[i];
+            var name = $"holes[{i}]";
+            var validated = new ReadOnlyCollection<GeoPoint>(ValidateRing(ring, name));
+            materialized.Add(validated);
+        }
+
+        _holes = new ReadOnlyCollection<IReadOnlyList<GeoPoint>>(materialized);
+    }
+
+    /// <summary>
+    /// Gets the closed outer ring describing the polygon boundary.
+    /// </summary>
+    public IReadOnlyList<GeoPoint> Outer => _outer;
+
+    /// <summary>
+    /// Gets the optional closed rings that describe holes within the polygon.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<GeoPoint>> Holes => _holes;
+
+    /// <inheritdoc />
+    public bool Equals(GeoPolygon? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (!SequenceEqual(_outer, other._outer))
+        {
+            return false;
+        }
+
+        if (_holes.Count != other._holes.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _holes.Count; i++)
+        {
+            if (!SequenceEqual(_holes[i], other._holes[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPolygon polygon && Equals(polygon);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            foreach (var point in _outer)
+            {
+                hash = (hash * 397) ^ point.GetHashCode();
+            }
+
+            foreach (var hole in _holes)
+            {
+                foreach (var point in hole)
+                {
+                    hash = (hash * 397) ^ point.GetHashCode();
+                }
+
+                hash = (hash * 397) ^ 31;
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        var holesDescription = _holes.Count == 0
+            ? "[]"
+            : $"[{string.Join("; ", _holes.Select(h => string.Join(", ", h)))}]";
+        return $"Polygon(outer: {string.Join(", ", _outer)}, holes: {holesDescription})";
+    }
+
+    private static List<GeoPoint> ValidateRing(IReadOnlyList<GeoPoint> ring, string argumentName)
+    {
+        if (ring is null)
+        {
+            throw new ArgumentNullException(argumentName);
+        }
+
+        if (ring.Count < 4)
+        {
+            throw new ArgumentException("Polygon rings must contain at least four points including closure.", argumentName);
+        }
+
+        var materialized = ring.ToList();
+        if (!materialized.First().Equals(materialized.Last()))
+        {
+            throw new ArgumentException("Polygon rings must be closed (first point equals last point).", argumentName);
+        }
+
+        return materialized;
+    }
+
+    private static bool SequenceEqual(IReadOnlyList<GeoPoint> left, IReadOnlyList<GeoPoint> right)
+    {
+        if (left.Count != right.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < left.Count; i++)
+        {
+            if (!left[i].Equals(right[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
@@ -1,5 +1,6 @@
 #nullable enable
 
+using System;
 using System.Linq.Expressions;
 
 namespace LiteDB.Spatial;
@@ -9,6 +10,21 @@ namespace LiteDB.Spatial;
 /// </summary>
 public sealed class SpatialResolver
 {
+    private readonly SpatialCollectionDescriptor _descriptor;
+    private readonly Func<SpatialCollectionDescriptor, ISpatialEngine>? _engineFactory;
+    private ISpatialEngine? _cachedEngine;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialResolver"/> class.
+    /// </summary>
+    /// <param name="descriptor">The spatial collection descriptor associated with the query source.</param>
+    /// <param name="engineFactory">Optional factory used to obtain a runtime engine instance when the descriptor is not already attached to one.</param>
+    public SpatialResolver(SpatialCollectionDescriptor descriptor, Func<SpatialCollectionDescriptor, ISpatialEngine>? engineFactory = null)
+    {
+        _descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+        _engineFactory = engineFactory;
+    }
+
     /// <summary>
     /// Attempts to translate the provided method call expression into a spatial query plan.
     /// </summary>
@@ -17,7 +33,181 @@ public sealed class SpatialResolver
     /// <returns><c>true</c> when translation succeeded; otherwise, <c>false</c>.</returns>
     public bool TryResolve(MethodCallExpression expression, out ISpatialQueryPlan? plan)
     {
+        if (expression is null)
+        {
+            throw new ArgumentNullException(nameof(expression));
+        }
+
         plan = default;
-        return false;
+
+        if (expression.Method.DeclaringType != typeof(SpatialExpressions))
+        {
+            return false;
+        }
+
+        return expression.Method.Name switch
+        {
+            nameof(SpatialExpressions.Near) => TryResolveNear(expression, out plan),
+            nameof(SpatialExpressions.InBox) => TryResolveInBox(expression, out plan),
+            _ => false
+        };
+    }
+
+    private bool TryResolveNear(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        var parameters = expression.Method.GetParameters();
+        if (parameters.Length != 3)
+        {
+            plan = default;
+            return false;
+        }
+
+        var candidateType = parameters[0].ParameterType;
+        var engine = ResolveEngine();
+
+        if (candidateType == typeof(GeoPoint))
+        {
+            EnsureDimensions(2, "GeoPoint", engine);
+            var center = EvaluateArgument<GeoPoint>(expression.Arguments[1], "center point");
+            var radius = EvaluateArgument<double>(expression.Arguments[2], "radius");
+            plan = engine.PlanNear(center, radius);
+            return true;
+        }
+
+        if (candidateType == typeof(GeoPoint3D))
+        {
+            EnsureDimensions(3, "GeoPoint3D", engine);
+            var center = EvaluateArgument<GeoPoint3D>(expression.Arguments[1], "center point");
+            var radius = EvaluateArgument<double>(expression.Arguments[2], "radius");
+            plan = engine.PlanNear(center, radius);
+            return true;
+        }
+
+        throw new NotSupportedException($"SpatialExpressions.Near does not support candidate type '{candidateType}'.");
+    }
+
+    private bool TryResolveInBox(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        var parameters = expression.Method.GetParameters();
+        if (parameters.Length != 2)
+        {
+            plan = default;
+            return false;
+        }
+
+        var candidateType = parameters[0].ParameterType;
+        var bounds = EvaluateArgument<BoundingBox>(expression.Arguments[1], "bounding box");
+        _descriptor.EnsureCompatible(bounds);
+
+        var engine = ResolveEngine();
+
+        if (candidateType == typeof(GeoPoint))
+        {
+            EnsureDimensions(2, "GeoPoint", engine);
+            plan = engine.PlanWithin(bounds);
+            return true;
+        }
+
+        if (candidateType == typeof(GeoPoint3D))
+        {
+            EnsureDimensions(3, "GeoPoint3D", engine);
+            plan = engine.PlanWithin(bounds);
+            return true;
+        }
+
+        throw new NotSupportedException($"SpatialExpressions.InBox does not support candidate type '{candidateType}'.");
+    }
+
+    private ISpatialEngine ResolveEngine()
+    {
+        if (_cachedEngine is not null)
+        {
+            return _cachedEngine;
+        }
+
+        if (_descriptor.HasEngine)
+        {
+            _cachedEngine = _descriptor.Engine!;
+        }
+        else
+        {
+            if (_engineFactory is null)
+            {
+                throw new SpatialMetadataException($"Collection '{_descriptor.CollectionName}' does not have a runtime spatial engine attached. Provide an engine factory when creating the resolver or attach an engine to the descriptor using WithEngine().");
+            }
+
+            _cachedEngine = _engineFactory(_descriptor) ?? throw new SpatialMetadataException($"The engine factory did not return an engine for collection '{_descriptor.CollectionName}'.");
+        }
+
+        if (!string.Equals(_cachedEngine.Name, _descriptor.EngineName, StringComparison.Ordinal))
+        {
+            throw new SpatialMetadataException($"Spatial engine '{_cachedEngine.Name}' does not match descriptor engine '{_descriptor.EngineName}'.");
+        }
+
+        if (_cachedEngine.Dimensions != _descriptor.Dimensions)
+        {
+            throw new SpatialMetadataException($"Spatial engine '{_cachedEngine.Name}' reports {_cachedEngine.Dimensions} dimensions but descriptor expects {_descriptor.Dimensions}.");
+        }
+
+        if (!_cachedEngine.Options.Equals(_descriptor.Options))
+        {
+            throw new SpatialMetadataException($"Spatial engine '{_cachedEngine.Name}' options do not match the descriptor options for collection '{_descriptor.CollectionName}'.");
+        }
+
+        return _cachedEngine;
+    }
+
+    private void EnsureDimensions(int expected, string argument, ISpatialEngine engine)
+    {
+        if (_descriptor.Dimensions != expected)
+        {
+            throw new SpatialMetadataException($"Collection '{_descriptor.CollectionName}' is configured for {_descriptor.Dimensions}D geometry but a {argument} was used which requires {expected}D metadata.");
+        }
+
+        if (engine.Dimensions != expected)
+        {
+            throw new SpatialMetadataException($"Spatial engine '{engine.Name}' reports {engine.Dimensions} dimensions but a {argument} requires {expected}D support.");
+        }
+    }
+
+    private static T EvaluateArgument<T>(Expression expression, string description)
+    {
+        if (expression is null)
+        {
+            throw new ArgumentNullException(nameof(expression));
+        }
+
+        if (ContainsParameter(expression))
+        {
+            throw new NotSupportedException($"SpatialExpressions arguments must be constant or captured values. Unable to evaluate {description}.");
+        }
+
+        try
+        {
+            var lambda = Expression.Lambda<Func<T>>(Expression.Convert(expression, typeof(T)));
+            return lambda.Compile().Invoke();
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to evaluate spatial argument '{description}'.", ex);
+        }
+    }
+
+    private static bool ContainsParameter(Expression expression)
+    {
+        var visitor = new ParameterDetectionVisitor();
+        visitor.Visit(expression);
+        return visitor.ContainsParameter;
+    }
+
+    private sealed class ParameterDetectionVisitor : ExpressionVisitor
+    {
+        public bool ContainsParameter { get; private set; }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            ContainsParameter = true;
+            return base.VisitParameter(node);
+        }
     }
 }

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -142,15 +142,15 @@ LiteDB.Spatial
 
 ### S8 — LINQ resolver
 
-- [ ] Translate `SpatialExpressions` into query plans based on metadata.
+- [x] Translate `SpatialExpressions` into query plans based on metadata.
 
 ### S9 — Diagnostics ("Explain")
 
-- [ ] Produce printable `SpatialExplainResult` summaries for query plans.
+- [x] Produce printable `SpatialExplainResult` summaries for query plans.
 
 ### S10 — GeoJSON I/O (minimal)
 
-- [ ] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
+- [x] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
 
 ### S11 — Top-level facade & dispatch
 


### PR DESCRIPTION
## Summary
- translate `SpatialExpressions` LINQ calls into engine plans using spatial descriptors
- add spatial diagnostics helpers that format query plans for explain output
- introduce GeoJSON serializer support with supporting geometry types and tests
- update the spatial revamp task checklist for completed work

## Testing
- dotnet build LiteDB.sln
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e791778c14832683a5df34bceec562