### PR TITLE
Add 3D differential regression tests and covering diagnostics

### DIFF
--- a/LiteDB.Spatial.Cartesian2D/Engine/Cartesian2DEngine.cs
+++ b/LiteDB.Spatial.Cartesian2D/Engine/Cartesian2DEngine.cs
@@ -96,9 +96,9 @@ public sealed class Cartesian2DEngine : ICartesianSpatialEngine
     private SpatialQueryPlan PlanFromBounds(BoundingBox bounds, string predicate)
     {
         var normalized = _normalizer.Normalize(bounds);
-        var ranges = _encoder.Cover(normalized, _options.MaxCoveringCells);
-        var merged = MortonIndexEncoder.UnionAdjacentRanges(ranges);
-        return new SpatialQueryPlan(Name, Dimensions, bounds, merged, predicate);
+        var covering = _encoder.Cover(normalized, _options.MaxCoveringCells);
+        var merged = MortonIndexEncoder.UnionAdjacentRanges(covering.Ranges);
+        return new SpatialQueryPlan(Name, Dimensions, bounds, merged, predicate, covering.CoveringCellCount, covering.UsedMaxCoveringCellFallback);
     }
 
     private static void ValidateRadius(double radius)

--- a/LiteDB.Spatial.Cartesian3D/Engine/Cartesian3DEngine.cs
+++ b/LiteDB.Spatial.Cartesian3D/Engine/Cartesian3DEngine.cs
@@ -100,9 +100,9 @@ public sealed class Cartesian3DEngine : ICartesianSpatialEngine
     private SpatialQueryPlan PlanFromBounds(BoundingBox bounds, string predicate)
     {
         var normalized = _normalizer.Normalize(bounds);
-        var ranges = _encoder.Cover(normalized, _options.MaxCoveringCells);
-        var merged = MortonIndexEncoder.UnionAdjacentRanges(ranges);
-        return new SpatialQueryPlan(Name, Dimensions, bounds, merged, predicate);
+        var covering = _encoder.Cover(normalized, _options.MaxCoveringCells);
+        var merged = MortonIndexEncoder.UnionAdjacentRanges(covering.Ranges);
+        return new SpatialQueryPlan(Name, Dimensions, bounds, merged, predicate, covering.CoveringCellCount, covering.UsedMaxCoveringCellFallback);
     }
 
     private static void ValidateRadius(double radius)

--- a/LiteDB.Spatial.Core.Tests/Diagnostics/SpatialDiagnosticsTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Diagnostics/SpatialDiagnosticsTests.cs
@@ -19,7 +19,9 @@ public sealed class SpatialDiagnosticsTests
                 new SpatialIndexRange(1, 5),
                 new SpatialIndexRange(6, 10)
             },
-            "Distance <= 10");
+            "Distance <= 10",
+            coveringCellCount: 12,
+            usedMaxCoveringCellFallback: true);
 
         var descriptor = new SpatialCollectionDescriptor("places", "Geographic2D", 2, "location", new SpatialIndexOptions());
         var explain = SpatialDiagnostics.Explain(plan, descriptor);
@@ -29,6 +31,8 @@ public sealed class SpatialDiagnosticsTests
         explain.CoveringBounds.Should().Be(plan.CoveringBounds);
         explain.IndexRanges.Should().ContainInOrder(plan.IndexRanges);
         explain.RangeCount.Should().Be(2);
+        explain.CoveringCellCount.Should().Be(12);
+        explain.UsedMaxCoveringCellFallback.Should().BeTrue();
         explain.ExactPredicate.Should().Be("Distance <= 10");
         explain.IndexFieldName.Should().Be(descriptor.Options.IndexFieldName);
         explain.BoundingBoxFieldName.Should().Be(descriptor.Options.BoundingBoxFieldName);
@@ -40,6 +44,7 @@ public sealed class SpatialDiagnosticsTests
         summary.Should().Contain("Index ranges (2) via _idx");
         summary.Should().Contain("[1, 5] (0x0000000000000001 - 0x0000000000000005)");
         summary.Should().Contain("Covering bounds via _mbb");
+        summary.Should().Contain("Covering cells: 12 (fallback)");
         summary.Should().Contain("Exact predicate: Distance <= 10");
     }
 
@@ -51,7 +56,9 @@ public sealed class SpatialDiagnosticsTests
             3,
             null,
             Array.Empty<SpatialIndexRange>(),
-            null);
+            null,
+            coveringCellCount: 0,
+            usedMaxCoveringCellFallback: false);
 
         var explain = SpatialDiagnostics.Explain(plan);
 
@@ -66,6 +73,7 @@ public sealed class SpatialDiagnosticsTests
         summary.Should().Contain("Bounding box field: n/a");
         summary.Should().Contain("Index ranges (0)");
         summary.Should().Contain("Covering bounds: none");
+        summary.Should().Contain("Covering cells: 0");
         summary.Should().Contain("Exact predicate: none");
     }
 }

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DDifferentialTests.cs
@@ -1,0 +1,358 @@
+extern alias LiteDbBase;
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using LiteDB.Spatial;
+using Xunit;
+using Xunit.Abstractions;
+using BaseLiteDB = LiteDbBase::LiteDB;
+
+namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian3D;
+
+public sealed class Cartesian3DDifferentialTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly string FixtureDirectory = Path.Combine(AppContext.BaseDirectory, "Differential", "Cartesian3D", "Fixtures");
+    private static readonly string FailureDirectory = Path.Combine(GetRepositoryRoot(), "tests", "failures", "3d");
+    private readonly ITestOutputHelperAdapter _output;
+
+    public Cartesian3DDifferentialTests(ITestOutputHelper output)
+    {
+        _output = new TestOutputHelperAdapter(output);
+    }
+
+    public static IEnumerable<object[]> LatticeFixtures()
+    {
+        if (!Directory.Exists(FixtureDirectory))
+        {
+            yield break;
+        }
+
+        foreach (var file in Directory.EnumerateFiles(FixtureDirectory, "*.json"))
+        {
+            var json = File.ReadAllText(file);
+            var fixture = JsonSerializer.Deserialize<Cartesian3DFixture>(json, JsonOptions);
+            if (fixture is null)
+            {
+                continue;
+            }
+
+            yield return new object[] { Path.GetFileNameWithoutExtension(file) ?? fixture.Name, fixture };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LatticeFixtures))]
+    public void NearQueriesMatchMathNet(string fixtureName, Cartesian3DFixture fixture)
+    {
+        using var context = CreateContext(fixture);
+
+        foreach (var query in fixture.Queries)
+        {
+            var center = ToGeoPoint(query.Center);
+            var plan = SpatialCartesian3D.Near(context.Descriptor, center, query.Radius);
+            _output.WriteLine($"[{fixtureName}/{query.Name}] Covering cells={plan.CoveringCellCount}, fallback={plan.UsedMaxCoveringCellFallback}");
+
+            plan.UsedMaxCoveringCellFallback.Should().Be(query.ExpectFallback);
+            var maxCoveringCells = context.Descriptor.Options.MaxCoveringCells;
+            plan.IndexRanges.Count.Should().BeLessOrEqualTo(maxCoveringCells);
+            if (plan.UsedMaxCoveringCellFallback)
+            {
+                plan.CoveringCellCount.Should().BeGreaterThan(maxCoveringCells);
+            }
+            else
+            {
+                plan.CoveringCellCount.Should().BeLessOrEqualTo(maxCoveringCells);
+            }
+
+            var results = Spatial.Near(context.Collection, x => x.Position, center, query.Radius).ToList();
+            var actualIds = results.Select(p => p.Id).OrderBy(id => id, StringComparer.Ordinal).ToList();
+
+            var tolerance = query.Tolerance ?? context.Descriptor.Options.DistanceTolerance;
+            var expectedIds = fixture.Points
+                .Where(p => MathNetOracle3D.Distance(p.Coordinates, query.Center) <= query.Radius + tolerance)
+                .Select(p => p.Id)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+
+            try
+            {
+                actualIds.Should().Equal(expectedIds);
+
+                foreach (var id in actualIds)
+                {
+                    var distance = MathNetOracle3D.Distance(context.Points[id].Coordinates, query.Center);
+                    distance.Should().BeLessOrEqualTo(query.Radius + tolerance + 1e-9, $"Point {id} should respect the tolerance window");
+                }
+            }
+            catch (Exception ex)
+            {
+                RecordFailure(fixtureName, $"near-{query.Name}", new NearFailure(
+                    fixture.Name,
+                    query,
+                    context.Descriptor.Options,
+                    plan.CoveringCellCount,
+                    plan.UsedMaxCoveringCellFallback,
+                    expectedIds,
+                    actualIds,
+                    fixture.Points), ex);
+                throw;
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LatticeFixtures))]
+    public void BoundingBoxesMatchManualPredicates(string fixtureName, Cartesian3DFixture fixture)
+    {
+        using var context = CreateContext(fixture);
+
+        var raw = context.Database.GetCollection("points");
+        var docs = raw.FindAll().ToList();
+
+        foreach (var doc in docs)
+        {
+            var mbb = doc[context.Descriptor.Options.BoundingBoxFieldName].AsArray;
+            mbb.Count.Should().Be(6);
+
+            var minX = mbb[0].AsDouble;
+            var maxX = mbb[3].AsDouble;
+            var minY = mbb[1].AsDouble;
+            var maxY = mbb[4].AsDouble;
+            var minZ = mbb[2].AsDouble;
+            var maxZ = mbb[5].AsDouble;
+
+            minX.Should().BeLessOrEqualTo(maxX + 1e-9);
+            minY.Should().BeLessOrEqualTo(maxY + 1e-9);
+            minZ.Should().BeLessOrEqualTo(maxZ + 1e-9);
+        }
+
+        foreach (var box in fixture.Boxes)
+        {
+            var bounds = BoundingBox.From3D(box.Min[0], box.Min[1], box.Min[2], box.Max[0], box.Max[1], box.Max[2]);
+            var plan = SpatialCartesian3D.WithinBoundingBox(context.Descriptor, bounds);
+            _output.WriteLine($"[{fixtureName}/{box.Name}] Covering cells={plan.CoveringCellCount}, fallback={plan.UsedMaxCoveringCellFallback}");
+
+            plan.UsedMaxCoveringCellFallback.Should().Be(box.ExpectFallback);
+            var maxCoveringCells = context.Descriptor.Options.MaxCoveringCells;
+            plan.IndexRanges.Count.Should().BeLessOrEqualTo(maxCoveringCells);
+            if (plan.UsedMaxCoveringCellFallback)
+            {
+                plan.CoveringCellCount.Should().BeGreaterThan(maxCoveringCells);
+            }
+            else
+            {
+                plan.CoveringCellCount.Should().BeLessOrEqualTo(maxCoveringCells);
+            }
+
+            var results = Spatial.WithinBoundingBox(context.Collection, x => x.Position, bounds)
+                .Select(p => p.Id)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+
+            var expected = fixture.Points
+                .Where(p => IsInside(bounds, p.Coordinates))
+                .Select(p => p.Id)
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToList();
+
+            try
+            {
+                results.Should().Equal(expected);
+            }
+            catch (Exception ex)
+            {
+                RecordFailure(fixtureName, $"aabb-{box.Name}", new BoundingFailure(
+                    fixture.Name,
+                    box,
+                    context.Descriptor.Options,
+                    bounds,
+                    plan.CoveringCellCount,
+                    plan.UsedMaxCoveringCellFallback,
+                    expected,
+                    results,
+                    fixture.Points), ex);
+                throw;
+            }
+        }
+    }
+
+    private FixtureContext CreateContext(Cartesian3DFixture fixture)
+    {
+        var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
+        var collection = database.GetCollection<FixturePoint>("points");
+        var domain = BoundingBox.From3D(
+            fixture.Domain.Min[0],
+            fixture.Domain.Min[1],
+            fixture.Domain.Min[2],
+            fixture.Domain.Max[0],
+            fixture.Domain.Max[1],
+            fixture.Domain.Max[2]);
+        var options = new SpatialIndexOptions(
+            fixture.Options.PrecisionBits,
+            fixture.Options.MaxCoveringCells,
+            fixture.Options.DistanceTolerance);
+
+        var descriptor = Spatial.UseCartesian3D(collection, x => x.Position, domain, options);
+        var entities = fixture.Points
+            .Select(p => new FixturePoint(p.Id, new GeoPoint3D(p.Coordinates[0], p.Coordinates[1], p.Coordinates[2])))
+            .ToList();
+
+        collection.Insert(entities);
+        Spatial.EnsurePointIndex(collection);
+
+        return new FixtureContext(database, collection, descriptor, fixture);
+    }
+
+    private static GeoPoint3D ToGeoPoint(double[] coordinates)
+    {
+        return new GeoPoint3D(coordinates[0], coordinates[1], coordinates[2]);
+    }
+
+    private static bool IsInside(BoundingBox bounds, double[] coordinates)
+    {
+        return coordinates[0] >= bounds.MinX - 1e-9 && coordinates[0] <= bounds.MaxX + 1e-9
+            && coordinates[1] >= bounds.MinY - 1e-9 && coordinates[1] <= bounds.MaxY + 1e-9
+            && coordinates[2] >= bounds.MinZ - 1e-9 && coordinates[2] <= bounds.MaxZ + 1e-9;
+    }
+
+    private static void RecordFailure(string fixtureName, string scenario, object payload, Exception exception)
+    {
+        Directory.CreateDirectory(FailureDirectory);
+        var fileName = $"{Sanitize(fixtureName)}-{Sanitize(scenario)}.json";
+        var path = Path.Combine(FailureDirectory, fileName);
+        var json = JsonSerializer.Serialize(new FailureEnvelope(payload, exception.ToString()), new JsonSerializerOptions
+        {
+            WriteIndented = true
+        });
+        File.WriteAllText(path, json);
+    }
+
+    private static string Sanitize(string value)
+    {
+        foreach (var invalid in Path.GetInvalidFileNameChars())
+        {
+            value = value.Replace(invalid, '_');
+        }
+
+        return value;
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    }
+
+    private sealed class FixtureContext : IDisposable
+    {
+        public FixtureContext(BaseLiteDB.LiteDatabase database, BaseLiteDB.ILiteCollection<FixturePoint> collection, SpatialCollectionDescriptor descriptor, Cartesian3DFixture fixture)
+        {
+            Database = database;
+            Collection = collection;
+            Descriptor = descriptor;
+            Fixture = fixture;
+            Points = fixture.Points.ToDictionary(p => p.Id, StringComparer.Ordinal);
+        }
+
+        public BaseLiteDB.LiteDatabase Database { get; }
+        public BaseLiteDB.ILiteCollection<FixturePoint> Collection { get; }
+        public SpatialCollectionDescriptor Descriptor { get; }
+        public Cartesian3DFixture Fixture { get; }
+        public IReadOnlyDictionary<string, LatticePointSpec> Points { get; }
+
+        public void Dispose()
+        {
+            Database.Dispose();
+        }
+    }
+
+    private sealed record FixturePoint(string Id, GeoPoint3D Position);
+
+    public sealed record Cartesian3DFixture(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("domain")] DomainSpec Domain,
+        [property: JsonPropertyName("options")] OptionsSpec Options,
+        [property: JsonPropertyName("points")] IReadOnlyList<LatticePointSpec> Points,
+        [property: JsonPropertyName("queries")] IReadOnlyList<LatticeQuerySpec> Queries,
+        [property: JsonPropertyName("boxes")] IReadOnlyList<LatticeBoundingBoxSpec> Boxes);
+
+    public sealed record DomainSpec(
+        [property: JsonPropertyName("min")] double[] Min,
+        [property: JsonPropertyName("max")] double[] Max);
+
+    public sealed record OptionsSpec(
+        [property: JsonPropertyName("precisionBits")] int PrecisionBits,
+        [property: JsonPropertyName("maxCoveringCells")] int MaxCoveringCells,
+        [property: JsonPropertyName("distanceTolerance")] double DistanceTolerance);
+
+    public sealed record LatticePointSpec(
+        [property: JsonPropertyName("id")] string Id,
+        [property: JsonPropertyName("coordinates")] double[] Coordinates);
+
+    public sealed record LatticeQuerySpec(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("center")] double[] Center,
+        [property: JsonPropertyName("radius")] double Radius,
+        [property: JsonPropertyName("tolerance")] double? Tolerance,
+        [property: JsonPropertyName("expectFallback")] bool ExpectFallback);
+
+    public sealed record LatticeBoundingBoxSpec(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("min")] double[] Min,
+        [property: JsonPropertyName("max")] double[] Max,
+        [property: JsonPropertyName("expectFallback")] bool ExpectFallback);
+
+    private sealed record NearFailure(
+        string Fixture,
+        LatticeQuerySpec Query,
+        SpatialIndexOptions Options,
+        int CoveringCells,
+        bool UsedFallback,
+        IReadOnlyList<string> Expected,
+        IReadOnlyList<string> Actual,
+        IReadOnlyList<LatticePointSpec> Points);
+
+    private sealed record BoundingFailure(
+        string Fixture,
+        LatticeBoundingBoxSpec Box,
+        SpatialIndexOptions Options,
+        BoundingBox Bounds,
+        int CoveringCells,
+        bool UsedFallback,
+        IReadOnlyList<string> Expected,
+        IReadOnlyList<string> Actual,
+        IReadOnlyList<LatticePointSpec> Points);
+
+    private sealed record FailureEnvelope(object Data, string Exception);
+
+    private interface ITestOutputHelperAdapter
+    {
+        void WriteLine(string message);
+    }
+
+    private sealed class TestOutputHelperAdapter : ITestOutputHelperAdapter
+    {
+        private readonly ITestOutputHelper _inner;
+
+        public TestOutputHelperAdapter(ITestOutputHelper inner)
+        {
+            _inner = inner;
+        }
+
+        public void WriteLine(string message)
+        {
+            _inner.WriteLine(message);
+        }
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Fixtures/lattice-aspects.json
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Fixtures/lattice-aspects.json
@@ -1,0 +1,1101 @@
+{
+  "name": "lattice-aspects",
+  "domain": {
+    "min": [
+      -12,
+      -12,
+      -12
+    ],
+    "max": [
+      12,
+      12,
+      12
+    ]
+  },
+  "options": {
+    "precisionBits": 12,
+    "maxCoveringCells": 4,
+    "distanceTolerance": 0.05
+  },
+  "points": [
+    {
+      "id": "P000",
+      "coordinates": [
+        -12,
+        -12,
+        -12
+      ]
+    },
+    {
+      "id": "P001",
+      "coordinates": [
+        -12,
+        -12,
+        -6
+      ]
+    },
+    {
+      "id": "P002",
+      "coordinates": [
+        -12,
+        -12,
+        0
+      ]
+    },
+    {
+      "id": "P003",
+      "coordinates": [
+        -12,
+        -12,
+        6
+      ]
+    },
+    {
+      "id": "P004",
+      "coordinates": [
+        -12,
+        -12,
+        12
+      ]
+    },
+    {
+      "id": "P005",
+      "coordinates": [
+        -12,
+        -6,
+        -12
+      ]
+    },
+    {
+      "id": "P006",
+      "coordinates": [
+        -12,
+        -6,
+        -6
+      ]
+    },
+    {
+      "id": "P007",
+      "coordinates": [
+        -12,
+        -6,
+        0
+      ]
+    },
+    {
+      "id": "P008",
+      "coordinates": [
+        -12,
+        -6,
+        6
+      ]
+    },
+    {
+      "id": "P009",
+      "coordinates": [
+        -12,
+        -6,
+        12
+      ]
+    },
+    {
+      "id": "P010",
+      "coordinates": [
+        -12,
+        0,
+        -12
+      ]
+    },
+    {
+      "id": "P011",
+      "coordinates": [
+        -12,
+        0,
+        -6
+      ]
+    },
+    {
+      "id": "P012",
+      "coordinates": [
+        -12,
+        0,
+        0
+      ]
+    },
+    {
+      "id": "P013",
+      "coordinates": [
+        -12,
+        0,
+        6
+      ]
+    },
+    {
+      "id": "P014",
+      "coordinates": [
+        -12,
+        0,
+        12
+      ]
+    },
+    {
+      "id": "P015",
+      "coordinates": [
+        -12,
+        6,
+        -12
+      ]
+    },
+    {
+      "id": "P016",
+      "coordinates": [
+        -12,
+        6,
+        -6
+      ]
+    },
+    {
+      "id": "P017",
+      "coordinates": [
+        -12,
+        6,
+        0
+      ]
+    },
+    {
+      "id": "P018",
+      "coordinates": [
+        -12,
+        6,
+        6
+      ]
+    },
+    {
+      "id": "P019",
+      "coordinates": [
+        -12,
+        6,
+        12
+      ]
+    },
+    {
+      "id": "P020",
+      "coordinates": [
+        -12,
+        12,
+        -12
+      ]
+    },
+    {
+      "id": "P021",
+      "coordinates": [
+        -12,
+        12,
+        -6
+      ]
+    },
+    {
+      "id": "P022",
+      "coordinates": [
+        -12,
+        12,
+        0
+      ]
+    },
+    {
+      "id": "P023",
+      "coordinates": [
+        -12,
+        12,
+        6
+      ]
+    },
+    {
+      "id": "P024",
+      "coordinates": [
+        -12,
+        12,
+        12
+      ]
+    },
+    {
+      "id": "P025",
+      "coordinates": [
+        -6,
+        -12,
+        -12
+      ]
+    },
+    {
+      "id": "P026",
+      "coordinates": [
+        -6,
+        -12,
+        -6
+      ]
+    },
+    {
+      "id": "P027",
+      "coordinates": [
+        -6,
+        -12,
+        0
+      ]
+    },
+    {
+      "id": "P028",
+      "coordinates": [
+        -6,
+        -12,
+        6
+      ]
+    },
+    {
+      "id": "P029",
+      "coordinates": [
+        -6,
+        -12,
+        12
+      ]
+    },
+    {
+      "id": "P030",
+      "coordinates": [
+        -6,
+        -6,
+        -12
+      ]
+    },
+    {
+      "id": "P031",
+      "coordinates": [
+        -6,
+        -6,
+        -6
+      ]
+    },
+    {
+      "id": "P032",
+      "coordinates": [
+        -6,
+        -6,
+        0
+      ]
+    },
+    {
+      "id": "P033",
+      "coordinates": [
+        -6,
+        -6,
+        6
+      ]
+    },
+    {
+      "id": "P034",
+      "coordinates": [
+        -6,
+        -6,
+        12
+      ]
+    },
+    {
+      "id": "P035",
+      "coordinates": [
+        -6,
+        0,
+        -12
+      ]
+    },
+    {
+      "id": "P036",
+      "coordinates": [
+        -6,
+        0,
+        -6
+      ]
+    },
+    {
+      "id": "P037",
+      "coordinates": [
+        -6,
+        0,
+        0
+      ]
+    },
+    {
+      "id": "P038",
+      "coordinates": [
+        -6,
+        0,
+        6
+      ]
+    },
+    {
+      "id": "P039",
+      "coordinates": [
+        -6,
+        0,
+        12
+      ]
+    },
+    {
+      "id": "P040",
+      "coordinates": [
+        -6,
+        6,
+        -12
+      ]
+    },
+    {
+      "id": "P041",
+      "coordinates": [
+        -6,
+        6,
+        -6
+      ]
+    },
+    {
+      "id": "P042",
+      "coordinates": [
+        -6,
+        6,
+        0
+      ]
+    },
+    {
+      "id": "P043",
+      "coordinates": [
+        -6,
+        6,
+        6
+      ]
+    },
+    {
+      "id": "P044",
+      "coordinates": [
+        -6,
+        6,
+        12
+      ]
+    },
+    {
+      "id": "P045",
+      "coordinates": [
+        -6,
+        12,
+        -12
+      ]
+    },
+    {
+      "id": "P046",
+      "coordinates": [
+        -6,
+        12,
+        -6
+      ]
+    },
+    {
+      "id": "P047",
+      "coordinates": [
+        -6,
+        12,
+        0
+      ]
+    },
+    {
+      "id": "P048",
+      "coordinates": [
+        -6,
+        12,
+        6
+      ]
+    },
+    {
+      "id": "P049",
+      "coordinates": [
+        -6,
+        12,
+        12
+      ]
+    },
+    {
+      "id": "P050",
+      "coordinates": [
+        0,
+        -12,
+        -12
+      ]
+    },
+    {
+      "id": "P051",
+      "coordinates": [
+        0,
+        -12,
+        -6
+      ]
+    },
+    {
+      "id": "P052",
+      "coordinates": [
+        0,
+        -12,
+        0
+      ]
+    },
+    {
+      "id": "P053",
+      "coordinates": [
+        0,
+        -12,
+        6
+      ]
+    },
+    {
+      "id": "P054",
+      "coordinates": [
+        0,
+        -12,
+        12
+      ]
+    },
+    {
+      "id": "P055",
+      "coordinates": [
+        0,
+        -6,
+        -12
+      ]
+    },
+    {
+      "id": "P056",
+      "coordinates": [
+        0,
+        -6,
+        -6
+      ]
+    },
+    {
+      "id": "P057",
+      "coordinates": [
+        0,
+        -6,
+        0
+      ]
+    },
+    {
+      "id": "P058",
+      "coordinates": [
+        0,
+        -6,
+        6
+      ]
+    },
+    {
+      "id": "P059",
+      "coordinates": [
+        0,
+        -6,
+        12
+      ]
+    },
+    {
+      "id": "P060",
+      "coordinates": [
+        0,
+        0,
+        -12
+      ]
+    },
+    {
+      "id": "P061",
+      "coordinates": [
+        0,
+        0,
+        -6
+      ]
+    },
+    {
+      "id": "P062",
+      "coordinates": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "id": "P063",
+      "coordinates": [
+        0,
+        0,
+        6
+      ]
+    },
+    {
+      "id": "P064",
+      "coordinates": [
+        0,
+        0,
+        12
+      ]
+    },
+    {
+      "id": "P065",
+      "coordinates": [
+        0,
+        6,
+        -12
+      ]
+    },
+    {
+      "id": "P066",
+      "coordinates": [
+        0,
+        6,
+        -6
+      ]
+    },
+    {
+      "id": "P067",
+      "coordinates": [
+        0,
+        6,
+        0
+      ]
+    },
+    {
+      "id": "P068",
+      "coordinates": [
+        0,
+        6,
+        6
+      ]
+    },
+    {
+      "id": "P069",
+      "coordinates": [
+        0,
+        6,
+        12
+      ]
+    },
+    {
+      "id": "P070",
+      "coordinates": [
+        0,
+        12,
+        -12
+      ]
+    },
+    {
+      "id": "P071",
+      "coordinates": [
+        0,
+        12,
+        -6
+      ]
+    },
+    {
+      "id": "P072",
+      "coordinates": [
+        0,
+        12,
+        0
+      ]
+    },
+    {
+      "id": "P073",
+      "coordinates": [
+        0,
+        12,
+        6
+      ]
+    },
+    {
+      "id": "P074",
+      "coordinates": [
+        0,
+        12,
+        12
+      ]
+    },
+    {
+      "id": "P075",
+      "coordinates": [
+        6,
+        -12,
+        -12
+      ]
+    },
+    {
+      "id": "P076",
+      "coordinates": [
+        6,
+        -12,
+        -6
+      ]
+    },
+    {
+      "id": "P077",
+      "coordinates": [
+        6,
+        -12,
+        0
+      ]
+    },
+    {
+      "id": "P078",
+      "coordinates": [
+        6,
+        -12,
+        6
+      ]
+    },
+    {
+      "id": "P079",
+      "coordinates": [
+        6,
+        -12,
+        12
+      ]
+    },
+    {
+      "id": "P080",
+      "coordinates": [
+        6,
+        -6,
+        -12
+      ]
+    },
+    {
+      "id": "P081",
+      "coordinates": [
+        6,
+        -6,
+        -6
+      ]
+    },
+    {
+      "id": "P082",
+      "coordinates": [
+        6,
+        -6,
+        0
+      ]
+    },
+    {
+      "id": "P083",
+      "coordinates": [
+        6,
+        -6,
+        6
+      ]
+    },
+    {
+      "id": "P084",
+      "coordinates": [
+        6,
+        -6,
+        12
+      ]
+    },
+    {
+      "id": "P085",
+      "coordinates": [
+        6,
+        0,
+        -12
+      ]
+    },
+    {
+      "id": "P086",
+      "coordinates": [
+        6,
+        0,
+        -6
+      ]
+    },
+    {
+      "id": "P087",
+      "coordinates": [
+        6,
+        0,
+        0
+      ]
+    },
+    {
+      "id": "P088",
+      "coordinates": [
+        6,
+        0,
+        6
+      ]
+    },
+    {
+      "id": "P089",
+      "coordinates": [
+        6,
+        0,
+        12
+      ]
+    },
+    {
+      "id": "P090",
+      "coordinates": [
+        6,
+        6,
+        -12
+      ]
+    },
+    {
+      "id": "P091",
+      "coordinates": [
+        6,
+        6,
+        -6
+      ]
+    },
+    {
+      "id": "P092",
+      "coordinates": [
+        6,
+        6,
+        0
+      ]
+    },
+    {
+      "id": "P093",
+      "coordinates": [
+        6,
+        6,
+        6
+      ]
+    },
+    {
+      "id": "P094",
+      "coordinates": [
+        6,
+        6,
+        12
+      ]
+    },
+    {
+      "id": "P095",
+      "coordinates": [
+        6,
+        12,
+        -12
+      ]
+    },
+    {
+      "id": "P096",
+      "coordinates": [
+        6,
+        12,
+        -6
+      ]
+    },
+    {
+      "id": "P097",
+      "coordinates": [
+        6,
+        12,
+        0
+      ]
+    },
+    {
+      "id": "P098",
+      "coordinates": [
+        6,
+        12,
+        6
+      ]
+    },
+    {
+      "id": "P099",
+      "coordinates": [
+        6,
+        12,
+        12
+      ]
+    },
+    {
+      "id": "P100",
+      "coordinates": [
+        12,
+        -12,
+        -12
+      ]
+    },
+    {
+      "id": "P101",
+      "coordinates": [
+        12,
+        -12,
+        -6
+      ]
+    },
+    {
+      "id": "P102",
+      "coordinates": [
+        12,
+        -12,
+        0
+      ]
+    },
+    {
+      "id": "P103",
+      "coordinates": [
+        12,
+        -12,
+        6
+      ]
+    },
+    {
+      "id": "P104",
+      "coordinates": [
+        12,
+        -12,
+        12
+      ]
+    },
+    {
+      "id": "P105",
+      "coordinates": [
+        12,
+        -6,
+        -12
+      ]
+    },
+    {
+      "id": "P106",
+      "coordinates": [
+        12,
+        -6,
+        -6
+      ]
+    },
+    {
+      "id": "P107",
+      "coordinates": [
+        12,
+        -6,
+        0
+      ]
+    },
+    {
+      "id": "P108",
+      "coordinates": [
+        12,
+        -6,
+        6
+      ]
+    },
+    {
+      "id": "P109",
+      "coordinates": [
+        12,
+        -6,
+        12
+      ]
+    },
+    {
+      "id": "P110",
+      "coordinates": [
+        12,
+        0,
+        -12
+      ]
+    },
+    {
+      "id": "P111",
+      "coordinates": [
+        12,
+        0,
+        -6
+      ]
+    },
+    {
+      "id": "P112",
+      "coordinates": [
+        12,
+        0,
+        0
+      ]
+    },
+    {
+      "id": "P113",
+      "coordinates": [
+        12,
+        0,
+        6
+      ]
+    },
+    {
+      "id": "P114",
+      "coordinates": [
+        12,
+        0,
+        12
+      ]
+    },
+    {
+      "id": "P115",
+      "coordinates": [
+        12,
+        6,
+        -12
+      ]
+    },
+    {
+      "id": "P116",
+      "coordinates": [
+        12,
+        6,
+        -6
+      ]
+    },
+    {
+      "id": "P117",
+      "coordinates": [
+        12,
+        6,
+        0
+      ]
+    },
+    {
+      "id": "P118",
+      "coordinates": [
+        12,
+        6,
+        6
+      ]
+    },
+    {
+      "id": "P119",
+      "coordinates": [
+        12,
+        6,
+        12
+      ]
+    },
+    {
+      "id": "P120",
+      "coordinates": [
+        12,
+        12,
+        -12
+      ]
+    },
+    {
+      "id": "P121",
+      "coordinates": [
+        12,
+        12,
+        -6
+      ]
+    },
+    {
+      "id": "P122",
+      "coordinates": [
+        12,
+        12,
+        0
+      ]
+    },
+    {
+      "id": "P123",
+      "coordinates": [
+        12,
+        12,
+        6
+      ]
+    },
+    {
+      "id": "P124",
+      "coordinates": [
+        12,
+        12,
+        12
+      ]
+    }
+  ],
+  "queries": [
+    {
+      "name": "TightOrigin",
+      "center": [
+        0,
+        0,
+        0
+      ],
+      "radius": 1.5,
+      "tolerance": 0.05,
+      "expectFallback": true
+    },
+    {
+      "name": "OriginShell",
+      "center": [
+        0,
+        0,
+        0
+      ],
+      "radius": 4.5,
+      "tolerance": 0.05,
+      "expectFallback": true
+    },
+    {
+      "name": "EdgeSweep",
+      "center": [
+        9,
+        9,
+        9
+      ],
+      "radius": 6.5,
+      "tolerance": 0.05,
+      "expectFallback": true
+    }
+  ],
+  "boxes": [
+    {
+      "name": "CoreCube",
+      "min": [
+        -6,
+        -6,
+        -6
+      ],
+      "max": [
+        6,
+        6,
+        6
+      ],
+      "expectFallback": true
+    },
+    {
+      "name": "NeedleX",
+      "min": [
+        -12,
+        -1,
+        -1
+      ],
+      "max": [
+        12,
+        1,
+        1
+      ],
+      "expectFallback": true
+    },
+    {
+      "name": "OffsetSlab",
+      "min": [
+        -12,
+        -12,
+        6
+      ],
+      "max": [
+        -4,
+        -4,
+        12
+      ],
+      "expectFallback": true
+    }
+  ]
+}

--- a/LiteDB.Spatial.Core.Tests/Differential/MathNetOracle3D.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/MathNetOracle3D.cs
@@ -1,0 +1,28 @@
+using System;
+using LiteDB.Spatial;
+using MathNet.Numerics;
+
+namespace LiteDB.Spatial.Core.Tests.Differential;
+
+internal static class MathNetOracle3D
+{
+    public static double Distance(double[] first, double[] second)
+    {
+        if (first.Length != 3 || second.Length != 3)
+        {
+            throw new ArgumentException("MathNetOracle3D requires three-dimensional coordinate arrays.");
+        }
+
+        return MathNet.Numerics.Distance.Euclidean(first, second);
+    }
+
+    public static double Distance(GeoPoint3D first, double[] second)
+    {
+        return Distance(new[] { first.X, first.Y, first.Z }, second);
+    }
+
+    public static double Distance(double[] first, GeoPoint3D second)
+    {
+        return Distance(first, new[] { second.X, second.Y, second.Z });
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Indexing/MortonIndexEncoderTests.cs
@@ -45,10 +45,12 @@ public sealed class MortonIndexEncoderTests
         var encoder = new LiteDB.Spatial.MortonIndexEncoder(2, precisionBits: 3);
         var bounds = LiteDB.Spatial.BoundingBox.From2D(0.25, 0.25, 0.5, 0.5);
 
-        var ranges = encoder.Cover(bounds, maxCells: 16);
-        ranges.Should().NotBeEmpty();
+        var covering = encoder.Cover(bounds, maxCells: 16);
+        covering.Ranges.Should().NotBeEmpty();
+        covering.CoveringCellCount.Should().BeGreaterThan(0);
+        covering.UsedMaxCoveringCellFallback.Should().BeFalse();
 
-        var codes = ranges.SelectMany(range => Enumerable.Range(0, (int)(range.End - range.Start + 1)).Select(offset => range.Start + (ulong)offset));
+        var codes = covering.Ranges.SelectMany(range => Enumerable.Range(0, (int)(range.End - range.Start + 1)).Select(offset => range.Start + (ulong)offset));
         var lowerBound = encoder.Encode(stackalloc double[] { 0.25, 0.25 });
         var upperBound = encoder.Encode(stackalloc double[] { 0.5, 0.5 });
 

--- a/LiteDB.Spatial.Core.Tests/Linq/SpatialResolverTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Linq/SpatialResolverTests.cs
@@ -194,7 +194,7 @@ public sealed class SpatialResolverTests
             Last2DCenter = center;
             LastRadius = radius;
             LastBounds = BoundingBox.From2D(center.Longitude - radius, center.Latitude - radius, center.Longitude + radius, center.Latitude + radius);
-            return new SpatialQueryPlan(Name, Dimensions, LastBounds, Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}");
+            return new SpatialQueryPlan(Name, Dimensions, LastBounds, Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}", 0, false);
         }
 
         public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
@@ -207,13 +207,13 @@ public sealed class SpatialResolverTests
             Last3DCenter = center;
             LastRadius = radius;
             LastBounds = BoundingBox.From3D(center.X - radius, center.Y - radius, center.Z - radius, center.X + radius, center.Y + radius, center.Z + radius);
-            return new SpatialQueryPlan(Name, Dimensions, LastBounds, Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}");
+            return new SpatialQueryPlan(Name, Dimensions, LastBounds, Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}", 0, false);
         }
 
         public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
         {
             LastBounds = bounds;
-            return new SpatialQueryPlan(Name, Dimensions, bounds, Array.Empty<SpatialIndexRange>(), "Within bounds");
+            return new SpatialQueryPlan(Name, Dimensions, bounds, Array.Empty<SpatialIndexRange>(), "Within bounds", 0, false);
         }
 
         private sealed class StubMapper : ISpatialMapper

--- a/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+++ b/LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,6 +27,10 @@
     <ProjectReference Include="..\LiteDB\LiteDB.csproj">
       <Aliases>LiteDbBase</Aliases>
     </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Differential\Cartesian3D\Fixtures\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/LiteDB.Spatial.Core.Tests/Metadata/SpatialCollectionDescriptorTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Metadata/SpatialCollectionDescriptorTests.cs
@@ -85,17 +85,17 @@ public sealed class SpatialCollectionDescriptorTests
 
         public ISpatialQueryPlan PlanNear(GeoPoint center, double radius)
         {
-            return new SpatialQueryPlan(Name, Dimensions, BoundingBox.From2D(center.Longitude, center.Latitude, center.Longitude, center.Latitude), Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}");
+            return new SpatialQueryPlan(Name, Dimensions, BoundingBox.From2D(center.Longitude, center.Latitude, center.Longitude, center.Latitude), Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}", 0, false);
         }
 
         public ISpatialQueryPlan PlanNear(GeoPoint3D center, double radius)
         {
-            return new SpatialQueryPlan(Name, Dimensions, BoundingBox.From3D(center.X, center.Y, center.Z, center.X, center.Y, center.Z), Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}");
+            return new SpatialQueryPlan(Name, Dimensions, BoundingBox.From3D(center.X, center.Y, center.Z, center.X, center.Y, center.Z), Array.Empty<SpatialIndexRange>(), $"Radius <= {radius}", 0, false);
         }
 
         public ISpatialQueryPlan PlanWithin(BoundingBox bounds)
         {
-            return new SpatialQueryPlan(Name, Dimensions, bounds, Array.Empty<SpatialIndexRange>(), "Within bounds");
+            return new SpatialQueryPlan(Name, Dimensions, bounds, Array.Empty<SpatialIndexRange>(), "Within bounds", 0, false);
         }
 
         private sealed class NullMapper : ISpatialMapper

--- a/LiteDB.Spatial.Core/Diagnostics/SpatialDiagnostics.cs
+++ b/LiteDB.Spatial.Core/Diagnostics/SpatialDiagnostics.cs
@@ -28,6 +28,8 @@ public static class SpatialDiagnostics
             plan.CoveringBounds,
             plan.IndexRanges,
             plan.ExactPredicateDescription,
+            plan.CoveringCellCount,
+            plan.UsedMaxCoveringCellFallback,
             descriptor?.Options.IndexFieldName,
             descriptor?.Options.BoundingBoxFieldName);
     }

--- a/LiteDB.Spatial.Core/Diagnostics/SpatialExplainResult.cs
+++ b/LiteDB.Spatial.Core/Diagnostics/SpatialExplainResult.cs
@@ -22,6 +22,8 @@ public sealed class SpatialExplainResult
     /// <param name="coveringBounds">The optional coarse bounding box evaluated prior to exact predicates.</param>
     /// <param name="ranges">The index ranges that will be scanned.</param>
     /// <param name="exactPredicate">The human readable exact predicate description.</param>
+    /// <param name="coveringCellCount">The number of ranges requested before enforcing <c>MaxCoveringCells</c>.</param>
+    /// <param name="usedMaxCoveringCellFallback">Indicates whether the covering exceeded <c>MaxCoveringCells</c>.</param>
     /// <param name="indexFieldName">Optional name of the index field used during scanning.</param>
     /// <param name="boundingBoxFieldName">Optional name of the bounding box field storing coarse bounds.</param>
     public SpatialExplainResult(
@@ -30,6 +32,8 @@ public sealed class SpatialExplainResult
         BoundingBox? coveringBounds,
         IReadOnlyList<SpatialIndexRange> ranges,
         string? exactPredicate,
+        int coveringCellCount,
+        bool usedMaxCoveringCellFallback,
         string? indexFieldName = null,
         string? boundingBoxFieldName = null)
     {
@@ -47,7 +51,14 @@ public sealed class SpatialExplainResult
         Dimensions = dimensions;
         CoveringBounds = coveringBounds;
         _ranges = ranges ?? throw new ArgumentNullException(nameof(ranges));
+        if (coveringCellCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(coveringCellCount), "Covering cell count cannot be negative.");
+        }
+
         ExactPredicate = exactPredicate;
+        CoveringCellCount = coveringCellCount;
+        UsedMaxCoveringCellFallback = usedMaxCoveringCellFallback;
         IndexFieldName = string.IsNullOrWhiteSpace(indexFieldName) ? null : indexFieldName;
         BoundingBoxFieldName = string.IsNullOrWhiteSpace(boundingBoxFieldName) ? null : boundingBoxFieldName;
     }
@@ -71,6 +82,16 @@ public sealed class SpatialExplainResult
     /// Gets the index ranges that will be scanned.
     /// </summary>
     public IReadOnlyList<SpatialIndexRange> IndexRanges => _ranges;
+
+    /// <summary>
+    /// Gets the number of ranges requested before enforcing the covering cell cap.
+    /// </summary>
+    public int CoveringCellCount { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the encoder exceeded the cell cap and merged ranges.
+    /// </summary>
+    public bool UsedMaxCoveringCellFallback { get; }
 
     /// <summary>
     /// Gets a human readable description of the exact predicate applied after index pruning.
@@ -142,6 +163,11 @@ public sealed class SpatialExplainResult
         builder.Append(": ");
         builder.Append(CoveringBounds.HasValue ? CoveringBounds.Value.ToString() : "none");
         builder.AppendLine();
+
+        builder.Append("Covering cells: ")
+            .Append(CoveringCellCount.ToString(CultureInfo.InvariantCulture))
+            .Append(UsedMaxCoveringCellFallback ? " (fallback)" : string.Empty)
+            .AppendLine();
 
         builder.Append("Exact predicate: ");
         builder.Append(string.IsNullOrWhiteSpace(ExactPredicate) ? "none" : ExactPredicate);

--- a/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/ISpatialQueryPlan.cs
@@ -30,6 +30,16 @@ public interface ISpatialQueryPlan
     IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
 
     /// <summary>
+    /// Gets the number of index ranges requested before applying the <c>MaxCoveringCells</c> limit.
+    /// </summary>
+    int CoveringCellCount { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the covering exceeded <c>MaxCoveringCells</c> and required coarse fallback ranges.
+    /// </summary>
+    bool UsedMaxCoveringCellFallback { get; }
+
+    /// <summary>
     /// Gets a human readable description of the exact predicate applied after index filtering.
     /// </summary>
     string? ExactPredicateDescription { get; }

--- a/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
+++ b/LiteDB.Spatial.Core/Engine/SpatialQueryPlan.cs
@@ -18,12 +18,16 @@ public sealed class SpatialQueryPlan : ISpatialQueryPlan
     /// <param name="coveringBounds">The optional coarse covering bounds.</param>
     /// <param name="indexRanges">The index ranges that should be scanned.</param>
     /// <param name="predicateDescription">Human friendly description of the exact predicate.</param>
+    /// <param name="coveringCellCount">The number of ranges requested before enforcing the maximum covering cell limit.</param>
+    /// <param name="usedMaxCoveringCellFallback">Indicates whether the covering exceeded the configured cell budget.</param>
     public SpatialQueryPlan(
         string engineName,
         int dimensions,
         BoundingBox? coveringBounds,
         IReadOnlyList<SpatialIndexRange> indexRanges,
-        string? predicateDescription)
+        string? predicateDescription,
+        int coveringCellCount,
+        bool usedMaxCoveringCellFallback)
     {
         if (string.IsNullOrWhiteSpace(engineName))
         {
@@ -40,6 +44,13 @@ public sealed class SpatialQueryPlan : ISpatialQueryPlan
         CoveringBounds = coveringBounds;
         IndexRanges = indexRanges ?? throw new ArgumentNullException(nameof(indexRanges));
         ExactPredicateDescription = predicateDescription;
+        if (coveringCellCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(coveringCellCount), "Covering cell count cannot be negative.");
+        }
+
+        CoveringCellCount = coveringCellCount;
+        UsedMaxCoveringCellFallback = usedMaxCoveringCellFallback;
     }
 
     /// <inheritdoc />
@@ -53,6 +64,12 @@ public sealed class SpatialQueryPlan : ISpatialQueryPlan
 
     /// <inheritdoc />
     public IReadOnlyList<SpatialIndexRange> IndexRanges { get; }
+
+    /// <inheritdoc />
+    public int CoveringCellCount { get; }
+
+    /// <inheritdoc />
+    public bool UsedMaxCoveringCellFallback { get; }
 
     /// <inheritdoc />
     public string? ExactPredicateDescription { get; }

--- a/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/ISpatialIndexEncoder.cs
@@ -30,6 +30,6 @@ public interface ISpatialIndexEncoder
     /// </summary>
     /// <param name="bounds">The bounding box to cover.</param>
     /// <param name="maxCells">The maximum number of ranges the caller is willing to accept.</param>
-    /// <returns>A collection of closed index ranges ordered from lowest to highest.</returns>
-    IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells);
+    /// <returns>A covering description containing closed index ranges ordered from lowest to highest.</returns>
+    SpatialIndexCovering Cover(BoundingBox bounds, int maxCells);
 }

--- a/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
+++ b/LiteDB.Spatial.Core/Indexing/MortonIndexEncoder.cs
@@ -61,7 +61,7 @@ public sealed class MortonIndexEncoder : ISpatialIndexEncoder
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<SpatialIndexRange> Cover(BoundingBox bounds, int maxCells)
+    public SpatialIndexCovering Cover(BoundingBox bounds, int maxCells)
     {
         if (bounds.Dimensions != Dimensions)
         {
@@ -80,7 +80,7 @@ public sealed class MortonIndexEncoder : ISpatialIndexEncoder
 
         if (totalCells == 0)
         {
-            return Array.Empty<SpatialIndexRange>();
+            return new SpatialIndexCovering(Array.Empty<SpatialIndexRange>(), 0, usedMaxCoveringCellFallback: false);
         }
 
         if (totalCells > _enumerationThreshold)
@@ -92,15 +92,21 @@ public sealed class MortonIndexEncoder : ISpatialIndexEncoder
                 (start, end) = (end, start);
             }
 
-            return new[] { new SpatialIndexRange(start, end) };
+            var ranges = new[] { new SpatialIndexRange(start, end) };
+            var coveringCells = totalCells > int.MaxValue ? int.MaxValue : (int)Math.Min(totalCells, (ulong)int.MaxValue);
+            var fallback = totalCells > (ulong)maxCells;
+            return new SpatialIndexCovering(ranges, coveringCells, fallback);
         }
 
         var buffer = new List<ulong>((int)Math.Min(totalCells, int.MaxValue));
         EnumerateCodes(minimum, maximum, buffer, new ulong[Dimensions], 0);
         buffer.Sort();
 
-        var ranges = BuildRanges(buffer);
-        return ReduceRangeCount(ranges, maxCells);
+        var enumeratedRanges = BuildRanges(buffer);
+        var coveringCellCount = enumeratedRanges.Count;
+        var usedFallback = enumeratedRanges.Count > maxCells;
+        var reduced = ReduceRangeCount(enumeratedRanges, maxCells);
+        return new SpatialIndexCovering(reduced, coveringCellCount, usedFallback);
     }
 
     /// <summary>

--- a/LiteDB.Spatial.Core/Indexing/SpatialIndexCovering.cs
+++ b/LiteDB.Spatial.Core/Indexing/SpatialIndexCovering.cs
@@ -1,0 +1,48 @@
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Spatial;
+
+/// <summary>
+/// Describes the coarse Morton covering generated for a spatial query.
+/// </summary>
+public sealed class SpatialIndexCovering
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SpatialIndexCovering"/> class.
+    /// </summary>
+    /// <param name="ranges">The index ranges produced by the encoder.</param>
+    /// <param name="coveringCellCount">The number of ranges requested before applying any max-cell reductions.</param>
+    /// <param name="usedMaxCoveringCellFallback">Whether the covering exceeded the configured cell budget and required merging.</param>
+    public SpatialIndexCovering(
+        IReadOnlyList<SpatialIndexRange> ranges,
+        int coveringCellCount,
+        bool usedMaxCoveringCellFallback)
+    {
+        Ranges = ranges ?? throw new ArgumentNullException(nameof(ranges));
+        if (coveringCellCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(coveringCellCount), "Covering cell counts cannot be negative.");
+        }
+
+        CoveringCellCount = coveringCellCount;
+        UsedMaxCoveringCellFallback = usedMaxCoveringCellFallback;
+    }
+
+    /// <summary>
+    /// Gets the index ranges produced by the encoder after applying any range merging.
+    /// </summary>
+    public IReadOnlyList<SpatialIndexRange> Ranges { get; }
+
+    /// <summary>
+    /// Gets the number of ranges originally produced before enforcing <c>MaxCoveringCells</c>.
+    /// </summary>
+    public int CoveringCellCount { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the encoder had to merge ranges because the covering exceeded <c>MaxCoveringCells</c>.
+    /// </summary>
+    public bool UsedMaxCoveringCellFallback { get; }
+}

--- a/LiteDB.Spatial.Geographic/Engine/GeographicEngine.cs
+++ b/LiteDB.Spatial.Geographic/Engine/GeographicEngine.cs
@@ -94,11 +94,15 @@ public sealed class GeographicEngine : IGeographicSpatialEngine
     private SpatialQueryPlan BuildPlanFromSegments(IReadOnlyList<GeographicBoundsSegment> segments, double radius, string predicateUnit)
     {
         var ranges = new List<SpatialIndexRange>();
+        long coveringCells = 0;
+        var usedFallback = false;
 
         foreach (var segment in segments)
         {
-            var coverings = _encoder.Cover(segment.Normalized, _options.MaxCoveringCells);
-            ranges.AddRange(coverings);
+            var covering = _encoder.Cover(segment.Normalized, _options.MaxCoveringCells);
+            ranges.AddRange(covering.Ranges);
+            coveringCells += covering.CoveringCellCount;
+            usedFallback |= covering.UsedMaxCoveringCellFallback;
         }
 
         var mergedRanges = MortonIndexEncoder.UnionAdjacentRanges(ranges);
@@ -113,7 +117,8 @@ public sealed class GeographicEngine : IGeographicSpatialEngine
             _ => BoundingBox.From2D(-180d, segments.Min(s => s.MinLatitude), 180d, segments.Max(s => s.MaxLatitude))
         };
 
-        return new SpatialQueryPlan(Name, Dimensions, coveringBounds, mergedRanges, predicate);
+        var coveringCellCount = coveringCells > int.MaxValue ? int.MaxValue : (int)coveringCells;
+        return new SpatialQueryPlan(Name, Dimensions, coveringBounds, mergedRanges, predicate, coveringCellCount, usedFallback);
     }
 
     private static void ValidateGeoPoint(GeoPoint point)

--- a/docs/spatial-diagnostics.md
+++ b/docs/spatial-diagnostics.md
@@ -35,6 +35,7 @@ Index ranges (3) via _idx
   - [223372036856873984, 223372036857029631] (0x031C71C74F032000 - 0x031C71C75200007F)
   - [223372036860939264, 223372036861421567] (0x031C71C7B6664000 - 0x031C71C7BF3FFFFF)
 Covering bounds via _mbb: [16.1738, 47.9082, 16.5738, 48.5082]
+Covering cells: 96 (fallback)
 Exact predicate: Vincenty distance <= 5000 meters
 ```
 
@@ -43,6 +44,7 @@ Exact predicate: Vincenty distance <= 5000 meters
 * **Bounding box field** – the field used for coarse filtering (`null` when the plan does not require one).
 * **Index ranges** – the Morton windows that will be scanned. Values are displayed as decimal and hexadecimal for easy comparison.
 * **Covering bounds** – the bounding box applied before exact predicates.
+* **Covering cells** – the number of Morton ranges requested before enforcing `MaxCoveringCells`. `fallback` indicates the encoder merged ranges because the limit was exceeded.
 * **Exact predicate** – the final check executed for each candidate.
 
 ## 3. Bounding boxes and anti-meridian ranges
@@ -66,6 +68,7 @@ Engine: Cartesian3D (3D)
 Index ranges (1) via _idx
   - [4294967296, 4380866642] (0x0000000100000000 - 0x0000000105341202)
 Covering bounds via _mbb: [-10, -10, -10, 10, 10, 10]
+Covering cells: 1
 Exact predicate: Euclidean3D <= 25
 ```
 
@@ -99,4 +102,14 @@ explain.IndexRanges.Count.Should().BeLessThanOrEqualTo(descriptor.Options.MaxCov
 ```
 
 Combining explain assertions with query results helps catch both performance regressions and correctness issues early in CI.
+
+## 8. Refreshing Cartesian3D fixtures
+
+The differential tests under `LiteDB.Spatial.Core.Tests/Differential/Cartesian3D` rely on deterministic lattice fixtures. Regenerate them whenever you adjust the lattice spacing or query mix:
+
+```
+dotnet run --project scripts/Cartesian3DFixtures/Cartesian3DFixtures.csproj
+```
+
+The console app writes JSON fixtures into `LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Fixtures` without requiring external tooling. Commit the updated JSON alongside any test changes so CI and diagnostics stay in sync.
 

--- a/scripts/Cartesian3DFixtures/Cartesian3DFixtures.csproj
+++ b/scripts/Cartesian3DFixtures/Cartesian3DFixtures.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/scripts/Cartesian3DFixtures/Program.cs
+++ b/scripts/Cartesian3DFixtures/Program.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+var fixturesDir = Path.Combine(repoRoot, "LiteDB.Spatial.Core.Tests", "Differential", "Cartesian3D", "Fixtures");
+Directory.CreateDirectory(fixturesDir);
+
+var jsonOptions = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+};
+
+var fixtures = new[]
+{
+    GenerateLatticeFixture()
+};
+
+foreach (var fixture in fixtures)
+{
+    var path = Path.Combine(fixturesDir, $"{fixture.Name}.json");
+    var json = JsonSerializer.Serialize(fixture, jsonOptions);
+    File.WriteAllText(path, json);
+    Console.WriteLine($"Wrote {path}");
+}
+
+return;
+
+static Cartesian3DLatticeFixture GenerateLatticeFixture()
+{
+    const string name = "lattice-aspects";
+    var domain = new Domain(new[] { -12d, -12d, -12d }, new[] { 12d, 12d, 12d });
+    var options = new FixtureOptions(12, 4, 0.05);
+    var points = new List<LatticePoint>();
+    var coordinates = new[] { -12d, -6d, 0d, 6d, 12d };
+    var index = 0;
+
+    foreach (var x in coordinates)
+    {
+        foreach (var y in coordinates)
+        {
+            foreach (var z in coordinates)
+            {
+                points.Add(new LatticePoint($"P{index:000}", new[] { x, y, z }));
+                index++;
+            }
+        }
+    }
+
+    var queries = new List<LatticeQuery>
+    {
+        new("TightOrigin", new[] { 0d, 0d, 0d }, 1.5, 0.05, true),
+        new("OriginShell", new[] { 0d, 0d, 0d }, 4.5, 0.05, true),
+        new("EdgeSweep", new[] { 9d, 9d, 9d }, 6.5, 0.05, true)
+    };
+
+    var boxes = new List<LatticeBoundingBox>
+    {
+        new("CoreCube", new[] { -6d, -6d, -6d }, new[] { 6d, 6d, 6d }, true),
+        new("NeedleX", new[] { -12d, -1d, -1d }, new[] { 12d, 1d, 1d }, true),
+        new("OffsetSlab", new[] { -12d, -12d, 6d }, new[] { -4d, -4d, 12d }, true)
+    };
+
+    return new Cartesian3DLatticeFixture(name, domain, options, points, queries, boxes);
+}
+
+internal sealed record Cartesian3DLatticeFixture(
+    string Name,
+    Domain Domain,
+    FixtureOptions Options,
+    IReadOnlyList<LatticePoint> Points,
+    IReadOnlyList<LatticeQuery> Queries,
+    IReadOnlyList<LatticeBoundingBox> Boxes);
+
+internal sealed record Domain(double[] Min, double[] Max);
+
+internal sealed record FixtureOptions(int PrecisionBits, int MaxCoveringCells, double DistanceTolerance);
+
+internal sealed record LatticePoint(string Id, double[] Coordinates);
+
+internal sealed record LatticeQuery(string Name, double[] Center, double Radius, double Tolerance, bool ExpectFallback);
+
+internal sealed record LatticeBoundingBox(string Name, double[] Min, double[] Max, bool ExpectFallback);


### PR DESCRIPTION
## Summary
- instrument spatial query plans with covering cell counts and fallback flags via a new `SpatialIndexCovering`, updating encoders and diagnostics output
- add Cartesian3D lattice fixtures and differential tests that compare results against a MathNet oracle while recording failure repro data under `tests/failures/3d`
- provide a fixture generation utility and documentation describing the new diagnostics fields and how to refresh 3D fixtures

## Testing
- dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68e8052a86c8832ab4a58bd1f8a920c0