### PR TITLE
Add geographic oracle differential tests

### DIFF
--- a/LiteDB.Spatial.Core.Tests/CategoryAttribute.cs
+++ b/LiteDB.Spatial.Core.Tests/CategoryAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+namespace LiteDB.Spatial.Core.Tests;
+
+/// <summary>
+/// Provides a lightweight category marker matching NUnit-style semantics.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+public sealed class CategoryAttribute : Attribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CategoryAttribute"/> class.
+    /// </summary>
+    /// <param name="category">The category name to associate with the test.</param>
+    public CategoryAttribute(string category)
+    {
+        Name = category;
+    }
+
+    /// <summary>
+    /// Gets the category associated with the test.
+    /// </summary>
+    public string Name { get; }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeodesicDistanceParityTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeodesicDistanceParityTests.cs
@@ -1,0 +1,61 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using LiteDB.Spatial;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+// Regenerate fixtures with:
+//   pip install geographiclib
+//   python - <<'PY'
+//   from geographiclib.geodesic import Geodesic
+//   import json
+//   pairs = json.load(open('LiteDB.Spatial.Core.Tests/fixtures/geodesic_pairs.json'))
+//   for pair in pairs:
+//       res = Geodesic.WGS84.Inverse(pair["from"]["lat"], pair["from"]["lon"], pair["to"]["lat"], pair["to"]["lon"])
+//       pair["geographicLibDistanceMeters"] = res["s12"]
+//   json.dump(pairs, open('LiteDB.Spatial.Core.Tests/fixtures/geodesic_pairs.json', 'w'), indent=2)
+//   PY
+
+[Category("oracle")]
+public sealed class GeodesicDistanceParityTests
+{
+    private const double RelativeTolerance = 1e-4;
+    private const double AbsoluteTolerance = 0.05;
+
+    [Fact]
+    public void HaversineMatchesGeographicLibSamples()
+    {
+        var distance = new GeographicDistance(GeographicDistanceMode.Haversine);
+        foreach (var pair in GeographicLibOracle.LoadPairs())
+        {
+            using var scope = new AssertionScope();
+            scope.AddReportable("fixture", pair.Id);
+            scope.AddReportable("mode", nameof(GeographicDistanceMode.Haversine));
+
+            var expected = GeographicLibOracle.Distance(pair.Id, pair.From, pair.To);
+            var actual = distance.Distance(pair.From, pair.To);
+            var tolerance = RelativeTolerance * expected + AbsoluteTolerance;
+
+            actual.Should().BeApproximately(expected, tolerance);
+        }
+    }
+
+    [Fact]
+    public void VincentyMatchesGeographicLibSamples()
+    {
+        var distance = new GeographicDistance(GeographicDistanceMode.Vincenty);
+        foreach (var pair in GeographicLibOracle.LoadPairs())
+        {
+            using var scope = new AssertionScope();
+            scope.AddReportable("fixture", pair.Id);
+            scope.AddReportable("mode", nameof(GeographicDistanceMode.Vincenty));
+
+            var expected = GeographicLibOracle.Distance(pair.Id, pair.From, pair.To);
+            var actual = distance.Distance(pair.From, pair.To);
+            var tolerance = RelativeTolerance * expected + AbsoluteTolerance;
+
+            actual.Should().BeApproximately(expected, tolerance);
+        }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicBoundingBoxDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicBoundingBoxDifferentialTests.cs
@@ -1,0 +1,72 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using LiteDB.Spatial;
+using Xunit;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using SpatialFacade = LiteDB.Spatial.Spatial;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+[Category("oracle")]
+public sealed class GeographicBoundingBoxDifferentialTests
+{
+    [Fact]
+    public void WithinBoundingBoxMatchesNtsOracle()
+    {
+        var fixtures = TestDataLoader.LoadCollection<BoundingBoxFixtureDto>("geographic_bounding_boxes.json")
+            .Select(BoundingBoxFixture.FromDto)
+            .ToArray();
+
+        foreach (var fixture in fixtures)
+        {
+            using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+            var places = database.GetCollection<TestPlace>("places");
+            places.DeleteAll();
+
+            var records = fixture.Points
+                .Select((point, index) => new TestPlace
+                {
+                    Id = point.Id,
+                    Location = point.Location
+                })
+                .ToArray();
+
+            places.Insert(records);
+
+            var descriptor = SpatialFacade.UseGeographic(places, x => x.Location);
+            SpatialFacade.EnsurePointIndex(places);
+
+            var plan = SpatialGeographic.WithinBoundingBox(descriptor, fixture.Bounds);
+            var explain = SpatialDiagnostics.Explain(plan, descriptor);
+
+            using var scope = new AssertionScope();
+            scope.AddReportable("fixture", fixture.Id);
+
+            explain.IndexFieldName.Should().Be(descriptor.Options.IndexFieldName);
+            explain.ExactPredicate.Should().NotBeNullOrWhiteSpace();
+            explain.ExactPredicate.Should().Contain("Within");
+            plan.IndexRanges.Should().NotBeEmpty();
+
+            var actual = SpatialFacade.WithinBoundingBox(places, x => x.Location, fixture.Bounds)
+                .Select(place => place.Id)
+                .ToHashSet(StringComparer.Ordinal);
+
+            var expected = NtsOracle.WithinBoundingBox(fixture.Bounds, fixture.Points);
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+    }
+
+    private sealed class TestPlace
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public GeoPoint Location { get; set; }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicFixtures.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicFixtures.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB.Spatial;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+internal sealed record GeodesicPair(string Id, GeoPoint From, GeoPoint To, double GeographicLibDistanceMeters)
+{
+    public static GeodesicPair FromDto(GeodesicPairDto dto)
+    {
+        if (dto == null)
+        {
+            throw new ArgumentNullException(nameof(dto));
+        }
+
+        return new GeodesicPair(
+            dto.Id ?? throw new ArgumentException("Geodesic pair is missing an id."),
+            new GeoPoint(dto.From.Lon, dto.From.Lat),
+            new GeoPoint(dto.To.Lon, dto.To.Lat),
+            dto.GeographicLibDistanceMeters);
+    }
+}
+
+internal sealed record GeodesicPairDto(string? Id, CoordinateDto From, CoordinateDto To, double GeographicLibDistanceMeters);
+
+internal sealed record CoordinateDto(double Lon, double Lat);
+
+internal sealed record BoundingBoxFixture(
+    string Id,
+    BoundingBox Bounds,
+    IReadOnlyList<GeographicFixturePoint> Points)
+{
+    public static BoundingBoxFixture FromDto(BoundingBoxFixtureDto dto)
+    {
+        if (dto == null)
+        {
+            throw new ArgumentNullException(nameof(dto));
+        }
+
+        var bounds = BoundingBox.From2D(dto.Bounds.MinLon, dto.Bounds.MinLat, dto.Bounds.MaxLon, dto.Bounds.MaxLat);
+        var points = dto.Points
+            .Select(p => new GeographicFixturePoint(p.Id, new GeoPoint(p.Lon, p.Lat)))
+            .ToArray();
+
+        return new BoundingBoxFixture(
+            dto.Id ?? throw new ArgumentException("Bounding box fixture requires an id."),
+            bounds,
+            points);
+    }
+}
+
+internal sealed record BoundingBoxFixtureDto(
+    string? Id,
+    BoundingBoxDto Bounds,
+    IReadOnlyList<PointDto> Points);
+
+internal sealed record BoundingBoxDto(double MinLon, double MinLat, double MaxLon, double MaxLat);
+
+internal sealed record GeographicFixturePoint(string Id, GeoPoint Location);
+
+internal sealed record PointDto(string Id, double Lon, double Lat);
+
+internal sealed record NearQueryFixture(
+    string Id,
+    GeoPoint Center,
+    double RadiusMeters,
+    IReadOnlyList<GeographicFixturePoint> Points)
+{
+    public static NearQueryFixture FromDto(NearQueryFixtureDto dto)
+    {
+        if (dto == null)
+        {
+            throw new ArgumentNullException(nameof(dto));
+        }
+
+        var points = dto.Points
+            .Select(p => new GeographicFixturePoint(p.Id, new GeoPoint(p.Lon, p.Lat)))
+            .ToArray();
+
+        return new NearQueryFixture(
+            dto.Id ?? throw new ArgumentException("Near fixture requires an id."),
+            new GeoPoint(dto.Center.Lon, dto.Center.Lat),
+            dto.RadiusMeters,
+            points);
+    }
+}
+
+internal sealed record NearQueryFixtureDto(
+    string? Id,
+    CoordinateDto Center,
+    double RadiusMeters,
+    IReadOnlyList<PointDto> Points);

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicLibOracle.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicLibOracle.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB.Spatial;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+internal static class GeographicLibOracle
+{
+    private static readonly Lazy<IReadOnlyDictionary<string, GeodesicPair>> Cache = new(() =>
+    {
+        var dtos = TestDataLoader.LoadCollection<GeodesicPairDto>("geodesic_pairs.json");
+        return dtos
+            .Select(GeodesicPair.FromDto)
+            .ToDictionary(pair => pair.Id, StringComparer.Ordinal);
+    });
+
+    public static IReadOnlyList<GeodesicPair> LoadPairs()
+    {
+        return Cache.Value.Values.ToList();
+    }
+
+    public static double Distance(string id, GeoPoint from, GeoPoint to)
+    {
+        if (!Cache.Value.TryGetValue(id, out var pair))
+        {
+            throw new KeyNotFoundException($"Geodesic pair '{id}' was not found in the oracle cache.");
+        }
+
+        const double coordinateTolerance = 1e-9;
+        if (Math.Abs(pair.From.Longitude - from.Longitude) > coordinateTolerance ||
+            Math.Abs(pair.From.Latitude - from.Latitude) > coordinateTolerance ||
+            Math.Abs(pair.To.Longitude - to.Longitude) > coordinateTolerance ||
+            Math.Abs(pair.To.Latitude - to.Latitude) > coordinateTolerance)
+        {
+            throw new InvalidOperationException(
+                $"Fixture '{id}' does not match the requested coordinates. Ensure the test dataset is up to date.");
+        }
+
+        return pair.GeographicLibDistanceMeters;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicNearDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicNearDifferentialTests.cs
@@ -1,0 +1,125 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using LiteDB.Spatial;
+using Xunit;
+using Xunit.Sdk;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using SpatialFacade = LiteDB.Spatial.Spatial;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+[Category("oracle")]
+public sealed class GeographicNearDifferentialTests
+{
+    [Fact]
+    public void NearExplainUsesIndexAndMatchesVincenty()
+    {
+        var fixtures = TestDataLoader.LoadCollection<NearQueryFixtureDto>("geographic_near_queries.json")
+            .Select(NearQueryFixture.FromDto)
+            .ToArray();
+
+        foreach (var fixture in fixtures)
+        {
+            using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+            var places = database.GetCollection<TestPlace>("places");
+            places.DeleteAll();
+
+            var records = fixture.Points
+                .Select(point => new TestPlace
+                {
+                    Id = point.Id,
+                    Location = point.Location
+                })
+                .ToArray();
+
+            places.Insert(records);
+
+            var descriptor = SpatialFacade.UseGeographic(places, x => x.Location, new SpatialIndexOptions(distanceTolerance: 0.5), GeographicDistanceMode.Vincenty);
+            SpatialFacade.EnsurePointIndex(places);
+
+            var plan = SpatialGeographic.Near(descriptor, fixture.Center, fixture.RadiusMeters, GeographicDistanceMode.Vincenty);
+            var explain = SpatialDiagnostics.Explain(plan, descriptor);
+
+            using var scope = new AssertionScope();
+            scope.AddReportable("fixture", fixture.Id);
+
+            explain.IndexFieldName.Should().Be(descriptor.Options.IndexFieldName);
+            explain.ExactPredicate.Should().NotBeNullOrWhiteSpace();
+            explain.ExactPredicate.Should().Contain("Vincenty");
+            plan.IndexRanges.Should().NotBeEmpty();
+
+            var actual = SpatialFacade.Near(places, x => x.Location, fixture.Center, fixture.RadiusMeters)
+                .Select(place => place.Id)
+                .ToHashSet(StringComparer.Ordinal);
+
+            var distance = new GeographicDistance(GeographicDistanceMode.Vincenty);
+            var expected = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var point in fixture.Points)
+            {
+                var meters = distance.Distance(point.Location, fixture.Center);
+                if (meters <= fixture.RadiusMeters + descriptor.Options.DistanceTolerance)
+                {
+                    expected.Add(point.Id);
+                }
+            }
+
+            actual.Should().BeEquivalentTo(expected);
+        }
+    }
+
+    [Fact]
+    public async Task NearMatchesPostgisWhenEnabled()
+    {
+        if (!PostgisOracle.TryCreate(out var oracle))
+        {
+            return;
+        }
+
+        await using var postgis = oracle;
+        await postgis.InitializeAsync();
+
+        var fixture = NearQueryFixture.FromDto(TestDataLoader.LoadCollection<NearQueryFixtureDto>("geographic_near_queries.json").First());
+
+        await postgis.LoadPointsAsync(fixture.Points);
+
+        using var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var places = database.GetCollection<TestPlace>("places");
+        places.DeleteAll();
+        var records = fixture.Points.Select(point => new TestPlace { Id = point.Id, Location = point.Location }).ToArray();
+        places.Insert(records);
+
+        var descriptor = SpatialFacade.UseGeographic(places, x => x.Location, new SpatialIndexOptions(distanceTolerance: 0.5), GeographicDistanceMode.Vincenty);
+        SpatialFacade.EnsurePointIndex(places);
+
+        var plan = SpatialGeographic.Near(descriptor, fixture.Center, fixture.RadiusMeters, GeographicDistanceMode.Vincenty);
+        var explain = SpatialDiagnostics.Explain(plan, descriptor);
+
+        explain.IndexFieldName.Should().Be(descriptor.Options.IndexFieldName);
+        explain.ExactPredicate.Should().NotBeNullOrWhiteSpace();
+        explain.ExactPredicate.Should().Contain("Vincenty");
+
+        var liteDbResults = SpatialFacade.Near(places, x => x.Location, fixture.Center, fixture.RadiusMeters)
+            .Select(place => place.Id)
+            .OrderBy(id => id, StringComparer.Ordinal)
+            .ToArray();
+
+        var postgisResults = await postgis.QueryDWithinAsync(fixture.Center, fixture.RadiusMeters);
+
+        liteDbResults.Should().Equal(postgisResults);
+    }
+
+    private sealed class TestPlace
+    {
+        public string Id { get; set; } = string.Empty;
+
+        public GeoPoint Location { get; set; }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/NtsOracle.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/NtsOracle.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB.Spatial;
+using NetTopologySuite;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries.Prepared;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+internal static class NtsOracle
+{
+    private static readonly GeometryFactory Geometry = NtsGeometryServices.Instance.CreateGeometryFactory(srid: 4326);
+
+    public static IReadOnlySet<string> WithinBoundingBox(BoundingBox bounds, IReadOnlyList<GeographicFixturePoint> points)
+    {
+        if (bounds.Dimensions != 2)
+        {
+            throw new ArgumentException("Geographic bounding boxes must be two-dimensional.", nameof(bounds));
+        }
+
+        var polygons = BuildBoundingBoxPolygons(bounds).ToList();
+        var prepared = polygons.Select(PreparedGeometryFactory.Prepare).ToArray();
+        var matches = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var point in points)
+        {
+            var coordinate = new Coordinate(point.Location.Longitude, point.Location.Latitude);
+            var geometryPoint = Geometry.CreatePoint(coordinate);
+
+            if (prepared.Any(p => p.Covers(geometryPoint)))
+            {
+                matches.Add(point.Id);
+            }
+        }
+
+        return matches;
+    }
+
+    private static IEnumerable<Polygon> BuildBoundingBoxPolygons(BoundingBox bounds)
+    {
+        var minLon = bounds.MinX;
+        var maxLon = bounds.MaxX;
+        var minLat = ClampLatitude(bounds.MinY);
+        var maxLat = ClampLatitude(bounds.MaxY);
+
+        foreach (var segment in SplitLongitudeRange(minLon, maxLon))
+        {
+            var coordinates = new[]
+            {
+                new Coordinate(segment.minLon, minLat),
+                new Coordinate(segment.maxLon, minLat),
+                new Coordinate(segment.maxLon, maxLat),
+                new Coordinate(segment.minLon, maxLat),
+                new Coordinate(segment.minLon, minLat)
+            };
+
+            yield return Geometry.CreatePolygon(coordinates);
+        }
+    }
+
+    private static IEnumerable<(double minLon, double maxLon)> SplitLongitudeRange(double min, double max)
+    {
+        if (double.IsNaN(min) || double.IsNaN(max))
+        {
+            throw new ArgumentException("Longitude values must be finite.");
+        }
+
+        if (max - min >= 360d)
+        {
+            yield return (-180d, 180d);
+            yield break;
+        }
+
+        var normalizedMin = NormalizeLongitude(min);
+        var offset = normalizedMin - min;
+        var normalizedMax = max + offset;
+
+        if (normalizedMax <= 180d)
+        {
+            yield return (normalizedMin, normalizedMax);
+            yield break;
+        }
+
+        yield return (normalizedMin, 180d);
+        yield return (-180d, normalizedMax - 360d);
+    }
+
+    private static double NormalizeLongitude(double longitude)
+    {
+        var value = longitude % 360d;
+        if (value <= -180d)
+        {
+            value += 360d;
+        }
+        else if (value > 180d)
+        {
+            value -= 360d;
+        }
+
+        return value;
+    }
+
+    private static double ClampLatitude(double latitude)
+    {
+        if (latitude < -90d)
+        {
+            return -90d;
+        }
+
+        if (latitude > 90d)
+        {
+            return 90d;
+        }
+
+        return latitude;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/PostgisOracle.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/PostgisOracle.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using LiteDB.Spatial;
+using Npgsql;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+internal sealed class PostgisOracle : IAsyncDisposable
+{
+    private readonly string _tableName;
+    private readonly NpgsqlConnection _connection;
+
+    private PostgisOracle(NpgsqlConnection connection, string tableName)
+    {
+        _connection = connection;
+        _tableName = tableName;
+    }
+
+    public static bool TryCreate(out PostgisOracle? oracle)
+    {
+        var connectionString = Environment.GetEnvironmentVariable("SPATIAL_DB_TESTS");
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            oracle = null;
+            return false;
+        }
+
+        var tableName = "tmp_litedb_points_" + Guid.NewGuid().ToString("N");
+        var connection = new NpgsqlConnection(connectionString);
+        oracle = new PostgisOracle(connection, tableName);
+        return true;
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _connection.OpenAsync().ConfigureAwait(false);
+
+        await using (var command = _connection.CreateCommand())
+        {
+            command.CommandText = "CREATE TEMP TABLE IF NOT EXISTS spatial_temp_guard(flag int);";
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        await using (var command = _connection.CreateCommand())
+        {
+            command.CommandText = $"CREATE TEMP TABLE {_tableName} (id TEXT PRIMARY KEY, geom geometry(Point, 4326));";
+            await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+
+    public async Task LoadPointsAsync(IEnumerable<GeographicFixturePoint> points)
+    {
+        var payload = points.ToArray();
+        if (payload.Length == 0)
+        {
+            return;
+        }
+
+        await using var transaction = await _connection.BeginTransactionAsync().ConfigureAwait(false);
+
+        foreach (var point in payload)
+        {
+            await using var insert = _connection.CreateCommand();
+            insert.Transaction = transaction;
+            insert.CommandText = $"INSERT INTO {_tableName} (id, geom) VALUES (@id, ST_SetSRID(ST_MakePoint(@lon, @lat), 4326));";
+            insert.Parameters.AddWithValue("@id", point.Id);
+            insert.Parameters.AddWithValue("@lon", point.Location.Longitude);
+            insert.Parameters.AddWithValue("@lat", point.Location.Latitude);
+            await insert.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        await transaction.CommitAsync().ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<string>> QueryDWithinAsync(GeoPoint center, double radiusMeters)
+    {
+        await using var command = _connection.CreateCommand();
+        command.CommandText = $@"SELECT id
+FROM {_tableName}
+WHERE ST_DWithin(
+    geom::geography,
+    ST_SetSRID(ST_MakePoint(@lon, @lat), 4326)::geography,
+    @radius)
+ORDER BY id;";
+        command.Parameters.AddWithValue("@lon", center.Longitude);
+        command.Parameters.AddWithValue("@lat", center.Latitude);
+        command.Parameters.AddWithValue("@radius", radiusMeters);
+
+        var results = new List<string>();
+        await using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        while (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            results.Add(reader.GetString(0));
+        }
+
+        return results;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_connection.State == System.Data.ConnectionState.Open)
+        {
+            await using var command = _connection.CreateCommand();
+            command.CommandText = $"TRUNCATE {_tableName};";
+            try
+            {
+                await command.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+            catch
+            {
+                // Ignore clean-up failures, temporary tables are scoped to the session.
+            }
+        }
+
+        await _connection.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/TestDataLoader.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/TestDataLoader.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
+
+internal static class TestDataLoader
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static IReadOnlyList<T> LoadCollection<T>(string fileName)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("Fixture file name must be provided.", nameof(fileName));
+        }
+
+        var basePath = AppContext.BaseDirectory;
+        var fullPath = Path.Combine(basePath, "fixtures", fileName);
+
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"Unable to locate fixture '{fileName}'. Expected at '{fullPath}'.", fullPath);
+        }
+
+        using var stream = File.OpenRead(fullPath);
+        var payload = JsonSerializer.Deserialize<IReadOnlyList<T>>(stream, SerializerOptions);
+
+        if (payload == null)
+        {
+            throw new InvalidOperationException($"Fixture '{fileName}' could not be deserialized as {typeof(T).Name}.");
+        }
+
+        return payload;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -10,6 +10,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,6 +28,12 @@
     <ProjectReference Include="..\LiteDB\LiteDB.csproj">
       <Aliases>LiteDbBase</Aliases>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="fixtures\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/LiteDB.Spatial.Core.Tests/fixtures/geodesic_pairs.json
+++ b/LiteDB.Spatial.Core.Tests/fixtures/geodesic_pairs.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "equator_micro",
+    "from": {
+      "lon": 10.0,
+      "lat": 0.0
+    },
+    "to": {
+      "lon": 9.999393,
+      "lat": -3e-06
+    },
+    "geographicLibDistanceMeters": 67.5420169593904
+  },
+  {
+    "id": "midlat_short",
+    "from": {
+      "lon": -73.98,
+      "lat": 40.75
+    },
+    "to": {
+      "lon": -73.979783,
+      "lat": 40.75009
+    },
+    "geographicLibDistanceMeters": 20.879088334260352
+  },
+  {
+    "id": "dateline_micro",
+    "from": {
+      "lon": 179.999,
+      "lat": -17.5
+    },
+    "to": {
+      "lon": 179.9985,
+      "lat": -17.50024
+    },
+    "geographicLibDistanceMeters": 59.37266133166225
+  },
+  {
+    "id": "southern_micro",
+    "from": {
+      "lon": 151.21,
+      "lat": -33.86
+    },
+    "to": {
+      "lon": 151.2094,
+      "lat": -33.8604
+    },
+    "geographicLibDistanceMeters": 71.07146370436712
+  },
+  {
+    "id": "andes_micro",
+    "from": {
+      "lon": -77.05,
+      "lat": -12.05
+    },
+    "to": {
+      "lon": -77.049538,
+      "lat": -12.049912
+    },
+    "geographicLibDistanceMeters": 51.284454776201784
+  },
+  {
+    "id": "polar_micro",
+    "from": {
+      "lon": -45.0,
+      "lat": 89.5
+    },
+    "to": {
+      "lon": -44.999772,
+      "lat": 89.499981
+    },
+    "geographicLibDistanceMeters": 2.135449291942629
+  }
+]
+
+

--- a/LiteDB.Spatial.Core.Tests/fixtures/geographic_bounding_boxes.json
+++ b/LiteDB.Spatial.Core.Tests/fixtures/geographic_bounding_boxes.json
@@ -1,0 +1,49 @@
+[
+  {
+    "id": "fiji_dateline",
+    "bounds": {
+      "minLon": 165.0,
+      "minLat": -25.0,
+      "maxLon": 195.0,
+      "maxLat": -10.0
+    },
+    "points": [
+      { "id": "nadi_fiji", "lon": 177.443, "lat": -17.755 },
+      { "id": "apia_samoa", "lon": -171.751, "lat": -13.833 },
+      { "id": "tongatapu", "lon": -175.2, "lat": -21.133 },
+      { "id": "auckland", "lon": 174.763, "lat": -36.848 },
+      { "id": "santiago", "lon": -70.669, "lat": -33.448 }
+    ]
+  },
+  {
+    "id": "aleutian_wrap",
+    "bounds": {
+      "minLon": 160.0,
+      "minLat": 50.0,
+      "maxLon": 200.0,
+      "maxLat": 66.0
+    },
+    "points": [
+      { "id": "attu_island", "lon": 173.185, "lat": 52.895 },
+      { "id": "umyatkin", "lon": 179.778, "lat": 53.361 },
+      { "id": "big_diomede", "lon": -169.035, "lat": 65.766 },
+      { "id": "anchorage", "lon": -149.9, "lat": 61.218 },
+      { "id": "yakutsk", "lon": 129.732, "lat": 62.034 }
+    ]
+  },
+  {
+    "id": "antarctic_cap",
+    "bounds": {
+      "minLon": -60.0,
+      "minLat": -90.0,
+      "maxLon": 60.0,
+      "maxLat": -70.0
+    },
+    "points": [
+      { "id": "south_pole", "lon": 0.0, "lat": -90.0 },
+      { "id": "mcmurdo", "lon": 166.667, "lat": -77.85 },
+      { "id": "palmer_station", "lon": -64.05, "lat": -64.77 },
+      { "id": "rio_de_janeiro", "lon": -43.1729, "lat": -22.9068 }
+    ]
+  }
+]

--- a/LiteDB.Spatial.Core.Tests/fixtures/geographic_near_queries.json
+++ b/LiteDB.Spatial.Core.Tests/fixtures/geographic_near_queries.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "tokyo_core",
+    "center": { "lon": 139.7671, "lat": 35.6812 },
+    "radiusMeters": 6000.0,
+    "points": [
+      { "id": "tokyo_station", "lon": 139.7671, "lat": 35.6812 },
+      { "id": "shinjuku", "lon": 139.7006, "lat": 35.6895 },
+      { "id": "tokyo_tower", "lon": 139.7454, "lat": 35.6586 },
+      { "id": "yokohama", "lon": 139.6380, "lat": 35.4437 },
+      { "id": "sapporo", "lon": 141.3545, "lat": 43.0618 }
+    ]
+  },
+  {
+    "id": "andes_arc",
+    "center": { "lon": -77.0428, "lat": -12.0464 },
+    "radiusMeters": 150000.0,
+    "points": [
+      { "id": "lima", "lon": -77.0428, "lat": -12.0464 },
+      { "id": "callao", "lon": -77.1290, "lat": -12.0560 },
+      { "id": "cusco", "lon": -71.9675, "lat": -13.5319 },
+      { "id": "quito", "lon": -78.4678, "lat": -0.1807 },
+      { "id": "santiago", "lon": -70.6690, "lat": -33.4489 }
+    ]
+  }
+]

--- a/docs/Spatial-Revamp/2-Testing.md
+++ b/docs/Spatial-Revamp/2-Testing.md
@@ -57,9 +57,13 @@
 
 * Store fixtures under `/tests/fixtures`:
 
-  * `geodesic_pairs.json` (from GeographicLib; meters).
-  * `geojson_polygons/*.json` (holes, self-touching, anti-meridian).
-  * `point_clouds/*.json` (dense 2D & 3D lattices).
+* `geodesic_pairs.json` (from GeographicLib; meters).
+  * Lives at `LiteDB.Spatial.Core.Tests/fixtures/geodesic_pairs.json` with `{ id, from, to, geographicLibDistanceMeters }` records.
+  * Re-generate via `python - <<'PY'` script in the test suite which uses `geographiclib.geodesic.Geodesic.WGS84.Inverse`.
+* `geojson_polygons/*.json` (holes, self-touching, anti-meridian).
+* `point_clouds/*.json` (dense 2D & 3D lattices).
+* `geographic_bounding_boxes.json` — Natural Earth anti-meridian slices used by `NtsOracle`.
+* `geographic_near_queries.json` — dense metro + regional samples for near/PostGIS parity.
 * Define numeric tolerances:
 
   * Distances: **Earth** `≤ 1e-4 * distance + 0.05 m` (Vincenty/Haversine parity),
@@ -89,6 +93,12 @@
 
 * Result sets equal to oracle (allow ordering differences).
 * Distance deltas within tolerance; anti-meridian parity proven on Natural Earth shapes.
+
+### PostGIS toggle & temporary schema
+
+* Set `SPATIAL_DB_TESTS` to an Npgsql connection string (e.g., `Host=localhost;Username=postgres;Password=secret;Database=spatial_tests`).
+* The test harness creates temporary tables (prefixed with `tmp_litedb_points_`) and expects the `postgis` extension to be installed.
+* When the variable is absent the xUnit suite throws a `SkipException`, keeping CI runs green without external services.
 
 ---
 
@@ -217,6 +227,18 @@ dOur.Should().BeApproximately(dRef, 1e-9);
 ```
 
 ---
+
+## Maintaining oracle datasets
+
+* Rebuild `geodesic_pairs.json` with the Python snippet in `GeodesicDistanceParityTests` whenever the upstream fixtures change.
+* Natural Earth bounding boxes (`geographic_bounding_boxes.json`) and near-query point clouds (`geographic_near_queries.json`) should be curated offline, keeping IDs stable so failure reports stay actionable.
+* `RelativeTolerance = 1e-4` and `AbsoluteTolerance = 0.05` underpin the geographic assertions—adjust fixtures instead of loosening tolerances.
+
+## Explain plan guardrails
+
+* All new geographic differential tests call `SpatialDiagnostics.Explain(plan, descriptor)` and assert the `_idx` predicate appears before the exact filter.
+* Expect distance plans to read like `Vincenty distance <= … meters` and bounding box plans to report `Within bounding box`.
+* Use the explain output to troubleshoot regressions before diving into index ranges.
 
 # How to integrate without polluting production
 


### PR DESCRIPTION
## Summary
- add oracle-tagged geographic parity suites that validate Haversine and Vincenty distances against cached GeographicLib fixtures
- build Natural Earth-inspired bounding box and near-query datasets with NTS and optional PostGIS comparisons, asserting explain plans use `_idx`
- document the new fixtures, toggles, and regeneration workflow for CI-friendly runs

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj


------
https://chatgpt.com/codex/tasks/task_e_68e8051db1e8832ab95b15cde8ad89a8