### PR TITLE
Implement spatial resolver, diagnostics, and GeoJSON serializer

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Diagnostics/SpatialDiagnosticsTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Diagnostics/SpatialDiagnosticsTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Diagnostics;
+
+public sealed class SpatialDiagnosticsTests
+{
+    [Fact]
+    public void ExplainProducesSummary()
+    {
+        var options = new SpatialIndexOptions(precisionBits: 4, maxCoveringCells: 8, distanceTolerance: 0.5);
+        var descriptor = new SpatialCollectionDescriptor("places", "Geographic2D", 2, "Location", options);
+        var ranges = new List<SpatialIndexRange>
+        {
+            new SpatialIndexRange(10, 12),
+            new SpatialIndexRange(20, 25)
+        };
+
+        var plan = new SpatialQueryPlan(2, BoundingBox.From2D(-1, -1, 1, 1), ranges, "Haversine <= 500 m");
+
+        var result = SpatialDiagnostics.Explain(descriptor, plan);
+
+        result.CollectionName.Should().Be("places");
+        result.EngineName.Should().Be("Geographic2D");
+        result.Dimensions.Should().Be(2);
+        result.IndexRanges.Should().BeEquivalentTo(ranges, options => options.WithStrictOrdering());
+        result.CoveringBounds.Should().Be(plan.CoveringBounds);
+        result.ExactPredicate.Should().Be("Haversine <= 500 m");
+
+        var summary = result.ToString();
+        summary.Should().Contain("Collection : places");
+        summary.Should().Contain("Engine     : Geographic2D (2D)");
+        summary.Should().Contain("Ranges (2):");
+        summary.Should().Contain("[10, 12]");
+        summary.Should().Contain("Predicate  : Haversine <= 500 m");
+    }
+
+    [Fact]
+    public void ExplainRequiresArguments()
+    {
+        var options = new SpatialIndexOptions();
+        var descriptor = new SpatialCollectionDescriptor("places", "Geographic2D", 2, "Location", options);
+
+        Assert.Throws<System.ArgumentNullException>(() => SpatialDiagnostics.Explain(descriptor, null!));
+        Assert.Throws<System.ArgumentNullException>(() => SpatialDiagnostics.Explain(null!, new SpatialQueryPlan(2, null, Array.Empty<SpatialIndexRange>(), null)));
+    }
+}
+

--- a/LiteDB.Spatial.Core.Tests/Io/GeoJsonSerializerTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Io/GeoJsonSerializerTests.cs
@@ -1,0 +1,91 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Io;
+
+public sealed class GeoJsonSerializerTests
+{
+    [Fact]
+    public void RoundTripPoint()
+    {
+        var point = new GeoPoint(12.5, -45.25);
+        var bson = GeoJsonSerializer.Serialize(point);
+
+        bson.IsDocument.Should().BeTrue();
+        bson.AsDocument["type"].AsString.Should().Be("Point");
+
+        var deserialized = GeoJsonSerializer.DeserializePoint(bson);
+        deserialized.Should().Be(point);
+
+        GeoJsonSerializer.Deserialize(bson).Should().Be(point);
+    }
+
+    [Fact]
+    public void RoundTripLineString()
+    {
+        var line = new GeoLineString(new List<GeoPoint>
+        {
+            new GeoPoint(0, 0),
+            new GeoPoint(1, 1),
+            new GeoPoint(2, 2)
+        });
+
+        var bson = GeoJsonSerializer.Serialize(line);
+        bson.AsDocument["type"].AsString.Should().Be("LineString");
+
+        var deserialized = GeoJsonSerializer.DeserializeLineString(bson);
+        deserialized.Should().BeEquivalentTo(line, options => options.WithStrictOrdering());
+        GeoJsonSerializer.Deserialize(bson).Should().BeEquivalentTo(line, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void RoundTripPolygon()
+    {
+        var outer = new List<GeoPoint>
+        {
+            new GeoPoint(0, 0),
+            new GeoPoint(0, 1),
+            new GeoPoint(1, 1),
+            new GeoPoint(1, 0),
+            new GeoPoint(0, 0)
+        };
+        var holes = new List<IReadOnlyList<GeoPoint>>
+        {
+            new List<GeoPoint>
+            {
+                new GeoPoint(0.2, 0.2),
+                new GeoPoint(0.2, 0.4),
+                new GeoPoint(0.4, 0.4),
+                new GeoPoint(0.4, 0.2),
+                new GeoPoint(0.2, 0.2)
+            }
+        };
+
+        var polygon = new GeoPolygon(outer, holes);
+        var bson = GeoJsonSerializer.Serialize(polygon);
+
+        bson.AsDocument["type"].AsString.Should().Be("Polygon");
+
+        var deserialized = GeoJsonSerializer.DeserializePolygon(bson);
+        deserialized.Should().BeEquivalentTo(polygon, options => options.WithStrictOrdering());
+        GeoJsonSerializer.Deserialize(bson).Should().BeEquivalentTo(polygon, options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void DeserializeRequiresType()
+    {
+        var invalid = new BaseLiteDB.BsonDocument
+        {
+            ["coordinates"] = new BaseLiteDB.BsonArray { 0, 0 }
+        };
+
+        FluentActions.Invoking(() => GeoJsonSerializer.Deserialize(invalid)).Should().Throw<FormatException>();
+    }
+}
+

--- a/LiteDB.Spatial.Core.Tests/Linq/SpatialResolverTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Linq/SpatialResolverTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Linq.Expressions;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Linq;
+
+public sealed class SpatialResolverTests
+{
+    private sealed class GeoDocument
+    {
+        public GeoPoint Location { get; set; }
+        public GeoPoint3D Position { get; set; }
+    }
+
+    [Fact]
+    public void ResolveNear2D_UsesGeographicEngine()
+    {
+        var options = new SpatialIndexOptions(precisionBits: 8, maxCoveringCells: 4, distanceTolerance: 0.01);
+        var engine = new GeographicEngine(nameof(GeoDocument.Location), options, GeographicDistanceMode.Haversine);
+        var descriptor = new SpatialCollectionDescriptor(
+            "places",
+            GeographicEngine.EngineName,
+            2,
+            nameof(GeoDocument.Location),
+            options,
+            SpatialEngineSettings.ForGeographic(GeographicDistanceMode.Haversine),
+            engine);
+
+        var resolver = new SpatialResolver(descriptor);
+        Expression<Func<GeoDocument, bool>> query = doc => SpatialExpressions.Near(doc.Location, new GeoPoint(10, 20), 500);
+        var expected = engine.PlanNear(new GeoPoint(10, 20), 500);
+
+        resolver.TryResolve((MethodCallExpression)query.Body, out var plan).Should().BeTrue();
+        plan.Should().NotBeNull();
+        plan!.Dimensions.Should().Be(expected.Dimensions);
+        plan.IndexRanges.Should().BeEquivalentTo(expected.IndexRanges, options => options.WithStrictOrdering());
+        plan.ExactPredicateDescription.Should().Be(expected.ExactPredicateDescription);
+    }
+
+    [Fact]
+    public void ResolveNear3D_UsesCartesianEngine()
+    {
+        var domain = BoundingBox.From3D(-100, -100, -100, 100, 100, 100);
+        var options = new SpatialIndexOptions(precisionBits: 6, maxCoveringCells: 8, distanceTolerance: 0.1);
+        var engine = new Cartesian3DEngine(nameof(GeoDocument.Position), domain, options);
+        var descriptor = new SpatialCollectionDescriptor(
+            "assets",
+            Cartesian3DEngine.EngineName,
+            3,
+            nameof(GeoDocument.Position),
+            options,
+            SpatialEngineSettings.ForCartesian(domain),
+            engine);
+
+        var resolver = new SpatialResolver(descriptor);
+        var center = new GeoPoint3D(1, 2, 3);
+        Expression<Func<GeoDocument, bool>> query = doc => SpatialExpressions.Near(doc.Position, center, 15.5);
+        var expected = engine.PlanNear(center, 15.5);
+
+        resolver.TryResolve((MethodCallExpression)query.Body, out var plan).Should().BeTrue();
+        plan.Should().NotBeNull();
+        plan!.Dimensions.Should().Be(expected.Dimensions);
+        plan.IndexRanges.Should().BeEquivalentTo(expected.IndexRanges, options => options.WithStrictOrdering());
+        plan.ExactPredicateDescription.Should().Be(expected.ExactPredicateDescription);
+    }
+
+    [Fact]
+    public void ResolveInBox_UsesBoundingBoxPlan()
+    {
+        var options = new SpatialIndexOptions();
+        var domain = BoundingBox.From2D(-1, -1, 1, 1);
+        var engine = new Cartesian2DEngine(nameof(GeoDocument.Location), domain, options);
+        var descriptor = new SpatialCollectionDescriptor(
+            "grid",
+            Cartesian2DEngine.EngineName,
+            2,
+            nameof(GeoDocument.Location),
+            options,
+            SpatialEngineSettings.ForCartesian(domain),
+            engine);
+
+        var resolver = new SpatialResolver(descriptor);
+        var bounds = BoundingBox.From2D(-0.5, -0.5, 0.5, 0.5);
+        Expression<Func<GeoDocument, bool>> query = doc => SpatialExpressions.InBox(doc.Location, bounds);
+        var expected = engine.PlanWithin(bounds);
+
+        resolver.TryResolve((MethodCallExpression)query.Body, out var plan).Should().BeTrue();
+        plan.Should().NotBeNull();
+        plan!.Dimensions.Should().Be(expected.Dimensions);
+        plan.IndexRanges.Should().BeEquivalentTo(expected.IndexRanges, options => options.WithStrictOrdering());
+        plan.CoveringBounds.Should().Be(expected.CoveringBounds);
+        plan.ExactPredicateDescription.Should().Be(expected.ExactPredicateDescription);
+    }
+
+    [Fact]
+    public void ResolveNearWithoutEngineThrows()
+    {
+        var options = new SpatialIndexOptions();
+        var descriptor = new SpatialCollectionDescriptor(
+            "places",
+            GeographicEngine.EngineName,
+            2,
+            nameof(GeoDocument.Location),
+            options,
+            SpatialEngineSettings.ForGeographic(GeographicDistanceMode.Haversine));
+
+        var resolver = new SpatialResolver(descriptor);
+        Expression<Func<GeoDocument, bool>> query = doc => SpatialExpressions.Near(doc.Location, new GeoPoint(0, 0), 10);
+
+        Action action = () => resolver.TryResolve((MethodCallExpression)query.Body, out _);
+        action.Should().Throw<SpatialMetadataException>()
+            .WithMessage("*does not have a runtime spatial engine attached*");
+    }
+}
+

--- a/LiteDB.Spatial.Core/Diagnostics/SpatialDiagnostics.cs
+++ b/LiteDB.Spatial.Core/Diagnostics/SpatialDiagnostics.cs
@@ -1,0 +1,33 @@
+#nullable enable
+
+using System;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helper methods for producing spatial diagnostic summaries.
+/// </summary>
+public static class SpatialDiagnostics
+{
+    /// <summary>
+    /// Generates an explain result describing the provided spatial plan.
+    /// </summary>
+    /// <param name="descriptor">The descriptor associated with the collection executing the plan.</param>
+    /// <param name="plan">The spatial query plan.</param>
+    /// <returns>A printable explain result.</returns>
+    public static SpatialExplainResult Explain(SpatialCollectionDescriptor descriptor, ISpatialQueryPlan plan)
+    {
+        if (descriptor == null)
+        {
+            throw new ArgumentNullException(nameof(descriptor));
+        }
+
+        if (plan == null)
+        {
+            throw new ArgumentNullException(nameof(plan));
+        }
+
+        return new SpatialExplainResult(descriptor, plan);
+    }
+}
+

--- a/LiteDB.Spatial.Core/Diagnostics/SpatialExplainResult.cs
+++ b/LiteDB.Spatial.Core/Diagnostics/SpatialExplainResult.cs
@@ -1,0 +1,117 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a human-readable summary of a spatial query plan.
+/// </summary>
+public sealed class SpatialExplainResult
+{
+    internal SpatialExplainResult(
+        SpatialCollectionDescriptor descriptor,
+        ISpatialQueryPlan plan)
+    {
+        CollectionName = descriptor?.CollectionName ?? throw new ArgumentNullException(nameof(descriptor));
+        EngineName = descriptor.EngineName;
+        Dimensions = plan?.Dimensions ?? throw new ArgumentNullException(nameof(plan));
+        IndexFieldName = descriptor.Options.IndexFieldName;
+        BoundingBoxFieldName = descriptor.Options.BoundingBoxFieldName;
+        CoveringBounds = plan.CoveringBounds;
+        ExactPredicate = plan.ExactPredicateDescription;
+        IndexRanges = plan.IndexRanges?.ToArray() ?? Array.Empty<SpatialIndexRange>();
+
+        Summary = BuildSummary();
+    }
+
+    /// <summary>
+    /// Gets the name of the collection associated with the plan.
+    /// </summary>
+    public string CollectionName { get; }
+
+    /// <summary>
+    /// Gets the name of the engine that produced the plan.
+    /// </summary>
+    public string EngineName { get; }
+
+    /// <summary>
+    /// Gets the number of spatial dimensions handled by the plan.
+    /// </summary>
+    public int Dimensions { get; }
+
+    /// <summary>
+    /// Gets the name of the index field used to persist Morton/Hilbert codes.
+    /// </summary>
+    public string IndexFieldName { get; }
+
+    /// <summary>
+    /// Gets the name of the bounding box field stored alongside indexed documents.
+    /// </summary>
+    public string BoundingBoxFieldName { get; }
+
+    /// <summary>
+    /// Gets the coarse bounding box applied before exact predicate evaluation.
+    /// </summary>
+    public BoundingBox? CoveringBounds { get; }
+
+    /// <summary>
+    /// Gets the collection of index ranges scanned by the plan.
+    /// </summary>
+    public IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <summary>
+    /// Gets the number of index ranges.
+    /// </summary>
+    public int RangeCount => IndexRanges.Count;
+
+    /// <summary>
+    /// Gets the textual description of the exact predicate.
+    /// </summary>
+    public string? ExactPredicate { get; }
+
+    /// <summary>
+    /// Gets the printable summary of the plan.
+    /// </summary>
+    public string Summary { get; }
+
+    /// <inheritdoc />
+    public override string ToString() => Summary;
+
+    private string BuildSummary()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"Collection : {CollectionName}");
+        builder.AppendLine($"Engine     : {EngineName} ({Dimensions}D)");
+        builder.AppendLine($"IndexField : {IndexFieldName}");
+        builder.AppendLine($"BBoxField  : {BoundingBoxFieldName}");
+        builder.AppendLine($"Covering   : {FormatBoundingBox(CoveringBounds)}");
+        builder.AppendLine($"Ranges ({RangeCount}):");
+
+        if (RangeCount == 0)
+        {
+            builder.AppendLine("  (none)");
+        }
+        else
+        {
+            foreach (var range in IndexRanges)
+            {
+                builder.AppendLine($"  {range}");
+            }
+        }
+
+        builder.Append("Predicate  : ");
+        builder.AppendLine(string.IsNullOrWhiteSpace(ExactPredicate) ? "(none)" : ExactPredicate);
+
+        return builder.ToString();
+    }
+
+    private static string FormatBoundingBox(BoundingBox? bounds)
+    {
+        return bounds.HasValue ? bounds.Value.ToString() : "(none)";
+    }
+}
+

--- a/LiteDB.Spatial.Core/Geometry/GeoLineString.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoLineString.cs
@@ -1,0 +1,103 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a sequence of two-dimensional points forming a GeoJSON LineString.
+/// </summary>
+public sealed class GeoLineString : IEquatable<GeoLineString>
+{
+    private readonly ReadOnlyCollection<GeoPoint> _points;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoLineString"/> class.
+    /// </summary>
+    /// <param name="points">The ordered collection of points that compose the line string.</param>
+    public GeoLineString(IReadOnlyList<GeoPoint> points)
+    {
+        if (points == null)
+        {
+            throw new ArgumentNullException(nameof(points));
+        }
+
+        if (points.Count < 2)
+        {
+            throw new ArgumentException("LineString requires at least two points.", nameof(points));
+        }
+
+        var copy = new GeoPoint[points.Count];
+        for (var i = 0; i < points.Count; i++)
+        {
+            copy[i] = points[i];
+        }
+
+        _points = Array.AsReadOnly(copy);
+    }
+
+    /// <summary>
+    /// Gets the ordered points that compose the line string.
+    /// </summary>
+    public IReadOnlyList<GeoPoint> Points => _points;
+
+    /// <inheritdoc />
+    public bool Equals(GeoLineString? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        if (_points.Count != other._points.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < _points.Count; i++)
+        {
+            if (!_points[i].Equals(other._points[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoLineString line && Equals(line);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            for (var i = 0; i < _points.Count; i++)
+            {
+                hash = (hash * 397) ^ _points[i].GetHashCode();
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"LineString({string.Join(", ", _points.Select(p => p.ToString()))})";
+    }
+}
+

--- a/LiteDB.Spatial.Core/Geometry/GeoPolygon.cs
+++ b/LiteDB.Spatial.Core/Geometry/GeoPolygon.cs
@@ -1,0 +1,143 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Represents a polygon described by an outer ring and optional interior holes.
+/// </summary>
+public sealed class GeoPolygon : IEquatable<GeoPolygon>
+{
+    private readonly ReadOnlyCollection<GeoPoint> _outer;
+    private readonly ReadOnlyCollection<IReadOnlyList<GeoPoint>> _holes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GeoPolygon"/> class.
+    /// </summary>
+    /// <param name="outer">The outer ring expressed as a closed sequence of points.</param>
+    /// <param name="holes">Optional inner rings expressed as closed sequences of points.</param>
+    public GeoPolygon(IReadOnlyList<GeoPoint> outer, IReadOnlyList<IReadOnlyList<GeoPoint>>? holes = null)
+    {
+        _outer = ValidateRing(outer, nameof(outer));
+
+        if (holes == null || holes.Count == 0)
+        {
+            _holes = Array.AsReadOnly(Array.Empty<IReadOnlyList<GeoPoint>>());
+            return;
+        }
+
+        var normalized = new IReadOnlyList<GeoPoint>[holes.Count];
+        for (var i = 0; i < holes.Count; i++)
+        {
+            normalized[i] = ValidateRing(holes[i], $"{nameof(holes)}[{i}]");
+        }
+
+        _holes = Array.AsReadOnly(normalized);
+    }
+
+    /// <summary>
+    /// Gets the outer ring of the polygon.
+    /// </summary>
+    public IReadOnlyList<GeoPoint> Outer => _outer;
+
+    /// <summary>
+    /// Gets the inner rings that describe holes within the polygon.
+    /// </summary>
+    public IReadOnlyList<IReadOnlyList<GeoPoint>> Holes => _holes;
+
+    /// <inheritdoc />
+    public bool Equals(GeoPolygon? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (!Outer.SequenceEqual(other.Outer))
+        {
+            return false;
+        }
+
+        if (Holes.Count != other.Holes.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < Holes.Count; i++)
+        {
+            if (!Holes[i].SequenceEqual(other.Holes[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj)
+    {
+        return obj is GeoPolygon polygon && Equals(polygon);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hash = 17;
+            for (var i = 0; i < Outer.Count; i++)
+            {
+                hash = (hash * 397) ^ Outer[i].GetHashCode();
+            }
+
+            for (var holeIndex = 0; holeIndex < Holes.Count; holeIndex++)
+            {
+                var hole = Holes[holeIndex];
+                for (var i = 0; i < hole.Count; i++)
+                {
+                    hash = (hash * 397) ^ hole[i].GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"Polygon(outer={Outer.Count}, holes={Holes.Count})";
+    }
+
+    private static ReadOnlyCollection<GeoPoint> ValidateRing(IReadOnlyList<GeoPoint> ring, string argumentName)
+    {
+        if (ring == null)
+        {
+            throw new ArgumentNullException(argumentName);
+        }
+
+        if (ring.Count < 4)
+        {
+            throw new ArgumentException("Polygon rings must contain at least four points including closure.", argumentName);
+        }
+
+        var copy = new GeoPoint[ring.Count];
+        for (var i = 0; i < ring.Count; i++)
+        {
+            copy[i] = ring[i];
+        }
+
+        if (!copy[0].Equals(copy[copy.Length - 1]))
+        {
+            throw new ArgumentException("Polygon rings must be closed (first and last point must match).", argumentName);
+        }
+
+        return Array.AsReadOnly(copy);
+    }
+}
+

--- a/LiteDB.Spatial.Core/Io/GeoJsonSerializer.cs
+++ b/LiteDB.Spatial.Core/Io/GeoJsonSerializer.cs
@@ -1,0 +1,264 @@
+#nullable enable
+
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Provides helpers for converting spatial geometries to and from GeoJSON-compatible <see cref="BaseLiteDB.BsonValue"/> payloads.
+/// </summary>
+public static class GeoJsonSerializer
+{
+    /// <summary>
+    /// Serializes the provided geometry into a GeoJSON <see cref="BaseLiteDB.BsonValue"/> payload.
+    /// </summary>
+    /// <param name="geometry">The geometry to serialize. May be <c>null</c>.</param>
+    /// <returns>A GeoJSON document or <see cref="BaseLiteDB.BsonValue.Null"/> when <paramref name="geometry"/> is <c>null</c>.</returns>
+    public static BaseLiteDB.BsonValue Serialize(object? geometry)
+    {
+        return geometry switch
+        {
+            null => BaseLiteDB.BsonValue.Null,
+            GeoPoint point => Serialize(point),
+            GeoLineString line => Serialize(line),
+            GeoPolygon polygon => Serialize(polygon),
+            _ => throw new ArgumentException($"Unsupported geometry type '{geometry.GetType().FullName}'.", nameof(geometry))
+        };
+    }
+
+    /// <summary>
+    /// Serializes a geographic point into GeoJSON.
+    /// </summary>
+    public static BaseLiteDB.BsonValue Serialize(GeoPoint point)
+    {
+        return new BaseLiteDB.BsonDocument
+        {
+            ["type"] = "Point",
+            ["coordinates"] = new BaseLiteDB.BsonArray { point.Longitude, point.Latitude }
+        };
+    }
+
+    /// <summary>
+    /// Serializes a line string into GeoJSON.
+    /// </summary>
+    public static BaseLiteDB.BsonValue Serialize(GeoLineString line)
+    {
+        if (line == null)
+        {
+            throw new ArgumentNullException(nameof(line));
+        }
+
+        var coordinates = new BaseLiteDB.BsonArray();
+        foreach (var point in line.Points)
+        {
+            coordinates.Add(new BaseLiteDB.BsonArray { point.Longitude, point.Latitude });
+        }
+
+        return new BaseLiteDB.BsonDocument
+        {
+            ["type"] = "LineString",
+            ["coordinates"] = coordinates
+        };
+    }
+
+    /// <summary>
+    /// Serializes a polygon into GeoJSON.
+    /// </summary>
+    public static BaseLiteDB.BsonValue Serialize(GeoPolygon polygon)
+    {
+        if (polygon == null)
+        {
+            throw new ArgumentNullException(nameof(polygon));
+        }
+
+        var rings = new BaseLiteDB.BsonArray
+        {
+            CreateRing(polygon.Outer)
+        };
+
+        foreach (var hole in polygon.Holes)
+        {
+            rings.Add(CreateRing(hole));
+        }
+
+        return new BaseLiteDB.BsonDocument
+        {
+            ["type"] = "Polygon",
+            ["coordinates"] = rings
+        };
+    }
+
+    /// <summary>
+    /// Deserializes a GeoJSON payload into a geometry instance.
+    /// </summary>
+    /// <param name="value">The serialized GeoJSON value.</param>
+    /// <returns>The geometry instance, or <c>null</c> when the payload represents <c>null</c>.</returns>
+    public static object? Deserialize(BaseLiteDB.BsonValue value)
+    {
+        if (value.IsNull)
+        {
+            return null;
+        }
+
+        var document = EnsureDocument(value);
+        var type = ReadType(document);
+
+        return type switch
+        {
+            "Point" => DeserializePoint(document),
+            "LineString" => DeserializeLineString(document),
+            "Polygon" => DeserializePolygon(document),
+            _ => throw new FormatException($"Unsupported GeoJSON geometry type '{type}'.")
+        };
+    }
+
+    /// <summary>
+    /// Deserializes the provided GeoJSON payload into a <see cref="GeoPoint"/>.
+    /// </summary>
+    public static GeoPoint DeserializePoint(BaseLiteDB.BsonValue value)
+    {
+        var document = EnsureDocument(value, "Point");
+        var coordinates = EnsureArray(document, "coordinates");
+        if (coordinates.Count < 2)
+        {
+            throw new FormatException("GeoJSON point coordinates must contain longitude and latitude.");
+        }
+
+        var longitude = coordinates[0].AsDouble;
+        var latitude = coordinates[1].AsDouble;
+        return new GeoPoint(longitude, latitude);
+    }
+
+    /// <summary>
+    /// Deserializes the provided GeoJSON payload into a <see cref="GeoLineString"/>.
+    /// </summary>
+    public static GeoLineString DeserializeLineString(BaseLiteDB.BsonValue value)
+    {
+        var document = EnsureDocument(value, "LineString");
+        var coordinates = EnsureArray(document, "coordinates");
+        if (coordinates.Count < 2)
+        {
+            throw new FormatException("LineString requires at least two coordinate positions.");
+        }
+
+        var points = new List<GeoPoint>(coordinates.Count);
+        foreach (var entry in coordinates)
+        {
+            points.Add(ReadPosition(entry));
+        }
+
+        return new GeoLineString(points);
+    }
+
+    /// <summary>
+    /// Deserializes the provided GeoJSON payload into a <see cref="GeoPolygon"/>.
+    /// </summary>
+    public static GeoPolygon DeserializePolygon(BaseLiteDB.BsonValue value)
+    {
+        var document = EnsureDocument(value, "Polygon");
+        var ringsArray = EnsureArray(document, "coordinates");
+        if (ringsArray.Count == 0)
+        {
+            throw new FormatException("Polygon requires at least one linear ring.");
+        }
+
+        var rings = ringsArray.Select(ReadRing).ToList();
+        var outer = rings[0];
+        var holes = rings.Count > 1 ? rings.Skip(1).Select(r => (IReadOnlyList<GeoPoint>)r).ToList() : null;
+
+        return new GeoPolygon(outer, holes);
+    }
+
+    private static BaseLiteDB.BsonDocument EnsureDocument(BaseLiteDB.BsonValue value, string? expectedType = null)
+    {
+        if (!value.IsDocument)
+        {
+            throw new FormatException("GeoJSON payload must be stored as a document with type and coordinates.");
+        }
+
+        var document = value.AsDocument;
+        var type = ReadType(document);
+
+        if (expectedType != null && !string.Equals(type, expectedType, StringComparison.Ordinal))
+        {
+            throw new FormatException($"GeoJSON payload describes '{type}' but '{expectedType}' was expected.");
+        }
+
+        return document;
+    }
+
+    private static string ReadType(BaseLiteDB.BsonDocument document)
+    {
+        if (!document.TryGetValue("type", out var typeValue) || !typeValue.IsString)
+        {
+            throw new FormatException("GeoJSON payload must include a string 'type' property.");
+        }
+
+        return typeValue.AsString;
+    }
+
+    private static BaseLiteDB.BsonArray EnsureArray(BaseLiteDB.BsonDocument document, string key)
+    {
+        if (!document.TryGetValue(key, out var value) || !value.IsArray)
+        {
+            throw new FormatException($"GeoJSON '{key}' property must be an array.");
+        }
+
+        return value.AsArray;
+    }
+
+    private static BaseLiteDB.BsonArray CreateRing(IReadOnlyList<GeoPoint> points)
+    {
+        var array = new BaseLiteDB.BsonArray();
+        foreach (var point in points)
+        {
+            array.Add(new BaseLiteDB.BsonArray { point.Longitude, point.Latitude });
+        }
+
+        return array;
+    }
+
+    private static GeoPoint ReadPosition(BaseLiteDB.BsonValue value)
+    {
+        if (!value.IsArray)
+        {
+            throw new FormatException("Coordinate position must be expressed as an array.");
+        }
+
+        var array = value.AsArray;
+        if (array.Count < 2)
+        {
+            throw new FormatException("Coordinate position must contain longitude and latitude.");
+        }
+
+        return new GeoPoint(array[0].AsDouble, array[1].AsDouble);
+    }
+
+    private static List<GeoPoint> ReadRing(BaseLiteDB.BsonValue value)
+    {
+        if (!value.IsArray)
+        {
+            throw new FormatException("Polygon rings must be arrays of coordinate positions.");
+        }
+
+        var array = value.AsArray;
+        if (array.Count < 4)
+        {
+            throw new FormatException("Polygon rings must contain at least four positions including closure.");
+        }
+
+        var points = new List<GeoPoint>(array.Count);
+        foreach (var entry in array)
+        {
+            points.Add(ReadPosition(entry));
+        }
+
+        return points;
+    }
+}
+

--- a/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
+++ b/LiteDB.Spatial.Core/Linq/SpatialResolver.cs
@@ -1,5 +1,8 @@
 #nullable enable
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace LiteDB.Spatial;
@@ -9,6 +12,36 @@ namespace LiteDB.Spatial;
 /// </summary>
 public sealed class SpatialResolver
 {
+    private readonly IReadOnlyList<SpatialCollectionDescriptor> _descriptors;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialResolver"/> class.
+    /// </summary>
+    /// <param name="descriptor">The descriptor associated with the collection targeted by the query.</param>
+    public SpatialResolver(SpatialCollectionDescriptor descriptor)
+        : this(new[] { descriptor ?? throw new ArgumentNullException(nameof(descriptor)) })
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialResolver"/> class.
+    /// </summary>
+    /// <param name="descriptors">The known spatial descriptors for the query scope.</param>
+    public SpatialResolver(IEnumerable<SpatialCollectionDescriptor> descriptors)
+    {
+        if (descriptors == null)
+        {
+            throw new ArgumentNullException(nameof(descriptors));
+        }
+
+        _descriptors = descriptors.ToArray();
+
+        if (_descriptors.Count == 0)
+        {
+            throw new ArgumentException("At least one descriptor must be provided to resolve spatial expressions.", nameof(descriptors));
+        }
+    }
+
     /// <summary>
     /// Attempts to translate the provided method call expression into a spatial query plan.
     /// </summary>
@@ -18,6 +51,142 @@ public sealed class SpatialResolver
     public bool TryResolve(MethodCallExpression expression, out ISpatialQueryPlan? plan)
     {
         plan = default;
-        return false;
+
+        if (expression == null)
+        {
+            throw new ArgumentNullException(nameof(expression));
+        }
+
+        if (expression.Method.DeclaringType != typeof(SpatialExpressions))
+        {
+            return false;
+        }
+
+        return expression.Method.Name switch
+        {
+            nameof(SpatialExpressions.Near) => ResolveNear(expression, out plan),
+            nameof(SpatialExpressions.InBox) => ResolveInBox(expression, out plan),
+            _ => false
+        };
+    }
+
+    private bool ResolveNear(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        plan = null;
+
+        var descriptor = ResolveDescriptor(expression.Arguments[0]);
+        var engine = RequireEngine(descriptor);
+
+        var parameters = expression.Method.GetParameters();
+        if (parameters.Length != 3)
+        {
+            throw new InvalidOperationException("SpatialExpressions.Near expects three parameters (candidate, center, radius).");
+        }
+
+        if (parameters[1].ParameterType == typeof(GeoPoint))
+        {
+            EnsureDimensions(descriptor, 2);
+            var center = EvaluateArgument<GeoPoint>(expression.Arguments[1]);
+            var radius = EvaluateArgument<double>(expression.Arguments[2]);
+            plan = engine.PlanNear(center, radius);
+            return true;
+        }
+
+        if (parameters[1].ParameterType == typeof(GeoPoint3D))
+        {
+            EnsureDimensions(descriptor, 3);
+            var center = EvaluateArgument<GeoPoint3D>(expression.Arguments[1]);
+            var radius = EvaluateArgument<double>(expression.Arguments[2]);
+            plan = engine.PlanNear(center, radius);
+            return true;
+        }
+
+        throw new NotSupportedException($"Unsupported Near overload: center parameter type '{parameters[1].ParameterType.Name}'.");
+    }
+
+    private bool ResolveInBox(MethodCallExpression expression, out ISpatialQueryPlan? plan)
+    {
+        plan = null;
+        if (expression.Arguments.Count != 2)
+        {
+            throw new InvalidOperationException("SpatialExpressions.InBox expects two parameters (candidate, bounds).");
+        }
+
+        var descriptor = ResolveDescriptor(expression.Arguments[0]);
+        var engine = RequireEngine(descriptor);
+        var bounds = EvaluateArgument<BoundingBox>(expression.Arguments[1]);
+        descriptor.EnsureCompatible(bounds);
+
+        plan = engine.PlanWithin(bounds);
+        return true;
+    }
+
+    private SpatialCollectionDescriptor ResolveDescriptor(Expression candidate)
+    {
+        var geometryName = TryExtractMemberName(candidate);
+
+        if (geometryName != null)
+        {
+            foreach (var descriptor in _descriptors)
+            {
+                if (string.Equals(descriptor.GeometryFieldName, geometryName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return descriptor;
+                }
+            }
+        }
+
+        if (_descriptors.Count == 1)
+        {
+            return _descriptors[0];
+        }
+
+        var available = string.Join(", ", _descriptors.Select(d => d.GeometryFieldName));
+        throw new SpatialMetadataException($"Unable to resolve spatial metadata for geometry member '{geometryName ?? "<unknown>"}'. Known geometries: {available}.");
+    }
+
+    private static string? TryExtractMemberName(Expression expression)
+    {
+        Expression current = expression;
+
+        while (current is UnaryExpression unary && (unary.NodeType == ExpressionType.Convert || unary.NodeType == ExpressionType.ConvertChecked))
+        {
+            current = unary.Operand;
+        }
+
+        return current switch
+        {
+            MemberExpression member => member.Member.Name,
+            _ => null
+        };
+    }
+
+    private static ISpatialEngine RequireEngine(SpatialCollectionDescriptor descriptor)
+    {
+        if (descriptor.Engine is { } engine)
+        {
+            return engine;
+        }
+
+        throw new SpatialMetadataException($"Collection '{descriptor.CollectionName}' does not have a runtime spatial engine attached. Ensure EnsurePointIndex has been executed and the descriptor retains the engine via WithEngine().");
+    }
+
+    private static void EnsureDimensions(SpatialCollectionDescriptor descriptor, int expected)
+    {
+        if (descriptor.Dimensions != expected)
+        {
+            throw new SpatialMetadataException($"Collection '{descriptor.CollectionName}' is configured for {descriptor.Dimensions}D geometry but the query requested {expected}D semantics.");
+        }
+    }
+
+    private static T EvaluateArgument<T>(Expression expression)
+    {
+        if (expression is ConstantExpression constant && constant.Value is T direct)
+        {
+            return direct;
+        }
+
+        var lambda = Expression.Lambda<Func<T>>(Expression.Convert(expression, typeof(T)));
+        return lambda.Compile().Invoke();
     }
 }

--- a/docs/spatial-modular-revamp.md
+++ b/docs/spatial-modular-revamp.md
@@ -142,15 +142,15 @@ LiteDB.Spatial
 
 ### S8 — LINQ resolver
 
-- [ ] Translate `SpatialExpressions` into query plans based on metadata.
+- [x] Translate `SpatialExpressions` into query plans based on metadata.
 
 ### S9 — Diagnostics ("Explain")
 
-- [ ] Produce printable `SpatialExplainResult` summaries for query plans.
+- [x] Produce printable `SpatialExplainResult` summaries for query plans.
 
 ### S10 — GeoJSON I/O (minimal)
 
-- [ ] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
+- [x] `GeoJsonSerializer` round-trips GeoPoint/Polygon/LineString data.
 
 ### S11 — Top-level facade & dispatch
 


### PR DESCRIPTION
## Summary
- implement SpatialResolver translation of Near/InBox expressions using metadata and attached engines
- add spatial diagnostics explain output to summarize query plans
- introduce GeoJSON serializer along with GeoLineString/GeoPolygon primitives and coverage tests

## Testing
- dotnet build LiteDB.sln
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj


------
https://chatgpt.com/codex/tasks/task_e_68e791778c14832683a5df34bceec562