### PR TITLE
Add FsCheck-backed Cartesian spatial differential tests

### DIFF
--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/Cartesian2DGenerators.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/Cartesian2DGenerators.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FsCheck;
+using FsCheck.Fluent;
+using FsArb = FsCheck.Fluent.Arb;
+using FsGen = FsCheck.Fluent.Gen;
+using LiteDB.Spatial;
+using LiteDB.Spatial.Core.Tests.Oracles;
+using LiteDB.Spatial.Core.Tests.TestSupport;
+
+namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
+
+internal static class Cartesian2DGenerators
+{
+    public static Arbitrary<CartesianPolygonCase> PolygonCases()
+    {
+        return FsArb.From(GenPolygonCase());
+    }
+
+    public static Arbitrary<CartesianBoxCase> BoxCases()
+    {
+        return FsArb.From(GenBoxCase());
+    }
+
+    private static Gen<CartesianPolygonCase> GenPolygonCase()
+    {
+        return from count in FsGen.Choose(4, 8)
+               from raw in FsGen.ListOf(PointGen(), count * 3)
+               let unique = raw.Distinct().ToList()
+               where unique.Count >= 4
+               let hullCoordinates = NtsOracle.Hull(unique.Select(p => (p.X, p.Y)).ToList())
+               let hull = NormalizeHull(hullCoordinates)
+               where hull.Count >= 4
+               let polygonPoints = hull.Take(hull.Count - 1).Select(p => new CartesianPoint2D(p.X, p.Y)).ToList()
+               let centroid = ComputeCentroid(polygonPoints)
+               let insideSamples = BuildInsideSamples(polygonPoints, centroid)
+               let outsideSamples = BuildOutsideSamples(polygonPoints, centroid)
+               let candidates = unique.Append(centroid).Concat(insideSamples).Concat(outsideSamples).Distinct().ToList()
+               let domain = BuildDomain(polygonPoints.Concat(candidates))
+               select new CartesianPolygonCase(domain, candidates, hull.Select(p => new CartesianPoint2D(p.X, p.Y)).ToList(), centroid);
+    }
+
+    private static Gen<CartesianBoxCase> GenBoxCase()
+    {
+        return from count in FsGen.Choose(12, 36)
+               from raw in FsGen.ListOf(PointGen(), count * 2)
+               let points = raw.Distinct().ToList()
+               where points.Count >= 6
+               from anchor in FsGen.Elements<CartesianPoint2D>(points)
+               from other in FsGen.Elements<CartesianPoint2D>(points)
+               let minX = Math.Min(anchor.X, other.X)
+               let maxX = Math.Max(anchor.X, other.X)
+               let minY = Math.Min(anchor.Y, other.Y)
+               let maxY = Math.Max(anchor.Y, other.Y)
+               let adjustedMaxX = maxX <= minX ? minX + 0.5 : maxX
+               let adjustedMaxY = maxY <= minY ? minY + 0.5 : maxY
+               let query = BoundingBox.From2D(minX, minY, adjustedMaxX, adjustedMaxY)
+               let domain = BuildDomain(points)
+               select new CartesianBoxCase(domain, query, points);
+    }
+
+    private static Gen<CartesianPoint2D> PointGen()
+    {
+        return from x in FsGen.Choose(-1700, 1700)
+               from y in FsGen.Choose(-850, 850)
+               let scaledX = Math.Round(x / 10.0, 3)
+               let scaledY = Math.Round(y / 10.0, 3)
+               select new CartesianPoint2D(scaledX, scaledY);
+    }
+
+    private static List<(double X, double Y)> NormalizeHull(IReadOnlyList<(double X, double Y)> hull)
+    {
+        if (hull.Count == 0)
+        {
+            return new List<(double X, double Y)>();
+        }
+
+        var closed = hull.ToList();
+        if (!PointsEqual(closed[0], closed[^1]))
+        {
+            closed.Add(closed[0]);
+        }
+
+        return closed;
+    }
+
+    private static bool PointsEqual((double X, double Y) left, (double X, double Y) right)
+    {
+        return Math.Abs(left.X - right.X) < 1e-9 && Math.Abs(left.Y - right.Y) < 1e-9;
+    }
+
+    private static CartesianPoint2D ComputeCentroid(IReadOnlyList<CartesianPoint2D> points)
+    {
+        var count = points.Count;
+        var sumX = points.Sum(p => p.X);
+        var sumY = points.Sum(p => p.Y);
+        return new CartesianPoint2D(sumX / count, sumY / count);
+    }
+
+    private static IEnumerable<CartesianPoint2D> BuildInsideSamples(IReadOnlyList<CartesianPoint2D> hull, CartesianPoint2D centroid)
+    {
+        foreach (var vertex in hull)
+        {
+            var inside = new CartesianPoint2D((vertex.X + centroid.X) / 2d, (vertex.Y + centroid.Y) / 2d);
+            yield return inside;
+        }
+    }
+
+    private static IEnumerable<CartesianPoint2D> BuildOutsideSamples(IReadOnlyList<CartesianPoint2D> hull, CartesianPoint2D centroid)
+    {
+        foreach (var vertex in hull)
+        {
+            var dx = vertex.X - centroid.X;
+            var dy = vertex.Y - centroid.Y;
+            var outside = ClampPoint(new CartesianPoint2D(vertex.X + dx, vertex.Y + dy));
+            if (!NtsOracle.Contains(hull.Select(p => (p.X, p.Y)).ToList(), (outside.X, outside.Y)))
+            {
+                yield return outside;
+            }
+        }
+    }
+
+    private static CartesianPoint2D ClampPoint(CartesianPoint2D point)
+    {
+        var clampedX = Math.Max(-179.9, Math.Min(179.9, point.X));
+        var clampedY = Math.Max(-89.9, Math.Min(89.9, point.Y));
+        return new CartesianPoint2D(clampedX, clampedY);
+    }
+
+    private static BoundingBox BuildDomain(IEnumerable<CartesianPoint2D> points)
+    {
+        var list = points.ToList();
+        var minX = list.Min(p => p.X) - 1;
+        var maxX = list.Max(p => p.X) + 1;
+        var minY = list.Min(p => p.Y) - 1;
+        var maxY = list.Max(p => p.Y) + 1;
+
+        minX = Math.Max(minX, -180);
+        maxX = Math.Min(maxX, 180);
+        minY = Math.Max(minY, -90);
+        maxY = Math.Min(maxY, 90);
+
+        if (maxX <= minX)
+        {
+            maxX = minX + 1;
+        }
+
+        if (maxY <= minY)
+        {
+            maxY = minY + 1;
+        }
+
+        return BoundingBox.From2D(minX, minY, maxX, maxY);
+    }
+}
+
+public sealed record CartesianPolygonCase(
+    BoundingBox Domain,
+    IReadOnlyList<CartesianPoint2D> Candidates,
+    IReadOnlyList<CartesianPoint2D> Polygon,
+    CartesianPoint2D Centroid)
+{
+    public IReadOnlyList<(double X, double Y)> ToRing() => Polygon.Select(p => (p.X, p.Y)).ToList();
+}
+
+public sealed record CartesianBoxCase(BoundingBox Domain, BoundingBox Query, IReadOnlyList<CartesianPoint2D> Points);

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianBoundingBoxDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianBoundingBoxDifferentialTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using LiteDB.Spatial.Core.Tests.TestSupport;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
+
+public sealed class CartesianBoundingBoxDifferentialTests
+{
+    [SpatialProperty(MaxTest = 100, Arbitrary = new[] { typeof(Cartesian2DGenerators) })]
+    public void AxisAlignedBoundingBoxesMatchManualInequalities(CartesianBoxCase testCase)
+    {
+        var snapshot = new
+        {
+            Domain = testCase.Domain.ToArray(),
+            Query = testCase.Query.ToArray(),
+            Points = testCase.Points
+        };
+
+        RunWithSnapshot("aabb-within", snapshot, () =>
+        {
+            using var harness = new Cartesian2DTestHarness(testCase.Domain);
+            harness.InsertPoints(testCase.Points);
+
+            var results = harness.ExecuteBoundingBox(testCase.Query, out var breakdown);
+            var expected = testCase.Points
+                .Select((point, index) => (point, id: index + 1))
+                .Where(pair => pair.point.X >= testCase.Query.MinX && pair.point.X <= testCase.Query.MaxX
+                               && pair.point.Y >= testCase.Query.MinY && pair.point.Y <= testCase.Query.MaxY)
+                .Select(pair => pair.id)
+                .OrderBy(id => id)
+                .ToList();
+
+            results.Select(r => r.Id).Should().Equal(expected);
+            breakdown.Index.Count.Should().BeGreaterOrEqualTo(breakdown.Prefilter.Count);
+            breakdown.Prefilter.Count.Should().BeGreaterOrEqualTo(breakdown.Exact.Count);
+        });
+    }
+
+    private static void RunWithSnapshot<T>(string scenario, T payload, Action body)
+    {
+        try
+        {
+            body();
+        }
+        catch (Exception)
+        {
+            FailureSnapshot.Capture(scenario, payload!);
+            throw;
+        }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianPolygonDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianPolygonDifferentialTests.cs
@@ -1,0 +1,74 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using LiteDB.Spatial;
+using LiteDB.Spatial.Core.Tests.Oracles;
+using LiteDB.Spatial.Core.Tests.TestSupport;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
+
+public sealed class CartesianPolygonDifferentialTests
+{
+    [SpatialProperty(MaxTest = 75, Arbitrary = new[] { typeof(Cartesian2DGenerators) })]
+    [Trait("Category", "Oracle")]
+    public void ConvexPolygonContainsMatchesOracle(CartesianPolygonCase testCase)
+    {
+        var snapshot = new
+        {
+            Domain = testCase.Domain.ToArray(),
+            Candidates = testCase.Candidates,
+            Polygon = testCase.Polygon
+        };
+
+        RunWithSnapshot("polygon-contains", snapshot, () =>
+        {
+            using var harness = new Cartesian2DTestHarness(testCase.Domain);
+            harness.InsertPoints(testCase.Candidates);
+
+            static bool OraclePredicate(CartesianPoint2D point, CartesianPolygonCase @case)
+            {
+                return NtsOracle.Contains(@case.ToRing(), (point.X, point.Y));
+            }
+
+            var polygon = BuildLiteDbPolygon(testCase.Polygon);
+            var matches = harness.ExecutePolygon(polygon, p => OraclePredicate(p, testCase), out var breakdown);
+
+            var expected = testCase.Candidates
+                .Select((point, index) => (point, id: index + 1))
+                .Where(pair => OraclePredicate(pair.point, testCase))
+                .Select(pair => pair.id)
+                .OrderBy(id => id)
+                .ToList();
+
+            matches.Select(m => m.Id).Should().Equal(expected);
+            breakdown.Index.Count.Should().BeGreaterOrEqualTo(breakdown.Exact.Count);
+            breakdown.Prefilter.Count.Should().BeGreaterOrEqualTo(breakdown.Exact.Count);
+        });
+    }
+
+    private static LiteDbBase::LiteDB.Spatial.GeoPolygon BuildLiteDbPolygon(IReadOnlyList<CartesianPoint2D> ring)
+    {
+        var outer = ring.Take(ring.Count - 1).Select(p => new LiteDbBase::LiteDB.Spatial.GeoPoint(p.Y, p.X)).ToList();
+        outer.Add(new LiteDbBase::LiteDB.Spatial.GeoPoint(ring[0].Y, ring[0].X));
+        return new LiteDbBase::LiteDB.Spatial.GeoPolygon(outer);
+    }
+
+    private static void RunWithSnapshot<T>(string scenario, T payload, Action body)
+    {
+        try
+        {
+            body();
+        }
+        catch (Exception)
+        {
+            FailureSnapshot.Capture(scenario, payload!);
+            throw;
+        }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/PointCloudFixtures.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/PointCloudFixtures.cs
@@ -1,0 +1,70 @@
+#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using LiteDB.Spatial.Core.Tests.TestSupport;
+
+namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
+
+internal sealed record PointCloudFixture(string Id, BoundingBox Domain, IReadOnlyList<PointSample> Points, IReadOnlyList<PointQuery> Queries)
+{
+    public static PointCloudFixture Load(string relativePath)
+    {
+        var path = TestResourceLocator.GetFixturePath(relativePath);
+        var json = File.ReadAllText(path);
+        var dto = JsonSerializer.Deserialize<PointCloudDto>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        }) ?? throw new InvalidDataException($"Fixture '{path}' could not be deserialized.");
+
+        var domain = BoundingBox.From2D(dto.Domain.MinX, dto.Domain.MinY, dto.Domain.MaxX, dto.Domain.MaxY);
+        var points = dto.Points.Select(p => new PointSample(p.Label, new CartesianPoint2D(p.X, p.Y))).ToList();
+        var queries = dto.Queries.Select(q => new PointQuery(q.Id, new CartesianPoint2D(q.Center.X, q.Center.Y), q.Radius)).ToList();
+        return new PointCloudFixture(dto.Id ?? Path.GetFileNameWithoutExtension(relativePath), domain, points, queries);
+    }
+}
+
+internal sealed record PointSample(string Label, CartesianPoint2D Position);
+
+internal sealed record PointQuery(string Id, CartesianPoint2D Center, double Radius);
+
+internal sealed class PointCloudDto
+{
+    public string? Id { get; set; }
+
+    public DomainDto Domain { get; set; } = null!;
+
+    public List<PointDto> Points { get; set; } = new();
+
+    public List<QueryDto> Queries { get; set; } = new();
+}
+
+internal sealed class DomainDto
+{
+    public double MinX { get; set; }
+    public double MinY { get; set; }
+    public double MaxX { get; set; }
+    public double MaxY { get; set; }
+}
+
+internal sealed class PointDto
+{
+    public string Label { get; set; } = string.Empty;
+    public double X { get; set; }
+    public double Y { get; set; }
+}
+
+internal sealed class QueryDto
+{
+    public string Id { get; set; } = string.Empty;
+    public CenterDto Center { get; set; } = new();
+    public double Radius { get; set; }
+}
+
+internal sealed class CenterDto
+{
+    public double X { get; set; }
+    public double Y { get; set; }
+}

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/PointCloudNearTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/PointCloudNearTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using LiteDB.Spatial.Core.Tests.TestSupport;
+using Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
+
+public sealed class PointCloudNearTests
+{
+    [Fact]
+    public void NearQueriesMatchEuclideanExpectations()
+    {
+        var fixture = PointCloudFixture.Load("point_clouds/unit_grid.json");
+        var snapshot = new
+        {
+            fixture.Id,
+            Domain = fixture.Domain.ToArray(),
+            Points = fixture.Points,
+            Queries = fixture.Queries
+        };
+
+        RunWithSnapshot(fixture.Id + "-near", snapshot, () =>
+        {
+            using var harness = new Cartesian2DTestHarness(fixture.Domain);
+            harness.InsertPoints(fixture.Points.Select(p => p.Position));
+
+            foreach (var query in fixture.Queries)
+            {
+                var matches = harness.ExecuteNear((query.Center.X, query.Center.Y), query.Radius, out var breakdown);
+                var expected = fixture.Points
+                    .Select((sample, index) => (sample, id: index + 1, distance: Distance(sample.Position, query.Center)))
+                    .Where(entry => entry.distance <= query.Radius + NumericTolerance.ForDistance(Math.Max(query.Radius, entry.distance)))
+                    .OrderBy(entry => entry.id)
+                    .ToList();
+
+                matches.Select(m => m.Id).Should().Equal(expected.Select(e => e.id));
+                matches.Select(m => Distance(m.Point, query.Center)).Zip(expected, (actual, exp) => (actual, exp.distance))
+                    .ToList()
+                    .ForEach(pair => pair.actual.Should().BeApproximately(pair.distance, NumericTolerance.ForDistance(Math.Max(pair.distance, query.Radius))));
+
+                breakdown.Index.Count.Should().BeGreaterOrEqualTo(breakdown.Prefilter.Count);
+                breakdown.Prefilter.Count.Should().BeGreaterOrEqualTo(breakdown.Exact.Count);
+                breakdown.Exact.Count.Should().Be(expected.Count);
+            }
+        });
+    }
+
+    [Fact]
+    public void MortonOrderIsStableAcrossRepeatedQueries()
+    {
+        var fixture = PointCloudFixture.Load("point_clouds/unit_grid.json");
+        var snapshot = new
+        {
+            fixture.Id,
+            Domain = fixture.Domain.ToArray(),
+            Points = fixture.Points,
+            Queries = fixture.Queries
+        };
+
+        RunWithSnapshot(fixture.Id + "-order", snapshot, () =>
+        {
+            using var harness = new Cartesian2DTestHarness(fixture.Domain);
+            harness.InsertPoints(fixture.Points.Select(p => p.Position));
+
+            var baseline = harness.ExecuteNear((fixture.Queries[0].Center.X, fixture.Queries[0].Center.Y), fixture.Queries[0].Radius, out _)
+                .Select(p => p.Id)
+                .ToList();
+
+            for (var i = 0; i < 5; i++)
+            {
+                var iteration = harness.ExecuteNear((fixture.Queries[0].Center.X, fixture.Queries[0].Center.Y), fixture.Queries[0].Radius, out _)
+                    .Select(p => p.Id)
+                    .ToList();
+
+                iteration.Should().Equal(baseline);
+            }
+        });
+    }
+
+    private static double Distance(CartesianPoint2D point, CartesianPoint2D center)
+    {
+        var dx = point.X - center.X;
+        var dy = point.Y - center.Y;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    private static void RunWithSnapshot<T>(string scenario, T payload, Action body)
+    {
+        try
+        {
+            body();
+        }
+        catch (Exception)
+        {
+            FailureSnapshot.Capture(scenario, payload!);
+            throw;
+        }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -9,7 +9,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="FsCheck.Xunit" Version="3.0.0" />
+    <PackageReference Include="FsCheck" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NetTopologySuite" Version="2.6.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LiteDB.Spatial.Core.Tests/Oracles/NtsOracle.cs
+++ b/LiteDB.Spatial.Core.Tests/Oracles/NtsOracle.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using NetTopologySuite.Geometries;
+
+namespace LiteDB.Spatial.Core.Tests.Oracles;
+
+internal static class NtsOracle
+{
+    private static readonly GeometryFactory Factory = GeometryFactory.Default;
+
+    public static bool Contains(IReadOnlyList<(double X, double Y)> ring, (double X, double Y) point)
+    {
+        var polygon = BuildPolygon(ring);
+        var ntsPoint = Factory.CreatePoint(new Coordinate(point.X, point.Y));
+        return polygon.Contains(ntsPoint) || polygon.Touches(ntsPoint);
+    }
+
+    public static IReadOnlyList<(double X, double Y)> Hull(IReadOnlyList<(double X, double Y)> points)
+    {
+        var coordinates = points.Select(p => new Coordinate(p.X, p.Y)).ToArray();
+        if (coordinates.Length == 0)
+        {
+            return new List<(double X, double Y)>();
+        }
+
+        var geometry = Factory.CreateMultiPointFromCoords(coordinates);
+        var hull = geometry.ConvexHull();
+        if (hull is Polygon polygon)
+        {
+            return polygon.Coordinates.Select(c => (c.X, c.Y)).ToList();
+        }
+
+        return geometry.ConvexHull().Coordinates.Select(c => (c.X, c.Y)).ToList();
+    }
+
+    private static Polygon BuildPolygon(IReadOnlyList<(double X, double Y)> ring)
+    {
+        var coordinates = ring.Select(p => new Coordinate(p.X, p.Y)).ToArray();
+        if (!coordinates.First().Equals2D(coordinates.Last()))
+        {
+            coordinates = coordinates.Concat(new[] { coordinates.First() }).ToArray();
+        }
+
+        var shell = Factory.CreateLinearRing(coordinates);
+        return Factory.CreatePolygon(shell);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/Cartesian2DTestHarness.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/Cartesian2DTestHarness.cs
@@ -1,0 +1,207 @@
+extern alias LiteDbBase;
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FluentAssertions;
+using LiteDB.Spatial;
+using BaseLiteDB = LiteDbBase::LiteDB;
+using BaseGeoPoint = LiteDbBase::LiteDB.Spatial.GeoPoint;
+using BaseGeoPolygon = LiteDbBase::LiteDB.Spatial.GeoPolygon;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal sealed class Cartesian2DTestHarness : IDisposable
+{
+    private readonly BaseLiteDB.LiteDatabase _database;
+    private readonly BaseLiteDB.ILiteCollection<BaseLiteDB.BsonDocument> _collection;
+    private readonly SpatialMetadataStore _metadata;
+    private SpatialCollectionDescriptor _descriptor;
+    private readonly BoundingBox _domain;
+    private readonly string _geometryFieldName = "position";
+    private readonly List<PointRecord> _records = new();
+
+    public Cartesian2DTestHarness(BoundingBox domain)
+    {
+        _database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        _collection = _database.GetCollection("points");
+        _metadata = new SpatialMetadataStore(_database);
+        _domain = domain;
+        _descriptor = SpatialCartesian2D.EnsurePointIndex(_metadata, _collection, _geometryFieldName, domain);
+    }
+
+    public IReadOnlyList<PointRecord> Records => _records;
+
+    public SpatialCollectionDescriptor Descriptor => _descriptor;
+
+    public BaseLiteDB.ILiteCollection<BaseLiteDB.BsonDocument> RawCollection => _collection;
+
+    public void InsertPoints(IEnumerable<CartesianPoint2D> points)
+    {
+        if (_records.Count > 0)
+        {
+            throw new InvalidOperationException("Points already inserted into harness.");
+        }
+
+        var list = points.Select((p, index) => new PointRecord(index + 1, p)).ToList();
+        foreach (var record in list)
+        {
+            var document = new BaseLiteDB.BsonDocument
+            {
+                ["_id"] = record.Id,
+                [_geometryFieldName] = new BaseLiteDB.BsonDocument
+                {
+                    ["x"] = record.Point.X,
+                    ["y"] = record.Point.Y
+                }
+            };
+
+            _collection.Insert(document);
+        }
+
+        _descriptor = SpatialCartesian2D.EnsurePointIndex(_metadata, _collection, _geometryFieldName, _domain, _descriptor.Options);
+        _records.AddRange(list);
+        _records.Should().NotBeEmpty("harness requires at least one point");
+    }
+
+    public IReadOnlyList<PointRecord> ExecuteNear((double X, double Y) center, double radius, out CandidateBreakdown breakdown)
+    {
+        var structCenter = new GeoPoint(center.X, center.Y);
+        var plan = SpatialCartesian2D.Near(_descriptor, structCenter, radius);
+        var candidates = EvaluateCandidates(plan, p =>
+        {
+            var distance = EuclideanDistance(p.Point, center);
+            var tolerance = NumericTolerance.ForDistance(Math.Max(radius, distance));
+            return distance <= radius + tolerance;
+        });
+
+        breakdown = candidates;
+        return candidates.Exact.OrderBy(r => r.Id).ToList();
+    }
+
+    public IReadOnlyList<PointRecord> ExecuteBoundingBox(BoundingBox query, out CandidateBreakdown breakdown)
+    {
+        var plan = SpatialCartesian2D.WithinBoundingBox(_descriptor, query);
+        var candidates = EvaluateCandidates(plan, p =>
+        {
+            return p.Point.X >= query.MinX && p.Point.X <= query.MaxX
+                && p.Point.Y >= query.MinY && p.Point.Y <= query.MaxY;
+        });
+        breakdown = candidates;
+        return candidates.Exact.OrderBy(r => r.Id).ToList();
+    }
+
+    public IReadOnlyList<PointRecord> ExecutePolygon(BaseGeoPolygon polygon, Func<CartesianPoint2D, bool> oracle, out CandidateBreakdown breakdown)
+    {
+        var bounds = ComputeBounds(polygon);
+        var plan = SpatialCartesian2D.WithinBoundingBox(_descriptor, bounds);
+        var candidates = EvaluateCandidates(plan, p => oracle(p.Point));
+        breakdown = candidates;
+        return candidates.Exact.OrderBy(r => r.Id).ToList();
+    }
+
+    public void Dispose()
+    {
+        _database.Dispose();
+    }
+
+    private CandidateBreakdown EvaluateCandidates(ISpatialQueryPlan plan, Func<PointRecord, bool> exactPredicate)
+    {
+        var indexField = _descriptor.Options.IndexFieldName;
+        var boundingField = _descriptor.Options.BoundingBoxFieldName;
+        var raw = RawCollection.FindAll().ToList();
+        var indexHits = new List<PointRecord>();
+        var prefilterHits = new List<PointRecord>();
+        var exactHits = new List<PointRecord>();
+
+        foreach (var document in raw)
+        {
+            if (!document.TryGetValue(indexField, out var encoded))
+            {
+                continue;
+            }
+
+            var id = document["_id"].AsInt32;
+            var record = _records.First(r => r.Id == id);
+            if (!IsIndexMatch(encoded, plan.IndexRanges))
+            {
+                continue;
+            }
+
+            indexHits.Add(record);
+
+            if (!document.TryGetValue(boundingField, out var bboxValue) || !bboxValue.IsArray)
+            {
+                continue;
+            }
+
+            var storedBounds = BoundingBox.Create(bboxValue.AsArray.Select(v => v.AsDouble).ToArray());
+            if (plan.CoveringBounds is { } covering && !Intersects(storedBounds, covering))
+            {
+                continue;
+            }
+
+            prefilterHits.Add(record);
+
+            if (exactPredicate(record))
+            {
+                exactHits.Add(record);
+            }
+        }
+
+        return new CandidateBreakdown(indexHits, prefilterHits, exactHits);
+    }
+
+    private static BoundingBox ComputeBounds(BaseGeoPolygon polygon)
+    {
+        var minX = polygon.Outer.Min(p => p.Lon);
+        var maxX = polygon.Outer.Max(p => p.Lon);
+        var minY = polygon.Outer.Min(p => p.Lat);
+        var maxY = polygon.Outer.Max(p => p.Lat);
+        return BoundingBox.From2D(minX, minY, maxX, maxY);
+    }
+
+    private static bool IsIndexMatch(BaseLiteDB.BsonValue value, IReadOnlyList<SpatialIndexRange> ranges)
+    {
+        if (!value.IsNumber)
+        {
+            return false;
+        }
+
+        ulong encoded = value.Type switch
+        {
+            BaseLiteDB.BsonType.Int64 => (ulong)value.AsInt64,
+            BaseLiteDB.BsonType.Int32 => (ulong)value.AsInt32,
+            BaseLiteDB.BsonType.Decimal => (ulong)value.AsDecimal,
+            BaseLiteDB.BsonType.Double => (ulong)value.AsDouble,
+            _ => 0
+        };
+        foreach (var range in ranges)
+        {
+            if (encoded >= range.Start && encoded <= range.End)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool Intersects(BoundingBox a, BoundingBox b)
+    {
+        return a.MinX <= b.MaxX && a.MaxX >= b.MinX
+            && a.MinY <= b.MaxY && a.MaxY >= b.MinY;
+    }
+
+    private static double EuclideanDistance(CartesianPoint2D left, (double X, double Y) right)
+    {
+        var dx = left.X - right.X;
+        var dy = left.Y - right.Y;
+        return Math.Sqrt((dx * dx) + (dy * dy));
+    }
+
+    public sealed record PointRecord(int Id, CartesianPoint2D Point);
+
+    public sealed record CandidateBreakdown(IReadOnlyList<PointRecord> Index, IReadOnlyList<PointRecord> Prefilter, IReadOnlyList<PointRecord> Exact);
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/CartesianPoint2D.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/CartesianPoint2D.cs
@@ -1,0 +1,18 @@
+extern alias LiteDbBase;
+
+using BaseGeoPoint = LiteDbBase::LiteDB.Spatial.GeoPoint;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+public readonly record struct CartesianPoint2D(double X, double Y)
+{
+    public LiteDB.Spatial.GeoPoint ToGeoPointStruct()
+    {
+        return new LiteDB.Spatial.GeoPoint(X, Y);
+    }
+
+    public BaseGeoPoint ToGeoPointClass()
+    {
+        return new BaseGeoPoint(Y, X);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/FailureSnapshot.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/FailureSnapshot.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal static class FailureSnapshot
+{
+    public static void Capture(string scenario, object payload)
+    {
+        try
+        {
+            var directory = TestResourceLocator.GetFailuresDirectory();
+            var fileName = $"{Sanitize(scenario)}-{DateTimeOffset.UtcNow:yyyyMMddTHHmmssfffZ}.json";
+            var path = Path.Combine(directory, fileName);
+            var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+            File.WriteAllText(path, json);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Failed to capture failure snapshot for '{scenario}': {ex}");
+        }
+    }
+
+    private static string Sanitize(string value)
+    {
+        foreach (var c in Path.GetInvalidFileNameChars())
+        {
+            value = value.Replace(c, '-');
+        }
+
+        return value;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/NumericTolerance.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/NumericTolerance.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal static class NumericTolerance
+{
+    private const double CartesianRelative = 1e-9;
+    private const double CartesianAbsolute = 1e-9;
+
+    public static double ForDistance(double scale)
+    {
+        var magnitude = Math.Abs(scale);
+        return Math.Max(CartesianAbsolute, (CartesianRelative * magnitude) + CartesianAbsolute);
+    }
+
+    public static bool AlmostEquals(double expected, double actual, double scale)
+    {
+        return Math.Abs(expected - actual) <= ForDistance(scale);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/SpatialPropertyAttribute.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/SpatialPropertyAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using FsCheck.Xunit;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal sealed class SpatialPropertyAttribute : PropertyAttribute
+{
+    public SpatialPropertyAttribute()
+    {
+        QuietOnSuccess = true;
+        var seed = Environment.GetEnvironmentVariable("SPATIAL_FSCHECK_SEED");
+        if (!string.IsNullOrWhiteSpace(seed))
+        {
+            Replay = seed;
+        }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/TestResourceLocator.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/TestResourceLocator.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal static class TestResourceLocator
+{
+    private static readonly Lazy<string> RepositoryRootAccessor = new(LocateRepositoryRoot, isThreadSafe: true);
+
+    public static string RepositoryRoot => RepositoryRootAccessor.Value;
+
+    public static string GetFailuresDirectory()
+    {
+        var directory = Path.Combine(RepositoryRoot, "tests", "failures");
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    public static string GetFixturePath(params string[] segments)
+    {
+        var path = Path.Combine(new[] { RepositoryRoot, "tests", "fixtures" }.Concat(segments).ToArray());
+        return path;
+    }
+
+    private static string LocateRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "LiteDB.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException($"Unable to locate repository root from '{AppContext.BaseDirectory}'.");
+    }
+}

--- a/docs/Spatial-Revamp/2-Testing.md
+++ b/docs/Spatial-Revamp/2-Testing.md
@@ -109,6 +109,12 @@
 
 * 1,000 random cases per run; zero mismatches or reproducible counterexamples saved to `/tests/failures`.
 
+### Running the property suites
+
+* Set `SPATIAL_FSCHECK_SEED=<randomSeed>,<startSize>` when invoking `dotnet test` to replay a specific FsCheck run. The seed uses the `StdGen` tuple format (for example `SPATIAL_FSCHECK_SEED=1742975381,0`).
+* Property snapshots are written to `tests/failures` using the shared helper – only promote counterexamples to fixtures when they represent new coverage.
+* Synthetic point-cloud fixtures live under `tests/fixtures/point_clouds`. Update or regenerate them by editing the JSON files directly; keep distance checks within the shared tolerance helper (`NumericTolerance.ForDistance`).
+
 ---
 
 ## T5 — Differential Correctness: Cartesian 3D

--- a/tests/failures/.gitignore
+++ b/tests/failures/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/fixtures/point_clouds/unit_grid.json
+++ b/tests/fixtures/point_clouds/unit_grid.json
@@ -1,0 +1,27 @@
+{
+  "id": "unit_grid",
+  "domain": { "minX": -5, "minY": -5, "maxX": 5, "maxY": 5 },
+  "points": [
+    { "label": "A", "x": -2, "y": -2 },
+    { "label": "B", "x": -1, "y": -1 },
+    { "label": "C", "x": -1, "y": 0 },
+    { "label": "D", "x": 0, "y": 0 },
+    { "label": "E", "x": 1, "y": 0 },
+    { "label": "F", "x": 2, "y": 1 },
+    { "label": "G", "x": 0, "y": 2 },
+    { "label": "H", "x": -2, "y": 1 },
+    { "label": "I", "x": 2, "y": -1 }
+  ],
+  "queries": [
+    {
+      "id": "origin_radius_2",
+      "center": { "x": 0, "y": 0 },
+      "radius": 2.0
+    },
+    {
+      "id": "offset_radius_1_5",
+      "center": { "x": 1, "y": 0 },
+      "radius": 1.5
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- introduce FsCheck/NetTopologySuite to the Cartesian spatial test project and add reusable generators
- add differential/property tests for polygons, bounding boxes, and point-cloud near queries including failure snapshotting
- document FsCheck seeding and fixture regeneration guidance and check in initial point-cloud fixture/failure directories

## Testing
- dotnet test LiteDB.Spatial.Core.Tests

------
https://chatgpt.com/codex/tasks/task_e_68e805250a54832abb648a491707bef5