### PR TITLE
Add GitHub test reporting for CI runs

### DIFF
--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -132,6 +132,26 @@ jobs:
           --logger "trx;LogFileName=SpatialCoreTests.trx"
           --logger "console;verbosity=detailed"
 
+      - name: Collect test result artifacts
+        if: always()
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          destination="artifacts/${{ matrix.item.framework }}"
+          mkdir -p "${destination}"
+          for file in LiteDB.Tests/TestResults/*.trx LiteDB.Spatial.Core.Tests/TestResults/*.trx; do
+            base_dir="$(basename "$(dirname "$file")")"
+            cp "$file" "${destination}/${base_dir}-$(basename "$file")"
+          done
+
+      - name: Upload test result artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.item.framework }}
+          path: artifacts/${{ matrix.item.framework }}
+          if-no-files-found: ignore
+
   repro-runner:
     runs-on: ubuntu-latest
     needs: build-linux

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,32 @@
+name: Test Report
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download test result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Publish test report
+        uses: dorny/test-reporter@v2
+        with:
+          artifact: /test-results-(.*)/
+          name: '.NET tests ($1)'
+          path: '*.trx'
+          reporter: dotnet-trx
+          use-actions-summary: true
+          fail-on-error: true


### PR DESCRIPTION
## Summary
- upload .trx outputs from each CI matrix test run so they persist as artifacts
- add a workflow_run reporter that converts the saved logs into annotated GitHub test reports

## Testing
- not run (workflow changes only)

------
https://chatgpt.com/codex/tasks/task_e_68ebee4365bc832aaa3a1c9ebf636850