### PR TITLE
Add locality suites and align spatial categories

### DIFF
--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -52,6 +52,8 @@ jobs:
           LiteDB.Spatial.Cartesian2D/obj/Release
           LiteDB.Spatial.Cartesian3D/bin/Release
           LiteDB.Spatial.Cartesian3D/obj/Release
+          LiteDB.Spatial.Testing.Oracles/bin/Release
+          LiteDB.Spatial.Testing.Oracles/obj/Release
 
       - name: Upload linux test build
         uses: actions/upload-artifact@v4
@@ -108,6 +110,27 @@ jobs:
           --logger "trx;LogFileName=TestResults.trx"
           --logger "console;verbosity=detailed"
           ${{ matrix.item.msbuildProps }}
+
+      - name: Build spatial core tests
+        if: matrix.item.framework == 'net8.0'
+        run: >-
+          dotnet build LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+          --configuration Release
+          --framework net8.0
+          --no-dependencies
+
+      - name: Run spatial core tests
+        if: matrix.item.framework == 'net8.0'
+        timeout-minutes: 10
+        run: >-
+          dotnet test LiteDB.Spatial.Core.Tests/LiteDB.Spatial.Core.Tests.csproj
+          --configuration Release
+          --no-build
+          --framework net8.0
+          --verbosity normal
+          --settings tests.ci.runsettings
+          --logger "trx;LogFileName=SpatialCoreTests.trx"
+          --logger "console;verbosity=detailed"
 
   repro-runner:
     runs-on: ubuntu-latest

--- a/LiteDB.Spatial.Core.Tests/CategoryAttribute.cs
+++ b/LiteDB.Spatial.Core.Tests/CategoryAttribute.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
 namespace LiteDB.Spatial.Core.Tests;
 
 /// <summary>
 /// Provides a lightweight category marker matching NUnit-style semantics.
 /// </summary>
+[TraitDiscoverer(CategoryDiscoverer.TypeName, CategoryDiscoverer.AssemblyName)]
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
-public sealed class CategoryAttribute : Attribute
+public sealed class CategoryAttribute : Attribute, ITraitAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="CategoryAttribute"/> class.
@@ -20,4 +26,43 @@ public sealed class CategoryAttribute : Attribute
     /// Gets the category associated with the test.
     /// </summary>
     public string Name { get; }
+}
+
+/// <summary>
+/// Discovers category traits and exposes them to xUnit's filtering infrastructure.
+/// </summary>
+public sealed class CategoryDiscoverer : ITraitDiscoverer
+{
+    /// <summary>
+    /// The fully-qualified type name used by <see cref="TraitDiscovererAttribute"/>.
+    /// </summary>
+    public const string TypeName = "LiteDB.Spatial.Core.Tests.CategoryDiscoverer";
+
+    /// <summary>
+    /// The assembly name where the discoverer lives.
+    /// </summary>
+    public const string AssemblyName = "LiteDB.Spatial.Core.Tests";
+
+    /// <inheritdoc />
+    public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+    {
+        var category = traitAttribute.GetNamedArgument<string>(nameof(CategoryAttribute.Name));
+
+        if (string.IsNullOrWhiteSpace(category))
+        {
+            category = traitAttribute.GetConstructorArguments().FirstOrDefault() as string;
+        }
+
+        if (string.IsNullOrWhiteSpace(category))
+        {
+            yield break;
+        }
+
+        yield return new KeyValuePair<string, string>("Category", category);
+
+        if (!string.Equals(category, "spatial", StringComparison.OrdinalIgnoreCase))
+        {
+            yield return new KeyValuePair<string, string>("Category", "spatial");
+        }
+    }
 }

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianBoundingBoxDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianBoundingBoxDifferentialTests.cs
@@ -3,11 +3,14 @@ using System.Linq;
 using FluentAssertions;
 using FsCheck;
 using FsCheck.Xunit;
+using LiteDB.Spatial.Core.Tests;
 using LiteDB.Spatial.Core.Tests.TestSupport;
 using Xunit;
 
 namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
 
+[Category("property")]
+[Category("differential")]
 public sealed class CartesianBoundingBoxDifferentialTests
 {
     [SpatialProperty(MaxTest = 100, Arbitrary = new[] { typeof(Cartesian2DGenerators) })]

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianPolygonDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/CartesianPolygonDifferentialTests.cs
@@ -7,12 +7,15 @@ using FluentAssertions;
 using FsCheck;
 using FsCheck.Xunit;
 using LiteDB.Spatial;
+using LiteDB.Spatial.Core.Tests;
 using LiteDB.Spatial.Core.Tests.Oracles;
 using LiteDB.Spatial.Core.Tests.TestSupport;
 using Xunit;
 
 namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
 
+[Category("property")]
+[Category("differential")]
 public sealed class CartesianPolygonDifferentialTests
 {
     [SpatialProperty(MaxTest = 75, Arbitrary = new[] { typeof(Cartesian2DGenerators) })]

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/PointCloudNearTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian2D/PointCloudNearTests.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Linq;
 using FluentAssertions;
+using LiteDB.Spatial.Core.Tests;
 using LiteDB.Spatial.Core.Tests.TestSupport;
 using Xunit;
 
 namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian2D;
 
+[Category("differential")]
 public sealed class PointCloudNearTests
 {
     [Fact]

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DAabbTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DAabbTests.cs
@@ -4,10 +4,12 @@ extern alias LiteDbBase;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
 using LiteDB.Spatial;
+using LiteDB.Spatial.Core.Tests;
 using LiteDB.Spatial.Core.Tests.TestSupport;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,6 +17,7 @@ using BaseLiteDB = LiteDbBase::LiteDB;
 
 namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian3D;
 
+[Category("differential")]
 public sealed class Cartesian3DAabbTests
 {
     private readonly ITestOutputHelper _output;
@@ -59,12 +62,20 @@ public sealed class Cartesian3DAabbTests
                 fixture.Options.BoundingBoxFieldName));
 
         var boundingField = descriptor.Options.BoundingBoxFieldName;
-        var mbbById = new Dictionary<int, double[]>(fixture.Points.Count);
-        var pointById = fixture.Points.ToDictionary(p => p.Id);
+        var mbbById = new Dictionary<string, double[]>(fixture.Points.Count, StringComparer.Ordinal);
+        var pointById = fixture.Points.ToDictionary(p => p.Id, StringComparer.Ordinal);
 
         foreach (var document in collection.FindAll())
         {
-            var id = document["_id"].AsInt32;
+            var idValue = document["_id"];
+            var id = idValue.Type switch
+            {
+                BaseLiteDB.BsonType.Int32 => idValue.AsInt32.ToString(CultureInfo.InvariantCulture),
+                BaseLiteDB.BsonType.Int64 => idValue.AsInt64.ToString(CultureInfo.InvariantCulture),
+                BaseLiteDB.BsonType.Double => idValue.AsDouble.ToString(CultureInfo.InvariantCulture),
+                BaseLiteDB.BsonType.String => idValue.AsString,
+                _ => idValue.ToString()
+            };
             var mbb = document[boundingField].AsArray.Select(v => v.AsDouble).ToArray();
             mbb.Length.Should().Be(6, "3D bounding boxes must contain six values");
             for (var axis = 0; axis < 3; axis++)
@@ -100,13 +111,13 @@ public sealed class Cartesian3DAabbTests
             var manualMatches = mbbById
                 .Where(pair => Contains(pair.Value, query))
                 .Select(pair => pair.Key)
-                .OrderBy(id => id)
+                .OrderBy(id => id, StringComparer.Ordinal)
                 .ToList();
 
             var coordinateMatches = fixture.Points
                 .Where(point => Contains(point, query))
                 .Select(point => point.Id)
-                .OrderBy(id => id)
+                .OrderBy(id => id, StringComparer.Ordinal)
                 .ToList();
 
             try

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DDifferentialTests.cs
@@ -2,16 +2,21 @@ extern alias LiteDbBase;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
 using LiteDB.Spatial;
+using LiteDB.Spatial.Core.Tests;
+using LiteDB.Spatial.Core.Tests.Infrastructure;
 using Xunit;
 using Xunit.Abstractions;
 using BaseLiteDB = LiteDbBase::LiteDB;
 
 namespace LiteDB.Spatial.Core.Tests.Differential.Cartesian3D;
 
+[Category("differential")]
 public sealed class Cartesian3DDifferentialTests
 {
     private readonly ITestOutputHelper _output;
@@ -34,10 +39,7 @@ public sealed class Cartesian3DDifferentialTests
             var plan = SpatialCartesian3D.Near(context.Descriptor, query.Center, query.Radius);
             LogCovering("near", fixture.Name, query.Id, plan);
 
-            if (query.ExpectCapped)
-            {
-                plan.CoveringDiagnostics.UsedMaxCoveringCellsFallback.Should().BeTrue($"Fixture {fixture.Name} query {query.Id} should trigger MaxCoveringCells fallback.");
-            }
+            EnsureExpectedFallback(plan.CoveringDiagnostics, fixture.Name, query);
 
             var baseTolerance = context.Descriptor.Options.DistanceTolerance;
             var expected = fixture.Points
@@ -49,7 +51,8 @@ public sealed class Cartesian3DDifferentialTests
                 .Where(candidate => candidate.Distance <= query.Radius + baseTolerance + 1e-9)
                 .OrderBy(candidate => candidate.Distance)
                 .ToList();
-            var tolerance = Math.Max(baseTolerance, CalculateTolerance(expected.Select(candidate => candidate.Distance)));
+            var membershipTolerance = CalculateMembershipTolerance(query.Radius, baseTolerance);
+            var parityTolerance = CalculateParityTolerance(expected.Select(candidate => candidate.Distance), baseTolerance);
 
             var actual = Spatial.Near(context.Collection, x => x.Position, query.Center, query.Radius);
             var actualProjected = actual
@@ -71,10 +74,10 @@ public sealed class Cartesian3DDifferentialTests
                     .ToList();
 
                 actualProjected.Should().AllSatisfy(result =>
-                    result.Distance.Should().BeLessThanOrEqualTo(query.Radius + tolerance + 1e-9));
+                    result.Distance.Should().BeLessThanOrEqualTo(query.Radius + membershipTolerance + 1e-9));
                 if (deltas.Count > 0)
                 {
-                    deltas.Max().Should().BeLessOrEqualTo(tolerance + 1e-9, "distance deltas should remain within tolerance");
+                    deltas.Max().Should().BeLessOrEqualTo(parityTolerance + 1e-9, "distance deltas should remain within tolerance");
                 }
             }
             catch
@@ -88,7 +91,8 @@ public sealed class Cartesian3DDifferentialTests
                         query = query.Id,
                         queryCenter = new { query.Center.X, query.Center.Y, query.Center.Z },
                         queryRadius = query.Radius,
-                        tolerance,
+                        membershipTolerance,
+                        parityTolerance,
                         baseTolerance,
                         covering = CreateCoveringSnapshot(plan.CoveringDiagnostics, context.Descriptor.Options.MaxCoveringCells),
                         expected = expected,
@@ -147,10 +151,17 @@ public sealed class Cartesian3DDifferentialTests
         }
     }
 
-    private static double CalculateTolerance(IEnumerable<double> distances)
+    private static double CalculateMembershipTolerance(double radius, double baseTolerance)
     {
-        var scale = distances.Select(Math.Abs).DefaultIfEmpty(1d).Max();
-        return (1e-9 * scale) + 1e-9;
+        var scaled = SpatialTolerance.ForCartesian(Math.Max(radius, baseTolerance));
+        return Math.Max(baseTolerance, scaled);
+    }
+
+    private static double CalculateParityTolerance(IEnumerable<double> distances, double baseTolerance)
+    {
+        var scale = distances.DefaultIfEmpty(0d).Select(Math.Abs).DefaultIfEmpty(0d).Max();
+        var scaled = scale <= 0d ? baseTolerance : SpatialTolerance.ForCartesian(scale);
+        return Math.Max(baseTolerance, scaled);
     }
 
     private void VerifyBoundingBoxesAreNormalized(FixtureContext context, Cartesian3DLatticeFixture fixture)
@@ -161,7 +172,14 @@ public sealed class Cartesian3DDifferentialTests
         foreach (var document in raw.FindAll())
         {
             document.TryGetValue("_id", out var idValue).Should().BeTrue();
-            var id = idValue.AsInt32;
+            var id = idValue.Type switch
+            {
+                BaseLiteDB.BsonType.Int32 => idValue.AsInt32.ToString(CultureInfo.InvariantCulture),
+                BaseLiteDB.BsonType.Int64 => idValue.AsInt64.ToString(CultureInfo.InvariantCulture),
+                BaseLiteDB.BsonType.Double => idValue.AsDouble.ToString(CultureInfo.InvariantCulture),
+                BaseLiteDB.BsonType.String => idValue.AsString,
+                _ => idValue.ToString()
+            };
             fixture.Points.Should().Contain(point => point.Id == id);
 
             document.TryGetValue(fieldName, out var boundingValue).Should().BeTrue();
@@ -194,6 +212,20 @@ public sealed class Cartesian3DDifferentialTests
         var values = bounds.GetValues();
         return point.X >= values[0] && point.Y >= values[1] && point.Z >= values[2]
             && point.X <= values[3] && point.Y <= values[4] && point.Z <= values[5];
+    }
+
+    private static void EnsureExpectedFallback(SpatialCoveringDiagnostics diagnostics, string fixtureName, Cartesian3DNearQuery query)
+    {
+        if (query.ExpectCapped)
+        {
+            diagnostics.UsedMaxCoveringCellsFallback.Should().BeTrue(
+                $"Fixture {fixtureName} query {query.Id} should trigger MaxCoveringCells fallback.");
+        }
+        else
+        {
+            diagnostics.UsedMaxCoveringCellsFallback.Should().BeFalse(
+                $"Fixture {fixtureName} query {query.Id} should avoid MaxCoveringCells fallback.");
+        }
     }
 
     private void LogCovering(string category, string fixtureName, string queryId, ISpatialQueryPlan plan)
@@ -239,7 +271,7 @@ public sealed class Cartesian3DDifferentialTests
         {
             var database = new BaseLiteDB.LiteDatabase(new MemoryStream());
             database.Mapper.Entity<TestPoint>().Id(x => x.Id, autoId: false);
-            var collection = database.GetCollection<TestPoint>($"fixture_{fixture.Name}");
+            var collection = database.GetCollection<TestPoint>(BuildCollectionName(fixture.Name));
             var descriptor = Spatial.UseCartesian3D(collection, x => x.Position, fixture.Domain, fixture.Options);
 
             collection.DeleteAll();
@@ -261,11 +293,34 @@ public sealed class Cartesian3DDifferentialTests
         {
             Database.Dispose();
         }
+
+        private static string BuildCollectionName(string fixtureName)
+        {
+            var builder = new StringBuilder("fixture_");
+
+            if (string.IsNullOrWhiteSpace(fixtureName))
+            {
+                builder.Append("cartesian3d");
+                return builder.ToString();
+            }
+
+            foreach (var ch in fixtureName)
+            {
+                builder.Append(IsValidCollectionCharacter(ch) ? ch : '_');
+            }
+
+            return builder.ToString();
+        }
+
+        private static bool IsValidCollectionCharacter(char ch)
+        {
+            return char.IsLetterOrDigit(ch) || ch == '_' || ch == '$';
+        }
     }
 
     private sealed class TestPoint
     {
-        public int Id { get; set; }
+        public string Id { get; set; } = default!;
 
         public GeoPoint3D Position { get; set; } = default!;
     }

--- a/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DLatticeFixture.cs
+++ b/LiteDB.Spatial.Core.Tests/Differential/Cartesian3D/Cartesian3DLatticeFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
@@ -75,8 +76,8 @@ public sealed class Cartesian3DLatticeFixture
             raw.Options?.BoundingBoxFieldName ?? SpatialIndexOptions.DefaultBoundingBoxFieldName);
 
         var points = raw.Points
-            .Select(p => new Cartesian3DLatticePoint(p.Id, p.X, p.Y, p.Z))
-            .OrderBy(p => p.Id)
+            .Select((p, index) => new Cartesian3DLatticePoint(ReadPointId(p.Id, index), p.X, p.Y, p.Z))
+            .OrderBy(p => p.Id, StringComparer.Ordinal)
             .ToList();
 
         var near = (raw.NearQueries ?? Array.Empty<RawNearQuery>())
@@ -139,10 +140,22 @@ public sealed class Cartesian3DLatticeFixture
         public string? BoundingBoxFieldName { get; set; }
     }
 
+    private static string ReadPointId(JsonElement element, int index)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString() ?? index.ToString(CultureInfo.InvariantCulture),
+            JsonValueKind.Number when element.TryGetInt64(out var integer) => integer.ToString(CultureInfo.InvariantCulture),
+            JsonValueKind.Number => element.GetDouble().ToString(CultureInfo.InvariantCulture),
+            JsonValueKind.Null => index.ToString(CultureInfo.InvariantCulture),
+            _ => element.ToString() ?? index.ToString(CultureInfo.InvariantCulture)
+        };
+    }
+
     private sealed class RawPoint
     {
         [JsonPropertyName("id")]
-        public int Id { get; set; }
+        public JsonElement Id { get; set; }
 
         [JsonPropertyName("x")]
         public double X { get; set; }
@@ -179,7 +192,7 @@ public sealed class Cartesian3DLatticeFixture
     }
 }
 
-public sealed record Cartesian3DLatticePoint(int Id, double X, double Y, double Z)
+public sealed record Cartesian3DLatticePoint(string Id, double X, double Y, double Z)
 {
     public GeoPoint3D ToGeoPoint() => new(X, Y, Z);
 }

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeodesicDistanceParityTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeodesicDistanceParityTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using FluentAssertions.Execution;
 using LiteDB.Spatial;
+using LiteDB.Spatial.Core.Tests.Infrastructure;
 using Xunit;
 
 namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
@@ -17,12 +18,10 @@ namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
 //   json.dump(pairs, open('LiteDB.Spatial.Core.Tests/fixtures/geodesic_pairs.json', 'w'), indent=2)
 //   PY
 
+[Category("geographic")]
 [Category("oracle")]
 public sealed class GeodesicDistanceParityTests
 {
-    private const double RelativeTolerance = 1e-4;
-    private const double AbsoluteTolerance = 0.05;
-
     [Fact]
     public void HaversineMatchesGeographicLibSamples()
     {
@@ -35,9 +34,7 @@ public sealed class GeodesicDistanceParityTests
 
             var expected = GeographicLibOracle.Distance(pair.Id, pair.From, pair.To);
             var actual = distance.Distance(pair.From, pair.To);
-            var tolerance = RelativeTolerance * expected + AbsoluteTolerance;
-
-            actual.Should().BeApproximately(expected, tolerance);
+            SpatialTolerance.AssertEarthDistance(pair.Id, expected, actual);
         }
     }
 
@@ -53,9 +50,7 @@ public sealed class GeodesicDistanceParityTests
 
             var expected = GeographicLibOracle.Distance(pair.Id, pair.From, pair.To);
             var actual = distance.Distance(pair.From, pair.To);
-            var tolerance = RelativeTolerance * expected + AbsoluteTolerance;
-
-            actual.Should().BeApproximately(expected, tolerance);
+            SpatialTolerance.AssertEarthDistance(pair.Id, expected, actual);
         }
     }
 }

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicBoundingBoxDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicBoundingBoxDifferentialTests.cs
@@ -13,6 +13,7 @@ using SpatialFacade = LiteDB.Spatial.Spatial;
 
 namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
 
+[Category("geographic")]
 [Category("oracle")]
 public sealed class GeographicBoundingBoxDifferentialTests
 {

--- a/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicNearDifferentialTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Engine/Differential/GeographicNearDifferentialTests.cs
@@ -15,6 +15,7 @@ using SpatialFacade = LiteDB.Spatial.Spatial;
 
 namespace LiteDB.Spatial.Core.Tests.Engine.Differential;
 
+[Category("geographic")]
 [Category("oracle")]
 public sealed class GeographicNearDifferentialTests
 {

--- a/LiteDB.Spatial.Core.Tests/Indexing/Fixtures/locality-fixtures.json
+++ b/LiteDB.Spatial.Core.Tests/Indexing/Fixtures/locality-fixtures.json
@@ -1,0 +1,36 @@
+{
+  "fixtures": [
+    {
+      "id": "uniform_2d_precision8",
+      "grid": "uniform_2d_precision8.json",
+      "neighborCount": 8,
+      "windowRadius": 12,
+      "topK": 8,
+      "expected": {
+        "averageOverlap": 0.791016,
+        "minimumOverlap": 0.375,
+        "averageWindow": 24.390625,
+        "maximumWindow": 25.0,
+        "averageSpan": 36.80859375,
+        "worstSpan": 133.0,
+        "metricTolerance": 0.01
+      }
+    },
+    {
+      "id": "uniform_3d_precision6",
+      "grid": "uniform_3d_precision6.json",
+      "neighborCount": 12,
+      "windowRadius": 18,
+      "topK": 6,
+      "expected": {
+        "averageOverlap": 0.6865234375,
+        "minimumOverlap": 0.4166666667,
+        "averageWindow": 36.33203125,
+        "maximumWindow": 37.0,
+        "averageSpan": 121.30859375,
+        "worstSpan": 342.0,
+        "metricTolerance": 0.01
+      }
+    }
+  ]
+}

--- a/LiteDB.Spatial.Core.Tests/Indexing/LocalityTests.cs
+++ b/LiteDB.Spatial.Core.Tests/Indexing/LocalityTests.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using LiteDB.Spatial.Core.Tests.TestSupport;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace LiteDB.Spatial.Core.Tests.Indexing;
+
+[Category("locality")]
+public sealed class LocalityTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public LocalityTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public static IEnumerable<object[]> Fixtures => LocalityTestHelpers
+        .LoadDefinitions()
+        .Select(definition => new object[] { definition });
+
+    [Theory]
+    [MemberData(nameof(Fixtures))]
+    public void MortonLocalityMatchesRecordedExpectations(LocalityFixtureDefinition definition)
+    {
+        var grid = LocalityTestHelpers.LoadGridFixture(definition);
+        var analysis = LocalityTestHelpers.Analyze(definition, grid);
+
+        _output.WriteLine($"fixture={definition.Id}");
+        _output.WriteLine($"points={analysis.PointsByRank.Count}");
+        _output.WriteLine($"avgOverlap={analysis.Metrics.AverageOverlap:F6} minOverlap={analysis.Metrics.MinimumOverlap:F6}");
+        _output.WriteLine($"avgWindow={analysis.Metrics.AverageWindow:F2} maxWindow={analysis.Metrics.MaximumWindow:F2}");
+        _output.WriteLine($"avgSpan={analysis.Metrics.AverageSpan:F2} worstSpan={analysis.Metrics.WorstSpan:F2}");
+
+        LocalityAssertions.AssertLocality(analysis);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/ExplainResultParser.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/ExplainResultParser.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal static class ExplainResultParser
+{
+    public static IReadOnlyDictionary<string, string> ParseDiagnostics(SpatialExplainResult explain)
+    {
+        if (explain == null)
+        {
+            throw new ArgumentNullException(nameof(explain));
+        }
+
+        var line = explain
+            .ToString()
+            .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(text => text.StartsWith("Covering diagnostics:", StringComparison.Ordinal));
+
+        if (line == null)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        var prefixLength = "Covering diagnostics:".Length;
+        var payload = line.Substring(prefixLength).Trim();
+        var segments = payload.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var segment in segments)
+        {
+            var parts = segment.Split('=', 2);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            map[parts[0].Trim()] = parts[1].Trim();
+        }
+
+        return map;
+    }
+
+    public static ulong ParseRangeCount(IReadOnlyDictionary<string, string> diagnostics, string key)
+    {
+        if (!diagnostics.TryGetValue(key, out var value))
+        {
+            return 0UL;
+        }
+
+        if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return 0UL;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/LocalityAssertions.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/LocalityAssertions.cs
@@ -1,0 +1,42 @@
+using System;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal static class LocalityAssertions
+{
+    public static void AssertLocality(LocalityAnalysis analysis)
+    {
+        if (analysis == null)
+        {
+            throw new ArgumentNullException(nameof(analysis));
+        }
+
+        using var scope = new AssertionScope();
+        scope.AddReportable("fixture", analysis.Definition.Id);
+        scope.AddReportable("points", analysis.PointsByRank.Count.ToString());
+        scope.AddReportable("neighborCount", analysis.Definition.NeighborCount.ToString());
+        scope.AddReportable("windowRadius", analysis.Definition.WindowRadius.ToString());
+        scope.AddReportable("topK", analysis.Definition.TopK.ToString());
+
+        var tolerance = analysis.Definition.Expected.MetricTolerance;
+        var expected = analysis.Definition.ExpectedMetrics;
+        var metrics = analysis.Metrics;
+
+        metrics.AverageOverlap.Should().BeApproximately(expected.AverageOverlap, tolerance, "average overlap should remain within the recorded envelope");
+        metrics.MinimumOverlap.Should().BeGreaterOrEqualTo(expected.MinimumOverlap - tolerance, "minimum overlap should not regress below the expected threshold");
+        metrics.AverageWindow.Should().BeApproximately(expected.AverageWindow, tolerance, "average Morton window should remain stable");
+        metrics.MaximumWindow.Should().BeLessOrEqualTo(expected.MaximumWindow + tolerance, "maximum Morton window should stay bounded");
+        metrics.AverageSpan.Should().BeApproximately(expected.AverageSpan, tolerance, "average span should remain consistent");
+        metrics.WorstSpan.Should().BeLessOrEqualTo(expected.WorstSpan + tolerance, "worst-case span should stay within the budget");
+
+        analysis.DuplicateCodes.Should().BeEmpty("Morton codes should be unique for grid '{0}'", analysis.Grid.Id);
+
+        analysis.Definition.TopK.Should().BeGreaterThan(0, "top-K neighbor windows must be configured");
+        analysis.PointsByRank.Count.Should().BeGreaterThan(analysis.Definition.TopK, "fixtures should have enough points to evaluate top-K neighborhoods");
+
+        SpatialTestAssertions.AssertUniqueMortonCodes(analysis.PointsByRank, analysis.Grid.Id);
+        SpatialTestAssertions.AssertTopKNeighborhoods(analysis.PointsByRank, analysis.Definition.TopK);
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/LocalityMetrics.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/LocalityMetrics.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+public readonly record struct LocalityMetrics(
+    double AverageOverlap,
+    double MinimumOverlap,
+    double AverageWindow,
+    double MaximumWindow,
+    double AverageSpan,
+    double WorstSpan)
+{
+    public LocalityMetrics ClampToPrecision(int decimals)
+    {
+        return new LocalityMetrics(
+            Math.Round(AverageOverlap, decimals, MidpointRounding.AwayFromZero),
+            Math.Round(MinimumOverlap, decimals, MidpointRounding.AwayFromZero),
+            Math.Round(AverageWindow, decimals, MidpointRounding.AwayFromZero),
+            Math.Round(MaximumWindow, decimals, MidpointRounding.AwayFromZero),
+            Math.Round(AverageSpan, decimals, MidpointRounding.AwayFromZero),
+            Math.Round(WorstSpan, decimals, MidpointRounding.AwayFromZero));
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/LocalityTestHelpers.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/LocalityTestHelpers.cs
@@ -1,0 +1,365 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal static class LocalityTestHelpers
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    public static IReadOnlyList<LocalityFixtureDefinition> LoadDefinitions()
+    {
+        var root = TestResourceLocator.RepositoryRoot;
+        var path = Path.Combine(root, "LiteDB.Spatial.Core.Tests", "Indexing", "Fixtures", "locality-fixtures.json");
+        var json = File.ReadAllText(path);
+        var payload = JsonSerializer.Deserialize<LocalityFixtureFile>(json, SerializerOptions)
+            ?? throw new InvalidOperationException("Unable to deserialize locality fixture definitions.");
+        return payload.Fixtures;
+    }
+
+    public static LocalityGridFixture LoadGridFixture(LocalityFixtureDefinition definition)
+    {
+        if (definition == null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        if (string.IsNullOrWhiteSpace(definition.Grid))
+        {
+            throw new InvalidOperationException($"Fixture '{definition.Id}' does not specify a grid definition.");
+        }
+
+        var root = TestResourceLocator.RepositoryRoot;
+        var path = Path.Combine(root, "LiteDB.Spatial.Core.Tests", "fixtures", definition.Grid);
+        var json = File.ReadAllText(path);
+        return JsonSerializer.Deserialize<LocalityGridFixture>(json, SerializerOptions)
+            ?? throw new InvalidOperationException($"Unable to deserialize grid fixture '{definition.Grid}'.");
+    }
+
+    public static LocalityAnalysis Analyze(LocalityFixtureDefinition definition, LocalityGridFixture grid)
+    {
+        if (definition == null)
+        {
+            throw new ArgumentNullException(nameof(definition));
+        }
+
+        if (grid == null)
+        {
+            throw new ArgumentNullException(nameof(grid));
+        }
+
+        if (grid.Dimensions <= 0)
+        {
+            throw new InvalidOperationException("Grid fixtures must declare at least one dimension.");
+        }
+
+        if (grid.Shape.Length != grid.Dimensions)
+        {
+            throw new InvalidOperationException($"Grid '{grid.Id}' declares {grid.Dimensions} dimensions but provided {grid.Shape.Length} shape entries.");
+        }
+
+        var points = GeneratePoints(grid);
+        var orderedByCode = points
+            .OrderBy(p => p.MortonCode)
+            .ThenBy(p => p.Index)
+            .ToList();
+
+        for (var i = 0; i < orderedByCode.Count; i++)
+        {
+            orderedByCode[i].MortonRank = i;
+        }
+
+        var neighbors = ComputeNearestNeighborRanks(points, definition.NeighborCount);
+        var windowSizes = new List<int>(points.Count);
+        var overlapSum = 0d;
+        var minOverlap = double.MaxValue;
+        var spanSum = 0d;
+        var worstSpan = 0d;
+
+        foreach (var point in points)
+        {
+            var ranks = neighbors[point.Index];
+            var windowLow = Math.Max(0, point.MortonRank - definition.WindowRadius);
+            var windowHigh = Math.Min(points.Count - 1, point.MortonRank + definition.WindowRadius);
+            var windowSize = windowHigh - windowLow + 1;
+            windowSizes.Add(windowSize);
+
+            if (ranks.Count > 0)
+            {
+                var overlapCount = ranks.Count(rank => rank >= windowLow && rank <= windowHigh);
+                var overlap = overlapCount / (double)definition.NeighborCount;
+                overlapSum += overlap;
+                minOverlap = Math.Min(minOverlap, overlap);
+
+                var minRank = ranks[0];
+                var maxRank = ranks[^1];
+                var span = maxRank - minRank + 1;
+                spanSum += span;
+                worstSpan = Math.Max(worstSpan, span);
+            }
+            else
+            {
+                overlapSum += 1d;
+                minOverlap = Math.Min(minOverlap, 1d);
+            }
+        }
+
+        var metrics = new LocalityMetrics(
+            AverageOverlap: overlapSum / points.Count,
+            MinimumOverlap: minOverlap,
+            AverageWindow: windowSizes.Average(),
+            MaximumWindow: windowSizes.Max(),
+            AverageSpan: points.Count == 0 ? 0d : spanSum / points.Count,
+            WorstSpan: worstSpan);
+
+        var duplicates = orderedByCode
+            .GroupBy(p => p.MortonCode)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        return new LocalityAnalysis(
+            definition,
+            grid,
+            orderedByCode,
+            metrics,
+            neighbors,
+            windowSizes,
+            duplicates);
+    }
+
+    private static List<LocalityPoint> GeneratePoints(LocalityGridFixture grid)
+    {
+        var encoder = new MortonIndexEncoder(grid.Dimensions, grid.PrecisionBits);
+        var counts = grid.Shape;
+        var total = 1;
+        foreach (var count in counts)
+        {
+            if (count <= 0)
+            {
+                throw new InvalidOperationException("Grid dimensions must be positive.");
+            }
+
+            total = checked(total * count);
+        }
+
+        var result = new List<LocalityPoint>(total);
+        var span = new double[grid.Dimensions];
+        for (var axis = 0; axis < grid.Dimensions; axis++)
+        {
+            var range = grid.Max[axis] - grid.Min[axis];
+            span[axis] = counts[axis] <= 1 ? 0d : range / (counts[axis] - 1);
+        }
+
+        for (var index = 0; index < total; index++)
+        {
+            var coordinates = new double[grid.Dimensions];
+            var normalized = new double[grid.Dimensions];
+            var remainder = index;
+
+            for (var axis = grid.Dimensions - 1; axis >= 0; axis--)
+            {
+                var count = counts[axis];
+                var position = remainder % count;
+                remainder /= count;
+
+                coordinates[axis] = count <= 1
+                    ? grid.Min[axis]
+                    : grid.Min[axis] + position * span[axis];
+
+                var range = grid.Max[axis] - grid.Min[axis];
+                normalized[axis] = range <= 0d
+                    ? 0d
+                    : (coordinates[axis] - grid.Min[axis]) / range;
+            }
+
+            var code = encoder.Encode(normalized);
+            result.Add(new LocalityPoint(index, coordinates, code));
+        }
+
+        return result;
+    }
+
+    private static IReadOnlyDictionary<int, IReadOnlyList<int>> ComputeNearestNeighborRanks(IReadOnlyList<LocalityPoint> points, int neighborCount)
+    {
+        var map = new Dictionary<int, IReadOnlyList<int>>(points.Count);
+        var byIndex = points.ToDictionary(point => point.Index);
+
+        foreach (var point in points)
+        {
+            var distances = new List<(int index, double distance)>(points.Count - 1);
+            foreach (var candidate in points)
+            {
+                if (candidate.Index == point.Index)
+                {
+                    continue;
+                }
+
+                var distance = CalculateDistance(point.Coordinates, candidate.Coordinates);
+                distances.Add((candidate.Index, distance));
+            }
+
+            distances.Sort((left, right) =>
+            {
+                var comparison = left.distance.CompareTo(right.distance);
+                return comparison != 0 ? comparison : left.index.CompareTo(right.index);
+            });
+
+            var selected = distances
+                .Take(neighborCount)
+                .Select(item => byIndex[item.index].MortonRank)
+                .OrderBy(rank => rank)
+                .ToList();
+
+            map[point.Index] = selected;
+        }
+
+        return map;
+    }
+
+    private static double CalculateDistance(IReadOnlyList<double> left, IReadOnlyList<double> right)
+    {
+        var sum = 0d;
+        for (var axis = 0; axis < left.Count; axis++)
+        {
+            var delta = left[axis] - right[axis];
+            sum += delta * delta;
+        }
+
+        return Math.Sqrt(sum);
+    }
+
+    private sealed class LocalityFixtureFile
+    {
+        public List<LocalityFixtureDefinition> Fixtures { get; set; } = new();
+    }
+}
+
+public sealed class LocalityFixtureDefinition
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Grid { get; set; } = string.Empty;
+
+    public int NeighborCount { get; set; }
+        = 0;
+
+    public int WindowRadius { get; set; }
+        = 0;
+
+    public int TopK { get; set; }
+        = 0;
+
+    public LocalityExpectation Expected { get; set; } = new();
+
+    public LocalityMetrics ExpectedMetrics => new(
+        Expected.AverageOverlap,
+        Expected.MinimumOverlap,
+        Expected.AverageWindow,
+        Expected.MaximumWindow,
+        Expected.AverageSpan,
+        Expected.WorstSpan);
+}
+
+public sealed class LocalityExpectation
+{
+    public double AverageOverlap { get; set; }
+        = 0d;
+
+    public double MinimumOverlap { get; set; }
+        = 0d;
+
+    public double AverageWindow { get; set; }
+        = 0d;
+
+    public double MaximumWindow { get; set; }
+        = 0d;
+
+    public double AverageSpan { get; set; }
+        = 0d;
+
+    public double WorstSpan { get; set; }
+        = 0d;
+
+    public double MetricTolerance { get; set; }
+        = 1e-6;
+}
+
+internal sealed class LocalityGridFixture
+{
+    public string Id { get; set; } = string.Empty;
+
+    public int Dimensions { get; set; }
+        = 0;
+
+    public int[] Shape { get; set; } = Array.Empty<int>();
+
+    public double[] Min { get; set; } = Array.Empty<double>();
+
+    public double[] Max { get; set; } = Array.Empty<double>();
+
+    public int PrecisionBits { get; set; }
+        = 8;
+}
+
+internal sealed class LocalityPoint
+{
+    public LocalityPoint(int index, double[] coordinates, ulong mortonCode)
+    {
+        Index = index;
+        Coordinates = coordinates;
+        MortonCode = mortonCode;
+    }
+
+    public int Index { get; }
+
+    public double[] Coordinates { get; }
+
+    public ulong MortonCode { get; }
+
+    public int MortonRank { get; set; }
+        = -1;
+}
+
+internal sealed class LocalityAnalysis
+{
+    public LocalityAnalysis(
+        LocalityFixtureDefinition definition,
+        LocalityGridFixture grid,
+        IReadOnlyList<LocalityPoint> orderedByCode,
+        LocalityMetrics metrics,
+        IReadOnlyDictionary<int, IReadOnlyList<int>> neighborRanks,
+        IReadOnlyList<int> windowSizes,
+        IReadOnlyList<ulong> duplicateCodes)
+    {
+        Definition = definition;
+        Grid = grid;
+        PointsByRank = orderedByCode;
+        Metrics = metrics;
+        NeighborRanks = neighborRanks;
+        WindowSizes = windowSizes;
+        DuplicateCodes = duplicateCodes;
+    }
+
+    public LocalityFixtureDefinition Definition { get; }
+
+    public LocalityGridFixture Grid { get; }
+
+    public IReadOnlyList<LocalityPoint> PointsByRank { get; }
+
+    public LocalityMetrics Metrics { get; }
+
+    public IReadOnlyDictionary<int, IReadOnlyList<int>> NeighborRanks { get; }
+
+    public IReadOnlyList<int> WindowSizes { get; }
+
+    public IReadOnlyList<ulong> DuplicateCodes { get; }
+}

--- a/LiteDB.Spatial.Core.Tests/TestSupport/SpatialTestAssertions.cs
+++ b/LiteDB.Spatial.Core.Tests/TestSupport/SpatialTestAssertions.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+
+namespace LiteDB.Spatial.Core.Tests.TestSupport;
+
+internal static class SpatialTestAssertions
+{
+    public static void AssertUniqueMortonCodes(IEnumerable<LocalityPoint> points, string context)
+    {
+        if (points == null)
+        {
+            throw new ArgumentNullException(nameof(points));
+        }
+
+        points.Select(point => point.MortonCode)
+            .Should()
+            .OnlyHaveUniqueItems($"Morton codes should remain unique for fixture '{context}'");
+    }
+
+    public static void AssertTopKNeighborhoods(IReadOnlyList<LocalityPoint> ordered, int topK)
+    {
+        if (ordered == null)
+        {
+            throw new ArgumentNullException(nameof(ordered));
+        }
+
+        if (topK <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(topK), "Top-K window must be positive.");
+        }
+
+        if (ordered.Count <= topK)
+        {
+            throw new ArgumentException("Top-K windows require at least topK + 1 points to evaluate.", nameof(ordered));
+        }
+
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            var neighbors = CollectNeighbors(ordered, i, topK);
+            neighbors.Count.Should().Be(topK, $"point at Morton rank {i} should expose exactly {topK} neighbors");
+            neighbors.Select(point => point.MortonCode).Should().OnlyHaveUniqueItems("neighbor Morton codes should remain unique");
+        }
+    }
+
+    private static IReadOnlyList<LocalityPoint> CollectNeighbors(IReadOnlyList<LocalityPoint> ordered, int rank, int topK)
+    {
+        var neighbors = new List<LocalityPoint>(topK);
+        var left = rank - 1;
+        var right = rank + 1;
+
+        while (neighbors.Count < topK && (left >= 0 || right < ordered.Count))
+        {
+            if (left >= 0)
+            {
+                neighbors.Add(ordered[left]);
+                left--;
+                if (neighbors.Count == topK)
+                {
+                    break;
+                }
+            }
+
+            if (right < ordered.Count)
+            {
+                neighbors.Add(ordered[right]);
+                right++;
+            }
+        }
+
+        return neighbors;
+    }
+}

--- a/LiteDB.Spatial.Core.Tests/fixtures/uniform_2d_precision8.json
+++ b/LiteDB.Spatial.Core.Tests/fixtures/uniform_2d_precision8.json
@@ -1,0 +1,8 @@
+{
+  "id": "uniform_2d_precision8",
+  "dimensions": 2,
+  "precisionBits": 8,
+  "shape": [16, 16],
+  "min": [0.0, 0.0],
+  "max": [1.0, 1.0]
+}

--- a/LiteDB.Spatial.Core.Tests/fixtures/uniform_3d_precision6.json
+++ b/LiteDB.Spatial.Core.Tests/fixtures/uniform_3d_precision6.json
@@ -1,0 +1,8 @@
+{
+  "id": "uniform_3d_precision6",
+  "dimensions": 3,
+  "precisionBits": 6,
+  "shape": [8, 8, 8],
+  "min": [0.0, 0.0, 0.0],
+  "max": [1.0, 1.0, 1.0]
+}

--- a/docs/Spatial-Revamp/Testing-Task.md
+++ b/docs/Spatial-Revamp/Testing-Task.md
@@ -145,7 +145,7 @@ git commit -m "FsCheck: base pr-84 + runner (pr-82) + plan coverage (pr-83) + si
 
 ---
 
-- [ ] **4) Differential Cartesian3D — base on `pr-87`, add fixtures (85), tolerance helpers (88), diagnostics (89)** *(in progress: merged lattice fixtures, upgraded diagnostics, added tuple-aware MathNet oracle; pending tolerance finalization + commit drop-in)*
+- [x] **4) Differential Cartesian3D — base on `pr-87`, add fixtures (85), tolerance helpers (88), diagnostics (89)**
 
 * Rationale: strongest API-level harness = `pr-87`; bring uncapped+mixed fixtures from `pr-85`; adopt scale-aware tolerance helpers from `pr-88`; surface `SpatialCoveringDiagnostics` and engine-vs-oracle parity from `pr-89`. 
 
@@ -180,7 +180,7 @@ git commit -m "Cartesian3D Differential: base pr-87 + fixtures (pr-85) + scale-a
 
 ---
 
-- [ ] **5) Synthetic Grid Locality — base on `pr-93`, add span metrics (90), uniqueness + top-K checks (92)**
+- [x] **5) Synthetic Grid Locality — base on `pr-93`, add span metrics (90), uniqueness + top-K checks (92)**
 
 * Rationale: `pr-93` offers the best generator+metrics+compact fixtures; add span metrics from `pr-90`; import uniqueness and constant neighborhood checks from `pr-92`; drop `pr-91`. 
 
@@ -213,7 +213,7 @@ git commit -m "Synthetic Grid Locality: base pr-93 + span metrics (pr-90) + uniq
 
 ---
 
-- [ ] **6) Wire-up + consistency pass (traits, toggles, tolerances)**
+- [x] **6) Wire-up + consistency pass (traits, toggles, tolerances)**
 
 ```bash
 # Restore trait filtering & category discoverer (from pr-77/78 into the current tree)
@@ -233,7 +233,7 @@ git add -A && git commit -m "Align distance tolerances to documented budgets"
 
 ---
 
-- [ ] **7) CI sanity: run suites deterministically**
+- [x] **7) CI sanity: run suites deterministically**
 
 ```bash
 # Run all spatial tests on net8


### PR DESCRIPTION
## Summary
- add locality regression fixtures, metrics, and top-K assertions for the spatial locality suite
- centralize 3D tolerance handling and reuse shared earth-distance assertions
- ensure category traits fan-in to the "spatial" umbrella for aggregated test runs and mark tasklist progress

## Testing
- dotnet test LiteDB.Spatial.Core.Tests -f net8.0 --filter Category=spatial
- dotnet test LiteDB.Spatial.Core.Tests -f net8.0 --filter Category=oracle
- dotnet test LiteDB.Spatial.Core.Tests -f net8.0 --filter Category=geographic
- dotnet test LiteDB.Spatial.Core.Tests -f net8.0 --filter Category=property
- dotnet test LiteDB.Spatial.Core.Tests -f net8.0 --filter Category=differential
- dotnet test LiteDB.Spatial.Core.Tests -f net8.0 --filter Category=locality

------
https://chatgpt.com/codex/tasks/task_e_68ebd74b2124832a87040383fcc75fa2