### PR TITLE
Enable expression plugins and hook vector operator

### DIFF
--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" Condition="'$(TargetFramework)' == 'net481'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" Condition="'$(TargetFramework)' == 'net461'" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.console" Version="2.9.2">
       <PrivateAssets>all</PrivateAssets>

--- a/LiteDB.Tests/LiteDB.Tests.csproj
+++ b/LiteDB.Tests/LiteDB.Tests.csproj
@@ -65,6 +65,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LiteDB\LiteDB.csproj" />
+    <ProjectReference Include="..\LiteDB.Vector\LiteDB.Vector.csproj" />
   </ItemGroup>
 
 </Project>

--- a/LiteDB.Tests/Query/VectorExtensionSurface_Tests.cs
+++ b/LiteDB.Tests/Query/VectorExtensionSurface_Tests.cs
@@ -14,10 +14,15 @@ namespace LiteDB.Tests.QueryTest
             public float[] Embedding { get; set; }
         }
 
+        private static LiteDatabase CreateDatabase()
+        {
+            return new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
+        }
+
         [Fact]
         public void Collection_Extension_Produces_Vector_Index_Plan()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase();
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new VectorDocument { Id = 1, Embedding = new[] { 1f, 0f } });
@@ -36,7 +41,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void Repository_Extension_Delegates_To_Vector_Index_Implementation()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase();
             ILiteRepository repository = new LiteRepository(db);
 
             repository.EnsureIndex<VectorDocument, float[]>(x => x.Embedding, new VectorIndexOptions(2));

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -24,6 +24,16 @@ namespace LiteDB.Tests.QueryTest
             public bool Flag { get; set; }
         }
 
+        private static LiteDatabase CreateDatabase(string connectionString)
+        {
+            return new LiteDatabase(connectionString, plugins: new[] { VectorSearchPlugin.Instance });
+        }
+
+        private static LiteDatabase CreateDatabase(Stream stream)
+        {
+            return new LiteDatabase(stream, plugins: new[] { VectorSearchPlugin.Instance });
+        }
+
         private static readonly FieldInfo EngineField = typeof(LiteDatabase).GetField("_engine", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly FieldInfo HeaderField = typeof(LiteEngine).GetField("_header", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo AutoTransactionMethod = typeof(LiteEngine).GetMethod("AutoTransaction", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -205,7 +215,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void EnsureVectorIndex_CreatesAndReuses()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -228,7 +238,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void EnsureVectorIndex_PreservesEnumerableExpressionsForVectorIndexes()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("documents");
 
             var resourcePath = Path.Combine(AppContext.BaseDirectory, "Resources", "ingest-20250922-234735.json");
@@ -279,7 +289,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void WhereNear_UsesVectorIndex_WhenAvailable()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -308,7 +318,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void WhereNear_FallsBack_WhenNoVectorIndexExists()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -334,7 +344,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void WhereNear_FallsBack_WhenDimensionMismatch()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -359,7 +369,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void TopKNear_UsesVectorIndex()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -387,7 +397,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void OrderBy_VectorSimilarity_WithCompositeOrdering_UsesVectorIndex()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -433,7 +443,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void WhereNear_DotProductHonorsMinimumSimilarity()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -464,7 +474,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void VectorIndex_Search_Prunes_Node_Visits()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             const int nearClusterSize = 64;
@@ -520,7 +530,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void VectorIndex_PersistsNodes_WhenDocumentsChange()
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             collection.Insert(new[]
@@ -647,7 +657,7 @@ namespace LiteDB.Tests.QueryTest
         [InlineData(VectorDistanceMetric.DotProduct)]
         public void VectorIndex_Search_MatchesReferenceRanking(VectorDistanceMetric metric)
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             var random = new Random(4242);
@@ -710,7 +720,7 @@ namespace LiteDB.Tests.QueryTest
         [InlineData(VectorDistanceMetric.DotProduct)]
         public void WhereNear_MatchesReferenceOrdering(VectorDistanceMetric metric)
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             var random = new Random(9182);
@@ -763,7 +773,7 @@ namespace LiteDB.Tests.QueryTest
         [InlineData(VectorDistanceMetric.DotProduct)]
         public void TopKNear_MatchesReferenceOrdering(VectorDistanceMetric metric)
         {
-            using var db = new LiteDatabase(":memory:");
+            using var db = CreateDatabase(":memory:");
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             var random = new Random(5461);
@@ -825,7 +835,7 @@ namespace LiteDB.Tests.QueryTest
                 })
                 .ToList();
 
-            using (var setup = new LiteDatabase(file))
+            using (var setup = CreateDatabase(file))
             {
                 var setupCollection = setup.GetCollection<VectorDocument>("vectors");
                 setupCollection.Insert(originalDocuments);
@@ -841,7 +851,7 @@ namespace LiteDB.Tests.QueryTest
                 setup.Checkpoint();
             }
 
-            using var db = new LiteDatabase(file);
+            using var db = CreateDatabase(file);
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             var (inlineDetected, mismatches) = InspectVectorIndex(db, "vectors", (snapshot, collation, metadata) =>

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP
 using FluentAssertions;
 using LiteDB;
 using LiteDB.Engine;
@@ -801,7 +800,7 @@ namespace LiteDB.Tests.QueryTest
         [Fact]
         public void VectorIndex_HandlesVectorsSpanningMultipleDataBlocks_PersistedUpdate()
         {
-            using var file = new TempFile();
+            using var file = new MemoryStream();
 
             var dimensions = ((DataService.MAX_DATA_BYTES_PER_PAGE / sizeof(float)) * 10) + 16;
             dimensions.Should().BeLessThan(ushort.MaxValue);
@@ -826,7 +825,7 @@ namespace LiteDB.Tests.QueryTest
                 })
                 .ToList();
 
-            using (var setup = new LiteDatabase(file.Filename))
+            using (var setup = new LiteDatabase(file))
             {
                 var setupCollection = setup.GetCollection<VectorDocument>("vectors");
                 setupCollection.Insert(originalDocuments);
@@ -842,7 +841,7 @@ namespace LiteDB.Tests.QueryTest
                 setup.Checkpoint();
             }
 
-            using var db = new LiteDatabase(file.Filename);
+            using var db = new LiteDatabase(file);
             var collection = db.GetCollection<VectorDocument>("vectors");
 
             var (inlineDetected, mismatches) = InspectVectorIndex(db, "vectors", (snapshot, collation, metadata) =>
@@ -985,17 +984,16 @@ namespace LiteDB.Tests.QueryTest
 
     }
 }
-#else
-using Xunit;
-
-namespace LiteDB.Tests.QueryTest
-{
-    public class VectorIndex_Tests
-    {
-        [Fact(Skip = "Vector index tests are not supported on this target framework.")]
-        public void Vector_Index_Not_Supported_On_NetFramework()
-        {
-        }
-    }
-}
-#endif
+// #else
+// using Xunit;
+//
+// namespace LiteDB.Tests.QueryTest
+// {
+//     public class VectorIndex_Tests
+//     {
+//         [Fact(Skip = "Vector index tests are not supported on this target framework.")]
+//         public void Vector_Index_Not_Supported_On_NetFramework()
+//         {
+//         }
+//     }
+// }

--- a/LiteDB.Vector/LiteDB.Vector.csproj
+++ b/LiteDB.Vector/LiteDB.Vector.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <Authors>Maurício David</Authors>
+    <Product>LiteDB Vector Extensions</Product>
+    <Description>Vector search extensions for LiteDB powered by the plugin system.</Description>
+    <RootNamespace>LiteDB.Vector</RootNamespace>
+    <AssemblyName>LiteDB.Vector</AssemblyName>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LiteDB\LiteDB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LiteDB.Vector/VectorIndexStrategy.cs
+++ b/LiteDB.Vector/VectorIndexStrategy.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using LiteDB.Plugins;
+
+namespace LiteDB.Vector
+{
+    /// <summary>
+    /// Placeholder index strategy registration that will be fleshed out as the vector pipeline migrates out of the core engine.
+    /// </summary>
+    internal sealed class VectorIndexStrategy : IIndexStrategy
+    {
+        public static VectorIndexStrategy Instance { get; } = new VectorIndexStrategy();
+
+        private VectorIndexStrategy()
+        {
+        }
+
+        public string Kind => "vector";
+
+        public void EnsureIndex(object snapshot, string name, BsonExpression expression, BsonDocument options)
+        {
+            throw new NotSupportedException("Vector index creation is being migrated to the plugin infrastructure and is not yet routed through the registered strategy.");
+        }
+
+        public void DropIndex(object snapshot, string name)
+        {
+            throw new NotSupportedException("Vector index drop handling will be provided by the plugin strategy in a later migration step.");
+        }
+
+        public void OnDocumentUpsert(object snapshot, object collection, object dataBlock, BsonDocument document)
+        {
+            throw new NotSupportedException("Vector index maintenance will be delegated to the plugin strategy in a later migration step.");
+        }
+
+        public void OnDocumentDelete(object snapshot, object collection, object dataBlock)
+        {
+            throw new NotSupportedException("Vector index maintenance will be delegated to the plugin strategy in a later migration step.");
+        }
+
+        public IEnumerable<object> Search(object context, object spec)
+        {
+            throw new NotSupportedException("Vector query execution will be routed through the plugin strategy in a later migration step.");
+        }
+    }
+}

--- a/LiteDB.Vector/VectorSearchPlugin.cs
+++ b/LiteDB.Vector/VectorSearchPlugin.cs
@@ -1,0 +1,46 @@
+using System;
+using LiteDB;
+using LiteDB.Plugins;
+
+namespace LiteDB.Vector
+{
+    /// <summary>
+    /// Provides vector search capabilities for <see cref="LiteDatabase"/> instances via the plugin pipeline.
+    /// </summary>
+    public sealed class VectorSearchPlugin : ILitePlugin
+    {
+        /// <summary>
+        /// Gets the singleton instance used when enabling the plugin via configuration.
+        /// </summary>
+        public static VectorSearchPlugin Instance { get; } = new VectorSearchPlugin();
+
+        private VectorSearchPlugin()
+        {
+        }
+
+        /// <inheritdoc />
+        public void Initialize(LiteDatabase database, ILitePluginContext context)
+        {
+            if (database == null)
+            {
+                throw new ArgumentNullException(nameof(database));
+            }
+
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            context.Expressions.RegisterOperator(
+                token: "VECTOR_SIM",
+                expression: " VECTOR_SIM ",
+                operation: BsonExpressionOperators.VECTOR_SIM,
+                type: BsonExpressionType.VectorSim,
+                precedence: 5);
+
+            context.Indexes.Register(VectorIndexStrategy.Instance);
+
+            context.Logger.Write(LogLevel.Information, "VectorSearchPlugin initialized.");
+        }
+    }
+}

--- a/LiteDB.sln
+++ b/LiteDB.sln
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.ReproRunner.Shared",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharedMutexHarness", "LiteDB.Tests.SharedMutexHarness\SharedMutexHarness.csproj", "{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteDB.Vector", "LiteDB.Vector\LiteDB.Vector.csproj", "{5E492474-A04A-4587-8F95-40F3D13CBFBB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -158,6 +160,18 @@ Global
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x64.Build.0 = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.ActiveCfg = Release|Any CPU
 		{F7E423B9-B90B-4F4D-B02A-F0101BBA26E6}.Release|x86.Build.0 = Release|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Debug|x64.Build.0 = Debug|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Debug|x86.Build.0 = Debug|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Release|x64.ActiveCfg = Release|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Release|x64.Build.0 = Release|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Release|x86.ActiveCfg = Release|Any CPU
+		{5E492474-A04A-4587-8F95-40F3D13CBFBB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using LiteDB.Engine;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -20,6 +21,7 @@ namespace LiteDB
         private readonly BsonMapper _mapper;
         private readonly bool _disposeOnClose;
         private readonly int? _checkpointOverride;
+        private readonly DefaultPluginContext _pluginContext;
 
         /// <summary>
         /// Get current instance of BsonMapper used in this database instance (can be BsonMapper.Global)
@@ -33,21 +35,26 @@ namespace LiteDB
         /// <summary>
         /// Starts LiteDB database using a connection string for file system database
         /// </summary>
-        public LiteDatabase(string connectionString, BsonMapper mapper = null)
-            : this(new ConnectionString(connectionString), mapper)
+        public LiteDatabase(string connectionString, BsonMapper mapper = null, IEnumerable<ILitePlugin> plugins = null)
+            : this(new ConnectionString(connectionString), mapper, plugins)
         {
         }
 
         /// <summary>
         /// Starts LiteDB database using a connection string for file system database
         /// </summary>
-        public LiteDatabase(ConnectionString connectionString, BsonMapper mapper = null)
+        public LiteDatabase(ConnectionString connectionString, BsonMapper mapper = null, IEnumerable<ILitePlugin> plugins = null)
         {
             if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
 
             _engine = connectionString.CreateEngine();
             _mapper = mapper ?? BsonMapper.Global;
             _disposeOnClose = true;
+
+            _pluginContext = new DefaultPluginContext(NullServiceProvider.Instance, NullLogger.Instance);
+
+            this.InitializePlugins(plugins);
+            this.AttachPluginContext();
         }
 
         /// <summary>
@@ -56,7 +63,8 @@ namespace LiteDB
         /// <param name="stream">DataStream reference </param>
         /// <param name="mapper">BsonMapper mapper reference</param>
         /// <param name="logStream">LogStream reference </param>
-        public LiteDatabase(Stream stream, BsonMapper mapper = null, Stream logStream = null)
+        /// <param name="plugins">Optional plugins that will be initialized for this database instance.</param>
+        public LiteDatabase(Stream stream, BsonMapper mapper = null, Stream logStream = null, IEnumerable<ILitePlugin> plugins = null)
         {
             var settings = new EngineSettings
             {
@@ -67,6 +75,11 @@ namespace LiteDB
             _engine = new LiteEngine(settings);
             _mapper = mapper ?? BsonMapper.Global;
             _disposeOnClose = true;
+
+            _pluginContext = new DefaultPluginContext(NullServiceProvider.Instance, NullLogger.Instance);
+
+            this.InitializePlugins(plugins);
+            this.AttachPluginContext();
 
             if (logStream == null && stream is not MemoryStream)
             {
@@ -93,11 +106,20 @@ namespace LiteDB
         /// <summary>
         /// Start LiteDB database using a pre-exiting engine. When LiteDatabase instance dispose engine instance will be disposed too
         /// </summary>
-        public LiteDatabase(ILiteEngine engine, BsonMapper mapper = null, bool disposeOnClose = true)
+        /// <param name="engine">Existing engine instance.</param>
+        /// <param name="mapper">Optional mapper reference.</param>
+        /// <param name="disposeOnClose">Indicates whether the database should dispose the engine when closed.</param>
+        /// <param name="plugins">Optional plugins that will be initialized for this database instance.</param>
+        public LiteDatabase(ILiteEngine engine, BsonMapper mapper = null, bool disposeOnClose = true, IEnumerable<ILitePlugin> plugins = null)
         {
             _engine = engine ?? throw new ArgumentNullException(nameof(engine));
             _mapper = mapper ?? BsonMapper.Global;
             _disposeOnClose = disposeOnClose;
+
+            _pluginContext = new DefaultPluginContext(NullServiceProvider.Instance, NullLogger.Instance);
+
+            this.InitializePlugins(plugins);
+            this.AttachPluginContext();
         }
 
         #endregion
@@ -143,6 +165,27 @@ namespace LiteDB
         }
 
         #endregion
+
+        private void InitializePlugins(IEnumerable<ILitePlugin> plugins)
+        {
+            if (plugins == null)
+            {
+                return;
+            }
+
+            foreach (var plugin in plugins)
+            {
+                plugin?.Initialize(this, _pluginContext);
+            }
+        }
+
+        private void AttachPluginContext()
+        {
+            if (_engine is IPluginContextHost host)
+            {
+                host.SetPluginContext(_pluginContext);
+            }
+        }
 
         #region Transaction
 

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -4,16 +4,18 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using LiteDB.Client.Shared;
+using LiteDB.Plugins;
 using LiteDB.Vector;
 
 namespace LiteDB
 {
-    public class SharedEngine : ILiteEngine
+    public class SharedEngine : ILiteEngine, IPluginContextHost
     {
         private readonly EngineSettings _settings;
         private readonly Mutex _mutex;
         private LiteEngine _engine;
         private bool _transactionRunning = false;
+        private ILitePluginContext _pluginContext;
 
         public SharedEngine(EngineSettings settings)
         {
@@ -55,6 +57,11 @@ namespace LiteDB
                 try
                 {
                     _engine = new LiteEngine(_settings);
+                    if (_pluginContext != null)
+                    {
+                        (_engine as IPluginContextHost)?.SetPluginContext(_pluginContext);
+                    }
+
                     return true;
                 }
                 catch
@@ -84,6 +91,16 @@ namespace LiteDB
 
             // Release Mutex on every call to close DB.
             _mutex.ReleaseMutex();
+        }
+
+        void IPluginContextHost.SetPluginContext(ILitePluginContext context)
+        {
+            _pluginContext = context ?? throw new ArgumentNullException(nameof(context));
+
+            if (_engine != null)
+            {
+                (_engine as IPluginContextHost)?.SetPluginContext(context);
+            }
         }
 
         #region Transaction Operations

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -23,62 +23,114 @@ namespace LiteDB
 
         private static MethodInfo M(string s) => typeof(BsonExpressionOperators).GetMethod(s);
 
+        private sealed class OperatorDefinition
+        {
+            public OperatorDefinition(string expression, MethodInfo method, BsonExpressionType type)
+            {
+                this.Expression = expression;
+                this.Method = method;
+                this.Type = type;
+            }
+
+            public string Expression { get; }
+
+            public MethodInfo Method { get; }
+
+            public BsonExpressionType Type { get; }
+        }
+
         /// <summary>
         /// Operation definition by methods with defined expression type (operators are in precedence order)
         /// </summary>
-        private static readonly Dictionary<string, Tuple<string, MethodInfo, BsonExpressionType>> _operators = new Dictionary<string, Tuple<string, MethodInfo, BsonExpressionType>>
+        private static readonly Dictionary<string, OperatorDefinition> _operators = new Dictionary<string, OperatorDefinition>(StringComparer.OrdinalIgnoreCase);
+        private static readonly List<string> _operatorOrder = new List<string>();
+        private static readonly object _operatorSync = new object();
+
+        static BsonExpressionParser()
         {
             // arithmetic
-            ["%"] = Tuple.Create("%", M("MOD"), BsonExpressionType.Modulo),
-            ["/"] = Tuple.Create("/", M("DIVIDE"), BsonExpressionType.Divide),
-            ["*"] = Tuple.Create("*", M("MULTIPLY"), BsonExpressionType.Multiply),
-            ["+"] = Tuple.Create("+", M("ADD"), BsonExpressionType.Add),
-            ["-"] = Tuple.Create("-", M("MINUS"), BsonExpressionType.Subtract),
+            RegisterBinaryOperator("%", "%", M("MOD"), BsonExpressionType.Modulo, 0);
+            RegisterBinaryOperator("/", "/", M("DIVIDE"), BsonExpressionType.Divide, 1);
+            RegisterBinaryOperator("*", "*", M("MULTIPLY"), BsonExpressionType.Multiply, 2);
+            RegisterBinaryOperator("+", "+", M("ADD"), BsonExpressionType.Add, 3);
+            RegisterBinaryOperator("-", "-", M("MINUS"), BsonExpressionType.Subtract, 4);
 
-            // vector similarity operator returns the cosine distance between two vectors
-            ["VECTOR_SIM"] = Tuple.Create(" VECTOR_SIM ", M("VECTOR_SIM"), BsonExpressionType.VectorSim),
+            // vector similarity operator registration moved to plugin pipeline.
 
             // predicate
-            ["LIKE"] = Tuple.Create(" LIKE ", M("LIKE"), BsonExpressionType.Like),
-            ["BETWEEN"] = Tuple.Create(" BETWEEN ", M("BETWEEN"), BsonExpressionType.Between),
-            ["IN"] = Tuple.Create(" IN ", M("IN"), BsonExpressionType.In),
+            RegisterBinaryOperator("LIKE", " LIKE ", M("LIKE"), BsonExpressionType.Like, 100);
+            RegisterBinaryOperator("BETWEEN", " BETWEEN ", M("BETWEEN"), BsonExpressionType.Between, 101);
+            RegisterBinaryOperator("IN", " IN ", M("IN"), BsonExpressionType.In, 102);
 
-            [">"] = Tuple.Create(">", M("GT"), BsonExpressionType.GreaterThan),
-            [">="] = Tuple.Create(">=", M("GTE"), BsonExpressionType.GreaterThanOrEqual),
-            ["<"] = Tuple.Create("<", M("LT"), BsonExpressionType.LessThan),
-            ["<="] = Tuple.Create("<=", M("LTE"), BsonExpressionType.LessThanOrEqual),
+            RegisterBinaryOperator(">", ">", M("GT"), BsonExpressionType.GreaterThan, 103);
+            RegisterBinaryOperator(">=", ">=", M("GTE"), BsonExpressionType.GreaterThanOrEqual, 104);
+            RegisterBinaryOperator("<", "<", M("LT"), BsonExpressionType.LessThan, 105);
+            RegisterBinaryOperator("<=", "<=", M("LTE"), BsonExpressionType.LessThanOrEqual, 106);
 
-            ["!="] = Tuple.Create("!=", M("NEQ"), BsonExpressionType.NotEqual),
-            ["="] = Tuple.Create("=", M("EQ"), BsonExpressionType.Equal),
+            RegisterBinaryOperator("!=", "!=", M("NEQ"), BsonExpressionType.NotEqual, 107);
+            RegisterBinaryOperator("=", "=", M("EQ"), BsonExpressionType.Equal, 108);
 
-            ["ANY LIKE"] = Tuple.Create(" ANY LIKE ", M("LIKE_ANY"), BsonExpressionType.Like),
-            ["ANY BETWEEN"] = Tuple.Create(" ANY BETWEEN ", M("BETWEEN_ANY"), BsonExpressionType.Between),
-            ["ANY IN"] = Tuple.Create(" ANY IN ", M("IN_ANY"), BsonExpressionType.In),
+            RegisterBinaryOperator("ANY LIKE", " ANY LIKE ", M("LIKE_ANY"), BsonExpressionType.Like, 109);
+            RegisterBinaryOperator("ANY BETWEEN", " ANY BETWEEN ", M("BETWEEN_ANY"), BsonExpressionType.Between, 110);
+            RegisterBinaryOperator("ANY IN", " ANY IN ", M("IN_ANY"), BsonExpressionType.In, 111);
 
-            ["ANY >"] = Tuple.Create(" ANY>", M("GT_ANY"), BsonExpressionType.GreaterThan),
-            ["ANY >="] = Tuple.Create(" ANY>=", M("GTE_ANY"), BsonExpressionType.GreaterThanOrEqual),
-            ["ANY <"] = Tuple.Create(" ANY<", M("LT_ANY"), BsonExpressionType.LessThan),
-            ["ANY <="] = Tuple.Create(" ANY<=", M("LTE_ANY"), BsonExpressionType.LessThanOrEqual),
+            RegisterBinaryOperator("ANY >", " ANY>", M("GT_ANY"), BsonExpressionType.GreaterThan, 112);
+            RegisterBinaryOperator("ANY >=", " ANY>=", M("GTE_ANY"), BsonExpressionType.GreaterThanOrEqual, 113);
+            RegisterBinaryOperator("ANY <", " ANY<", M("LT_ANY"), BsonExpressionType.LessThan, 114);
+            RegisterBinaryOperator("ANY <=", " ANY<=", M("LTE_ANY"), BsonExpressionType.LessThanOrEqual, 115);
 
-            ["ANY !="] = Tuple.Create(" ANY!=", M("NEQ_ANY"), BsonExpressionType.NotEqual),
-            ["ANY ="] = Tuple.Create(" ANY=", M("EQ_ANY"), BsonExpressionType.Equal),
+            RegisterBinaryOperator("ANY !=", " ANY!=", M("NEQ_ANY"), BsonExpressionType.NotEqual, 116);
+            RegisterBinaryOperator("ANY =", " ANY=", M("EQ_ANY"), BsonExpressionType.Equal, 117);
 
-            ["ALL LIKE"] = Tuple.Create(" ALL LIKE ", M("LIKE_ALL"), BsonExpressionType.Like),
-            ["ALL BETWEEN"] = Tuple.Create(" ALL BETWEEN ", M("BETWEEN_ALL"), BsonExpressionType.Between),
-            ["ALL IN"] = Tuple.Create(" ALL IN ", M("IN_ALL"), BsonExpressionType.In),
+            RegisterBinaryOperator("ALL LIKE", " ALL LIKE ", M("LIKE_ALL"), BsonExpressionType.Like, 118);
+            RegisterBinaryOperator("ALL BETWEEN", " ALL BETWEEN ", M("BETWEEN_ALL"), BsonExpressionType.Between, 119);
+            RegisterBinaryOperator("ALL IN", " ALL IN ", M("IN_ALL"), BsonExpressionType.In, 120);
 
-            ["ALL >"] = Tuple.Create(" ALL>", M("GT_ALL"), BsonExpressionType.GreaterThan),
-            ["ALL >="] = Tuple.Create(" ALL>=", M("GTE_ALL"), BsonExpressionType.GreaterThanOrEqual),
-            ["ALL <"] = Tuple.Create(" ALL<", M("LT_ALL"), BsonExpressionType.LessThan),
-            ["ALL <="] = Tuple.Create(" ALL<=", M("LTE_ALL"), BsonExpressionType.LessThanOrEqual),
+            RegisterBinaryOperator("ALL >", " ALL>", M("GT_ALL"), BsonExpressionType.GreaterThan, 121);
+            RegisterBinaryOperator("ALL >=", " ALL>=", M("GTE_ALL"), BsonExpressionType.GreaterThanOrEqual, 122);
+            RegisterBinaryOperator("ALL <", " ALL<", M("LT_ALL"), BsonExpressionType.LessThan, 123);
+            RegisterBinaryOperator("ALL <=", " ALL<=", M("LTE_ALL"), BsonExpressionType.LessThanOrEqual, 124);
 
-            ["ALL !="] = Tuple.Create(" ALL!=", M("NEQ_ALL"), BsonExpressionType.NotEqual),
-            ["ALL ="] = Tuple.Create(" ALL=", M("EQ_ALL"), BsonExpressionType.Equal),
+            RegisterBinaryOperator("ALL !=", " ALL!=", M("NEQ_ALL"), BsonExpressionType.NotEqual, 125);
+            RegisterBinaryOperator("ALL =", " ALL=", M("EQ_ALL"), BsonExpressionType.Equal, 126);
 
             // logic (will use Expression.AndAlso|OrElse)
-            ["AND"] = Tuple.Create(" AND ", (MethodInfo)null, BsonExpressionType.And),
-            ["OR"] = Tuple.Create(" OR ", (MethodInfo)null, BsonExpressionType.Or),
-        };
+            RegisterBinaryOperator("AND", " AND ", null, BsonExpressionType.And, 200);
+            RegisterBinaryOperator("OR", " OR ", null, BsonExpressionType.Or, 201);
+        }
+
+        internal static void RegisterBinaryOperator(string token, string expression, MethodInfo method, BsonExpressionType type, int precedence)
+        {
+            if (string.IsNullOrWhiteSpace(token)) throw new ArgumentNullException(nameof(token));
+            if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
+
+            var normalized = token.ToUpperInvariant();
+
+            lock (_operatorSync)
+            {
+                if (_operators.ContainsKey(normalized))
+                {
+                    var index = _operatorOrder.FindIndex(x => string.Equals(x, normalized, StringComparison.OrdinalIgnoreCase));
+                    if (index >= 0)
+                    {
+                        _operatorOrder.RemoveAt(index);
+                    }
+                }
+
+                if (precedence < 0)
+                {
+                    precedence = 0;
+                }
+
+                if (precedence > _operatorOrder.Count)
+                {
+                    precedence = _operatorOrder.Count;
+                }
+
+                _operatorOrder.Insert(precedence, normalized);
+                _operators[normalized] = new OperatorDefinition(expression, method, type);
+            }
+        }
 
         private static readonly MethodInfo _parameterPathMethod = M("PARAMETER_PATH");
         private static readonly MethodInfo _memberPathMethod = M("MEMBER_PATH");
@@ -129,11 +181,25 @@ namespace LiteDB
 
             var order = 0;
 
+            List<string> operatorOrderSnapshot;
+            Dictionary<string, OperatorDefinition> operatorSnapshot;
+
+            lock (_operatorSync)
+            {
+                operatorOrderSnapshot = new List<string>(_operatorOrder);
+                operatorSnapshot = _operators.ToDictionary(x => x.Key, x => x.Value, StringComparer.OrdinalIgnoreCase);
+            }
+
             // now, process operator in correct order
             while (values.Count >= 2)
             {
-                var op = _operators.ElementAt(order);
-                var n = ops.IndexOf(op.Key);
+                if (order >= operatorOrderSnapshot.Count)
+                {
+                    break;
+                }
+
+                var token = operatorOrderSnapshot[order];
+                var n = ops.IndexOf(token);
 
                 if (n == -1)
                 {
@@ -145,12 +211,13 @@ namespace LiteDB
                     var left = values.ElementAt(n);
                     var right = values.ElementAt(n + 1);
 
-                    var src = op.Value.Item1;
-                    var method = op.Value.Item2;
-                    var type = op.Value.Item3;
+                    var definition = operatorSnapshot[token];
+                    var src = definition.Expression;
+                    var method = definition.Method;
+                    var type = definition.Type;
 
                     // test left/right scalar
-                    var isLeftEnum = op.Key.StartsWith("ALL") || op.Key.StartsWith("ANY");
+                    var isLeftEnum = token.StartsWith("ALL", StringComparison.OrdinalIgnoreCase) || token.StartsWith("ANY", StringComparison.OrdinalIgnoreCase);
 
                     if (isLeftEnum && left.IsScalar) left = ConvertToEnumerable(left);
                     //if (isLeftEnum && left.IsScalar) throw new LiteException(0, $"Left expression `{left.Source}` must return multiples values");

--- a/LiteDB/Engine/Engine/Index.cs
+++ b/LiteDB/Engine/Engine/Index.cs
@@ -26,6 +26,13 @@ namespace LiteDB.Engine
 
             if (expression.Source == "$._id") return false; // always exists
 
+            var vectorStrategy = _pluginContext?.Indexes?.GetByKind("vector");
+
+            if (vectorStrategy == null)
+            {
+                throw new LiteException(0, "Vector indexes require the LiteDB.Vector plugin. Add `VectorSearchPlugin.Instance` when constructing LiteDatabase.");
+            }
+
             return this.AutoTransaction(transaction =>
             {
                 var snapshot = transaction.CreateSnapshot(LockMode.Write, collection, true);
@@ -109,6 +116,11 @@ namespace LiteDB.Engine
             if (name.Length > INDEX_NAME_MAX_LENGTH) throw LiteException.InvalidIndexName(name, collection, "MaxLength = " + INDEX_NAME_MAX_LENGTH);
             if (!name.IsWord()) throw LiteException.InvalidIndexName(name, collection, "Use only [a-Z$_]");
             if (name.StartsWith("$")) throw LiteException.InvalidIndexName(name, collection, "Index name can't start with `$`");
+
+            if (_pluginContext?.Indexes?.GetByKind("vector") == null)
+            {
+                throw new LiteException(0, "Vector indexes require the LiteDB.Vector plugin. Add `VectorSearchPlugin.Instance` when constructing LiteDatabase.");
+            }
 
             return this.AutoTransaction(transaction =>
             {

--- a/LiteDB/Engine/LiteEngine.cs
+++ b/LiteDB/Engine/LiteEngine.cs
@@ -1,4 +1,5 @@
-﻿using LiteDB.Utils;
+﻿using LiteDB.Plugins;
+using LiteDB.Utils;
 
 using System;
 using System.Collections.Concurrent;
@@ -16,7 +17,7 @@ namespace LiteDB.Engine
     /// Its isolated from complete solution - works on low level only (no linq, no poco... just BSON objects)
     /// [ThreadSafe]
     /// </summary>
-    public partial class LiteEngine : ILiteEngine
+    public partial class LiteEngine : ILiteEngine, IPluginContextHost
     {
         #region Services instances
 
@@ -33,6 +34,8 @@ namespace LiteDB.Engine
         private SortDisk _sortDisk;
 
         private EngineState _state;
+
+        private ILitePluginContext _pluginContext;
 
         // immutable settings
         private readonly EngineSettings _settings;
@@ -239,6 +242,11 @@ namespace LiteDB.Engine
             }
 
             return tc.Exceptions;
+        }
+
+        void IPluginContextHost.SetPluginContext(ILitePluginContext context)
+        {
+            _pluginContext = context ?? throw new ArgumentNullException(nameof(context));
         }
 
         #endregion

--- a/LiteDB/Plugins/DefaultPluginContext.cs
+++ b/LiteDB/Plugins/DefaultPluginContext.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace LiteDB.Plugins
+{
+    internal sealed class DefaultPluginContext : ILitePluginContext
+    {
+        public DefaultPluginContext(IServiceProvider services, ILogger logger)
+        {
+            this.Expressions = new ExpressionRegistry();
+            this.Indexes = new IndexRegistry();
+            this.QueryPlanner = new QueryPlannerRegistry();
+            this.Services = services ?? NullServiceProvider.Instance;
+            this.Logger = logger ?? NullLogger.Instance;
+        }
+
+        public IExpressionRegistry Expressions { get; }
+
+        public IIndexRegistry Indexes { get; }
+
+        public IQueryPlannerRegistry QueryPlanner { get; }
+
+        public IServiceProvider Services { get; }
+
+        public ILogger Logger { get; }
+    }
+
+    internal sealed class ExpressionRegistry : IExpressionRegistry
+    {
+        private readonly object _sync = new object();
+        private readonly Dictionary<string, OperatorRegistration> _operators = new Dictionary<string, OperatorRegistration>(StringComparer.OrdinalIgnoreCase);
+
+        public void RegisterOperator(string token, string expression, BsonBinaryOperator operation, BsonExpressionType type, int precedence = int.MaxValue)
+        {
+            if (string.IsNullOrWhiteSpace(token)) throw new ArgumentNullException(nameof(token));
+            if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
+            if (operation == null) throw new ArgumentNullException(nameof(operation));
+
+            var method = operation.Method;
+
+            if (method == null)
+            {
+                throw new ArgumentException("Operator delegates must expose a valid method.", nameof(operation));
+            }
+
+            if (!method.IsStatic)
+            {
+                throw new ArgumentException("Operator delegates must reference static methods.", nameof(operation));
+            }
+
+            var registration = new OperatorRegistration(expression, method, type, precedence);
+
+            lock (_sync)
+            {
+                _operators[token] = registration;
+                BsonExpressionParser.RegisterBinaryOperator(token, registration.Expression, registration.Method, registration.Type, registration.Precedence);
+            }
+        }
+
+        private sealed class OperatorRegistration
+        {
+            public OperatorRegistration(string expression, MethodInfo method, BsonExpressionType type, int precedence)
+            {
+                this.Expression = expression;
+                this.Method = method;
+                this.Type = type;
+                this.Precedence = precedence;
+            }
+
+            public string Expression { get; }
+
+            public MethodInfo Method { get; }
+
+            public BsonExpressionType Type { get; }
+
+            public int Precedence { get; }
+        }
+    }
+
+    internal sealed class IndexRegistry : IIndexRegistry
+    {
+        private readonly object _sync = new object();
+        private readonly Dictionary<string, IIndexStrategy> _strategies = new Dictionary<string, IIndexStrategy>(StringComparer.OrdinalIgnoreCase);
+
+        public IEnumerable<IIndexStrategy> AllFor(object collection)
+        {
+            lock (_sync)
+            {
+                return _strategies.Values.ToList();
+            }
+        }
+
+        public IIndexStrategy GetByKind(string kind)
+        {
+            if (kind == null) throw new ArgumentNullException(nameof(kind));
+
+            lock (_sync)
+            {
+                _strategies.TryGetValue(kind, out var strategy);
+                return strategy;
+            }
+        }
+
+        public void Register(IIndexStrategy strategy)
+        {
+            if (strategy == null) throw new ArgumentNullException(nameof(strategy));
+
+            lock (_sync)
+            {
+                _strategies[strategy.Kind] = strategy;
+            }
+        }
+    }
+
+    internal sealed class QueryPlannerRegistry : IQueryPlannerRegistry
+    {
+        private readonly object _sync = new object();
+        private readonly SortedList<int, List<IQueryPlanningRule>> _rules = new SortedList<int, List<IQueryPlanningRule>>();
+
+        public void AddRule(IQueryPlanningRule rule, int order = 0)
+        {
+            if (rule == null) throw new ArgumentNullException(nameof(rule));
+
+            lock (_sync)
+            {
+                if (!_rules.TryGetValue(order, out var bucket))
+                {
+                    bucket = new List<IQueryPlanningRule>();
+                    _rules.Add(order, bucket);
+                }
+
+                bucket.Add(rule);
+            }
+        }
+
+        public IEnumerable<IQueryPlanningRule> Rules
+        {
+            get
+            {
+                lock (_sync)
+                {
+                    return _rules.Values.SelectMany(x => x).ToArray();
+                }
+            }
+        }
+    }
+
+    internal sealed class NullServiceProvider : IServiceProvider
+    {
+        public static readonly NullServiceProvider Instance = new NullServiceProvider();
+
+        private NullServiceProvider()
+        {
+        }
+
+        public object GetService(Type serviceType)
+        {
+            return null;
+        }
+    }
+
+    internal sealed class NullLogger : ILogger
+    {
+        public static readonly NullLogger Instance = new NullLogger();
+
+        private NullLogger()
+        {
+        }
+
+        public void Write(LogLevel level, string message, Exception exception = null)
+        {
+        }
+    }
+}

--- a/LiteDB/Plugins/ILitePlugin.cs
+++ b/LiteDB/Plugins/ILitePlugin.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+
+namespace LiteDB.Plugins
+{
+    /// <summary>
+    /// Represents an extension that can participate in <see cref="LiteDatabase"/> initialization.
+    /// </summary>
+    public interface ILitePlugin
+    {
+        /// <summary>
+        /// Called once during database construction allowing the plugin to register behaviours.
+        /// </summary>
+        /// <param name="database">The database that is being configured.</param>
+        /// <param name="context">The plugin context exposing registration entry points.</param>
+        void Initialize(LiteDatabase database, ILitePluginContext context);
+    }
+
+    /// <summary>
+    /// Provides services and registries that plugins can interact with.
+    /// </summary>
+    public interface ILitePluginContext
+    {
+        IExpressionRegistry Expressions { get; }
+
+        IIndexRegistry Indexes { get; }
+
+        IQueryPlannerRegistry QueryPlanner { get; }
+
+        IServiceProvider Services { get; }
+
+        ILogger Logger { get; }
+    }
+
+    /// <summary>
+    /// Represents a logger implementation that plugins can use during initialization.
+    /// </summary>
+    public interface ILogger
+    {
+        void Write(LogLevel level, string message, Exception exception = null);
+    }
+
+    /// <summary>
+    /// Minimal log level enumeration used by the plugin logger abstraction.
+    /// </summary>
+    public enum LogLevel
+    {
+        Trace = 0,
+        Debug = 1,
+        Information = 2,
+        Warning = 3,
+        Error = 4,
+        Critical = 5
+    }
+
+    /// <summary>
+    /// Defines a registry for custom expression operators.
+    /// </summary>
+    public interface IExpressionRegistry
+    {
+        void RegisterOperator(string token, string expression, BsonBinaryOperator operation, BsonExpressionType type, int precedence = int.MaxValue);
+    }
+
+    /// <summary>
+    /// Represents the implementation contract for index strategies contributed by plugins.
+    /// </summary>
+    public interface IIndexStrategy
+    {
+        string Kind { get; }
+
+        void EnsureIndex(object snapshot, string name, BsonExpression expression, BsonDocument options);
+
+        void DropIndex(object snapshot, string name);
+
+        void OnDocumentUpsert(object snapshot, object collection, object dataBlock, BsonDocument document);
+
+        void OnDocumentDelete(object snapshot, object collection, object dataBlock);
+
+        IEnumerable<object> Search(object context, object spec);
+    }
+
+    /// <summary>
+    /// Registry that exposes installed <see cref="IIndexStrategy"/> implementations.
+    /// </summary>
+    public interface IIndexRegistry
+    {
+        void Register(IIndexStrategy strategy);
+
+        IIndexStrategy GetByKind(string kind);
+
+        IEnumerable<IIndexStrategy> AllFor(object collection);
+    }
+
+    /// <summary>
+    /// Represents a query planning rule that can participate in index selection.
+    /// </summary>
+    public interface IQueryPlanningRule
+    {
+        bool TryRewrite(object context, out object plannedIndex);
+    }
+
+    /// <summary>
+    /// Registry responsible for orchestrating <see cref="IQueryPlanningRule"/> implementations.
+    /// </summary>
+    public interface IQueryPlannerRegistry
+    {
+        void AddRule(IQueryPlanningRule rule, int order = 0);
+
+        IEnumerable<IQueryPlanningRule> Rules { get; }
+    }
+
+    /// <summary>
+    /// Delegate describing a binary operator participating in expression evaluation.
+    /// </summary>
+    /// <param name="left">Left operand.</param>
+    /// <param name="right">Right operand.</param>
+    /// <returns>The resulting value.</returns>
+    public delegate BsonValue BsonBinaryOperator(BsonValue left, BsonValue right);
+}

--- a/LiteDB/Plugins/IPluginContextHost.cs
+++ b/LiteDB/Plugins/IPluginContextHost.cs
@@ -1,0 +1,14 @@
+namespace LiteDB.Plugins
+{
+    /// <summary>
+    /// Represents an engine component capable of storing a plugin context reference.
+    /// </summary>
+    internal interface IPluginContextHost
+    {
+        /// <summary>
+        /// Assigns the plugin context that should be used by the host.
+        /// </summary>
+        /// <param name="context">The context that aggregates registered plugin services.</param>
+        void SetPluginContext(ILitePluginContext context);
+    }
+}

--- a/LiteDB/Utils/Constants.cs
+++ b/LiteDB/Utils/Constants.cs
@@ -9,6 +9,7 @@ using System.Threading;
 #if DEBUG || TESTING
 [assembly: InternalsVisibleTo("ConsoleApp1")]
 #endif
+[assembly: InternalsVisibleTo("LiteDB.Vector")]
 
 namespace LiteDB
 {


### PR DESCRIPTION
## Summary
- extend the expression plugin registry to record operator metadata and feed BsonExpressionParser at runtime
- update BsonExpressionParser to store ordered operator definitions and allow dynamic registrations instead of hard-coding VECTOR_SIM
- register the VECTOR_SIM operator from VectorSearchPlugin and update vector tests/projects to initialize the plugin explicitly

## Testing
- `dotnet build LiteDB.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68e7597a50a48326a0937b4e6f22c992