### PR TITLE
Publish CI test reports

### DIFF
--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -65,6 +65,8 @@ jobs:
     name: Test (Linux ${{ matrix.item.display }})
     runs-on: ubuntu-latest
     needs: build-linux
+    env:
+      RESULTS_KEY: ${{ format('{0}-{1}', replace(replace(matrix.item.display, '.NET', 'dotnet'), ' ', '-'), matrix.item.framework) }}
     strategy:
       fail-fast: false
       matrix:
@@ -136,7 +138,7 @@ jobs:
         if: always()
         run: |
           set -euxo pipefail
-          results_dir="artifacts/${{ matrix.item.framework }}"
+          results_dir="artifacts/${RESULTS_KEY}"
           mkdir -p "${results_dir}"
 
           if compgen -G "LiteDB.Tests/TestResults/*.trx" > /dev/null; then
@@ -151,8 +153,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.item.framework }}
-          path: artifacts/${{ matrix.item.framework }}
+          name: test-results-${{ env.RESULTS_KEY }}
+          path: artifacts/${{ env.RESULTS_KEY }}
           if-no-files-found: ignore
 
   repro-runner:

--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -132,6 +132,29 @@ jobs:
           --logger "trx;LogFileName=SpatialCoreTests.trx"
           --logger "console;verbosity=detailed"
 
+      - name: Collect test results
+        if: always()
+        run: |
+          set -euxo pipefail
+          results_dir="artifacts/${{ matrix.item.framework }}"
+          mkdir -p "${results_dir}"
+
+          if compgen -G "LiteDB.Tests/TestResults/*.trx" > /dev/null; then
+            cp LiteDB.Tests/TestResults/*.trx "${results_dir}/"
+          fi
+
+          if [ -d LiteDB.Spatial.Core.Tests/TestResults ] && compgen -G "LiteDB.Spatial.Core.Tests/TestResults/*.trx" > /dev/null; then
+            cp LiteDB.Spatial.Core.Tests/TestResults/*.trx "${results_dir}/"
+          fi
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.item.framework }}
+          path: artifacts/${{ matrix.item.framework }}
+          if-no-files-found: ignore
+
   repro-runner:
     runs-on: ubuntu-latest
     needs: build-linux

--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -65,14 +65,25 @@ jobs:
     name: Test (Linux ${{ matrix.item.display }})
     runs-on: ubuntu-latest
     needs: build-linux
-    env:
-      RESULTS_KEY: ${{ format('{0}-{1}', replace(replace(matrix.item.display, '.NET', 'dotnet'), ' ', '-'), matrix.item.framework) }}
     strategy:
       fail-fast: false
       matrix:
         item: ${{ fromJson(inputs.sdk-matrix) }}
 
     steps:
+      - name: Compute results key
+        id: results
+        run: |
+          set -euo pipefail
+          display="${{ matrix.item.display }}"
+          framework="${{ matrix.item.framework }}"
+          key="${display//.NET/dotnet}"
+          key="${key// /-}"
+          key="${key//./-}"
+          key="${key,,}"
+          framework_key="${framework//./-}"
+          echo "RESULTS_KEY=${key}-${framework_key}" >> "$GITHUB_ENV"
+
       - name: Check out repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -2,7 +2,7 @@ name: Test Report
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["CI", "Reusable CI (Build & Test)"]
     types: [completed]
 
 permissions:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,27 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish test report
+        uses: dorny/test-reporter@v2
+        with:
+          artifact: /test-results-(.*)/
+          name: '.NET tests ($1)'
+          path: '**/*.trx'
+          reporter: dotnet-trx
+          use-actions-summary: true
+          fail-on-error: true
+          run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Summary
- upload .trx logs from each test matrix leg as artifacts in the reusable CI workflow
- add a workflow_run job that uses dorny/test-reporter to publish annotated .NET test results from CI

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ebee4365bc832aaa3a1c9ebf636850