### PR TITLE
Propagate expression registries through collection pages

### DIFF
--- a/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
+++ b/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
@@ -124,11 +124,7 @@ public class BsonVector_Tests
         col.EnsureIndex(x => x.Embedding, new VectorIndexOptions(2));
 
         var target = new float[] { 1.0f, 0.0f };
-        BsonExpression fieldExpr;
-        using (db.EnterExpressionScope())
-        {
-            fieldExpr = BsonExpression.Create("$.Embedding");
-        }
+        var fieldExpr = BsonExpression.Create("$.Embedding", db.ExpressionRegistry);
 
         var results = col.Query()
             .WhereNear(fieldExpr, target, maxDistance: .28)
@@ -159,16 +155,12 @@ public class BsonVector_Tests
             ["Embedding"] = new BsonVector(new float[] { 1.0f, 1.0f })
         });
 
-        using (db.EnterExpressionScope())
-        {
-            col.EnsureIndex(
-                "embedding_idx",
-                BsonExpression.Create("$.Embedding"),
-                new VectorIndexOptions(2));
-        }
+        col.EnsureIndex(
+            "embedding_idx",
+            BsonExpression.Create("$.Embedding", db.ExpressionRegistry),
+            new VectorIndexOptions(2));
 
         var query = "SELECT * FROM vectors WHERE ($.Embedding VECTOR_SIM [1.0, 0.0]) <= 0.25";
-        using var _ = db.EnterExpressionScope();
         var rawResults = db.Execute(query).ToList();
 
         var docs = rawResults
@@ -196,11 +188,7 @@ public class BsonVector_Tests
     public void VectorSim_InfixExpression_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]");
-        }
+        var expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]", db.ExpressionRegistry);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 
@@ -219,11 +207,7 @@ public class BsonVector_Tests
     public void VectorSim_FunctionCall_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])");
-        }
+        var expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])", db.ExpressionRegistry);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -19,18 +19,12 @@ namespace LiteDB.Tests.QueryTest
     {
         private static BsonExpression CreateExpression(LiteDatabase db, string expression)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression);
-            }
+            return BsonExpression.Create(expression, db.ExpressionRegistry);
         }
 
         private static BsonExpression CreateExpression(LiteDatabase db, string expression, params BsonValue[] args)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression, args);
-            }
+            return BsonExpression.Create(expression, db.ExpressionRegistry, args);
         }
 
         private class VectorDocument

--- a/LiteDB/Client/Database/Collections/Aggregate.cs
+++ b/LiteDB/Client/Database/Collections/Aggregate.cs
@@ -33,10 +33,7 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Count(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -44,10 +41,7 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, args));
-            }
+            return this.Count(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
@@ -87,10 +81,7 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, parameters));
-            }
+            return this.LongCount(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -98,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, args));
-            }
+            return this.LongCount(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
@@ -133,10 +121,7 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Exists(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -144,10 +129,7 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, args));
-            }
+            return this.Exists(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/Collections/Delete.cs
+++ b/LiteDB/Client/Database/Collections/Delete.cs
@@ -39,10 +39,7 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, parameters));
-            }
+            return this.DeleteMany(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -50,10 +47,7 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, args));
-            }
+            return this.DeleteMany(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/Collections/Find.cs
+++ b/LiteDB/Client/Database/Collections/Find.cs
@@ -64,10 +64,7 @@ namespace LiteDB
         {
             if (id == null || id.IsNull) throw new ArgumentNullException(nameof(id));
 
-            using (this.EnterExpressionScope())
-            {
-                return this.Find(BsonExpression.Create("_id = @0", id)).FirstOrDefault();
-            }
+            return this.Find(BsonExpression.Create("_id = @0", _expressions, id)).FirstOrDefault();
         }
 
         /// <summary>
@@ -80,10 +77,7 @@ namespace LiteDB
         /// </summary>
         public T FindOne(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, parameters));
-            }
+            return this.FindOne(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -91,10 +85,7 @@ namespace LiteDB
         /// </summary>
         public T FindOne(BsonExpression predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, args));
-            }
+            return this.FindOne(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/ILiteDatabase.cs
+++ b/LiteDB/Client/Database/ILiteDatabase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using LiteDB.Engine;
+using LiteDB.Plugins;
 
 namespace LiteDB
 {
@@ -11,6 +12,11 @@ namespace LiteDB
         /// Get current instance of BsonMapper used in this database instance (can be BsonMapper.Global)
         /// </summary>
         BsonMapper Mapper { get; }
+
+        /// <summary>
+        /// Gets the expression registry associated with this database instance.
+        /// </summary>
+        IExpressionRegistry ExpressionRegistry { get; }
 
         /// <summary>
         /// Returns a special collection for storage files/stream inside datafile. Use _files and _chunks collection names. FileId is implemented as string. Use "GetStorage" for custom options

--- a/LiteDB/Client/Database/LiteCollection.cs
+++ b/LiteDB/Client/Database/LiteCollection.cs
@@ -32,11 +32,6 @@ namespace LiteDB
         /// </summary>
         public EntityMapper EntityMapper => _entity;
 
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_expressions);
-        }
-
         internal LiteCollection(string name, BsonAutoId autoId, ILiteEngine engine, BsonMapper mapper, IExpressionRegistry expressions)
         {
             _collection = name ?? mapper.ResolveCollectionName(typeof(T));
@@ -44,6 +39,8 @@ namespace LiteDB
             _mapper = mapper;
             _includes = new List<BsonExpression>();
             _expressions = expressions;
+
+            _mapper.ExpressionRegistry = expressions;
 
             // if strong typed collection, get _id member mapped (if exists)
             if (typeof(T) == typeof(BsonDocument))

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -28,6 +28,8 @@ namespace LiteDB
         /// </summary>
         public BsonMapper Mapper => _mapper;
 
+        public IExpressionRegistry ExpressionRegistry => _pluginContext.Expressions;
+
         #endregion
 
         #region Ctor
@@ -52,7 +54,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(connectionString, NullServiceProvider.Instance, NullLogger.Instance);
-
+            _mapper.ExpressionRegistry = _pluginContext.Expressions;
             this.InitializePlugins(plugins);
         }
 
@@ -76,7 +78,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
-
+            _mapper.ExpressionRegistry = _pluginContext.Expressions;
             this.InitializePlugins(plugins);
 
             if (logStream == null && stream is not MemoryStream)
@@ -115,7 +117,7 @@ namespace LiteDB
             _disposeOnClose = disposeOnClose;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
-
+            _mapper.ExpressionRegistry = _pluginContext.Expressions;
             this.InitializePlugins(plugins);
         }
 
@@ -159,11 +161,6 @@ namespace LiteDB
             if (name.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(name));
 
             return new LiteCollection<BsonDocument>(name, autoId, _engine, _mapper, _pluginContext.Expressions);
-        }
-
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_pluginContext.Expressions);
         }
 
         #endregion
@@ -298,8 +295,8 @@ namespace LiteDB
         {
             if (commandReader == null) throw new ArgumentNullException(nameof(commandReader));
 
-            var tokenizer = new Tokenizer(commandReader);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var tokenizer = new Tokenizer(commandReader, _pluginContext.Expressions);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;
@@ -312,8 +309,8 @@ namespace LiteDB
         {
             if (command == null) throw new ArgumentNullException(nameof(command));
 
-            var tokenizer = new Tokenizer(command);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var tokenizer = new Tokenizer(command, _pluginContext.Expressions);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -80,10 +80,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, BsonDocument parameters)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, parameters));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, parameters, _expressions));
             return this;
         }
 
@@ -92,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, params BsonValue[] args)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, args));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, _expressions, args));
             return this;
         }
 
@@ -260,18 +254,14 @@ namespace LiteDB
             ValidateVectorArguments(target, maxDistance);
 
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", targetArray, new BsonValue(maxDistance));
-            }
+            return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", _expressions, targetArray, new BsonValue(maxDistance));
         }
 
         internal ILiteQueryable<T> VectorWhereNear(string vectorField, float[] target, double maxDistance)
         {
             if (string.IsNullOrWhiteSpace(vectorField)) throw new ArgumentNullException(nameof(vectorField));
 
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{vectorField}");
+            var fieldExpr = BsonExpression.Create($"$.{vectorField}", _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
@@ -304,8 +294,7 @@ namespace LiteDB
 
         internal ILiteQueryableResult<T> VectorTopKNear(string field, float[] target, int k)
         {
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{field}");
+            var fieldExpr = BsonExpression.Create($"$.{field}", _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
@@ -318,18 +307,15 @@ namespace LiteDB
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
 
             // Build VECTOR_SIM as order clause
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", targetArray);
+            var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", _expressions, targetArray);
 
-                _query.VectorField = fieldExpr.Source;
-                _query.VectorTarget = target?.ToArray();
-                _query.VectorMaxDistance = double.MaxValue;
+            _query.VectorField = fieldExpr.Source;
+            _query.VectorTarget = target?.ToArray();
+            _query.VectorMaxDistance = double.MaxValue;
 
-                return this
-                    .OrderBy(simExpr, Query.Ascending)
-                    .Limit(k);
-            }
+            return this
+                .OrderBy(simExpr, Query.Ascending)
+                .Limit(k);
         }
 
         [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -100,6 +101,8 @@ namespace LiteDB
         /// </summary>
         public Func<Type, string> ResolveCollectionName;
 
+        internal IExpressionRegistry ExpressionRegistry { get; set; }
+
         #endregion
 
         public BsonMapper(Func<Type, object> customTypeInstantiator = null, ITypeNameBinder typeNameBinder = null)
@@ -113,6 +116,8 @@ namespace LiteDB
             this.ResolveCollectionName = (t) => Reflection.IsEnumerable(t) ? Reflection.GetListItemType(t).Name : t.Name;
             this.IncludeFields = false;
             this.MaxDepth = 20;
+
+            this.ExpressionRegistry = BsonExpression.DefaultRegistry;
 
             _typeInstantiator = customTypeInstantiator ?? ((Type t) => null);
             _typeNameBinder = typeNameBinder ?? DefaultTypeNameBinder.Instance;
@@ -169,7 +174,7 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            var visitor = new LinqExpressionVisitor(this, predicate, this.ExpressionRegistry);
 
             var expr = visitor.Resolve(typeof(K) == typeof(bool));
 
@@ -183,7 +188,7 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            var visitor = new LinqExpressionVisitor(this, predicate, this.ExpressionRegistry);
 
             var expr = visitor.Resolve(false);
 

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -38,6 +39,7 @@ namespace LiteDB
         private readonly BsonMapper _mapper;
         private readonly Expression _expr;
         private readonly ParameterExpression _rootParameter = null;
+        private readonly IExpressionRegistry _registry;
 
         private readonly BsonDocument _parameters = new BsonDocument();
         private int _paramIndex = 0;
@@ -46,10 +48,11 @@ namespace LiteDB
         private readonly StringBuilder _builder = new StringBuilder();
         private readonly Stack<Expression> _nodes = new Stack<Expression>();
 
-        public LinqExpressionVisitor(BsonMapper mapper, Expression expr)
+        public LinqExpressionVisitor(BsonMapper mapper, Expression expr, IExpressionRegistry registry)
         {
             _mapper = mapper;
             _expr = expr;
+            _registry = registry;
 
             if (expr is LambdaExpression lambda)
             {
@@ -71,14 +74,15 @@ namespace LiteDB
 
             try
             {
-                var e = BsonExpression.Create(expression, _parameters);
+                var registry = _registry ?? BsonExpression.DefaultRegistry;
+                var e = BsonExpression.Create(expression, _parameters, registry);
 
                 // if expression must return an predicate but expression result is Path/Parameter/Call add `= true`
                 if (predicate && (e.Type == BsonExpressionType.Path || e.Type == BsonExpressionType.Call || e.Type == BsonExpressionType.Parameter))
                 {
                     expression = "(" + expression + " = true)";
 
-                    e = BsonExpression.Create(expression, _parameters);
+                    e = BsonExpression.Create(expression, _parameters, registry);
                 }
 
                 return e;

--- a/LiteDB/Client/SqlParser/Commands/Create.cs
+++ b/LiteDB/Client/SqlParser/Commands/Create.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             _tokenizer.ReadToken().Expect(TokenType.OpenParenthesis);
 
             // read index expression
-            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument());
+            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument(), _expressions);
 
             // read )
             _tokenizer.ReadToken().Expect(TokenType.CloseParenthesis);

--- a/LiteDB/Client/SqlParser/Commands/Delete.cs
+++ b/LiteDB/Client/SqlParser/Commands/Delete.cs
@@ -24,7 +24,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             _tokenizer.ReadToken().Expect(TokenType.EOF, TokenType.SemiColon);

--- a/LiteDB/Client/SqlParser/Commands/ParseLists.cs
+++ b/LiteDB/Client/SqlParser/Commands/ParseLists.cs
@@ -16,7 +16,7 @@ namespace LiteDB
         {
             while(true)
             {
-                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 yield return expr;
 

--- a/LiteDB/Client/SqlParser/Commands/Select.cs
+++ b/LiteDB/Client/SqlParser/Commands/Select.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             token.Expect("SELECT");
 
             // read required SELECT <expr> and convert into single expression
-            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters);
+            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters, _expressions);
 
             // read FROM|INTO
             var from = _tokenizer.ReadToken();
@@ -88,7 +88,7 @@ namespace LiteDB
                 // read WHERE keyword
                 _tokenizer.ReadToken();
 
-                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.Where.Add(where);
             }
@@ -101,7 +101,7 @@ namespace LiteDB
                 _tokenizer.ReadToken();
                 _tokenizer.ReadToken().Expect("BY");
 
-                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.GroupBy = groupBy;
 
@@ -112,7 +112,7 @@ namespace LiteDB
                     // read HAVING keyword
                     _tokenizer.ReadToken();
 
-                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     query.Having = having;
                 }
@@ -128,7 +128,7 @@ namespace LiteDB
 
                 while (true)
                 {
-                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     var orderByOrder = Query.Ascending;
                     var orderByToken = _tokenizer.LookAhead();

--- a/LiteDB/Client/SqlParser/Commands/Update.cs
+++ b/LiteDB/Client/SqlParser/Commands/Update.cs
@@ -22,7 +22,7 @@ namespace LiteDB
             var collection = _tokenizer.ReadToken().Expect(TokenType.Word).Value;
             _tokenizer.ReadToken().Expect("SET");
 
-            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters);
+            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters, _expressions);
 
             // optional where
             BsonExpression where = null;
@@ -33,7 +33,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             // read eof

--- a/LiteDB/Client/SqlParser/SqlParser.cs
+++ b/LiteDB/Client/SqlParser/SqlParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using LiteDB.Engine;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -16,13 +17,15 @@ namespace LiteDB
         private readonly Tokenizer _tokenizer;
         private readonly BsonDocument _parameters;
         private readonly Lazy<Collation> _collation;
+        private readonly IExpressionRegistry _expressions;
 
-        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters)
+        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters, IExpressionRegistry expressions)
         {
             _engine = engine;
             _tokenizer = tokenizer;
             _parameters = parameters ?? new BsonDocument();
             _collation = new Lazy<Collation>(() => new Collation(_engine.Pragma(Pragmas.COLLATION)));
+            _expressions = expressions;
         }
 
         public IBsonDataReader Execute()

--- a/LiteDB/Client/Storage/LiteStorage.cs
+++ b/LiteDB/Client/Storage/LiteStorage.cs
@@ -68,12 +68,12 @@ namespace LiteDB
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters, _db.ExpressionRegistry));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, args));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, _db.ExpressionRegistry, args));
 
         /// <summary>
         /// Find all files that match with predicate expression.

--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -8,7 +8,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
+using System.Runtime.CompilerServices;
 using LiteDB.Plugins;
 using static LiteDB.Constants;
 
@@ -126,16 +126,7 @@ namespace LiteDB
         /// </summary>
         private BsonExpressionScalarDelegate _funcScalar;
 
-        private static readonly AsyncLocal<IExpressionRegistry> _currentRegistry = new AsyncLocal<IExpressionRegistry>();
-
-        internal static IDisposable UseRegistry(IExpressionRegistry registry)
-        {
-            var previous = _currentRegistry.Value;
-            _currentRegistry.Value = registry;
-            return new RegistryScope(previous);
-        }
-
-        internal static IExpressionRegistry CurrentRegistry => _currentRegistry.Value;
+        internal IExpressionRegistry Registry { get; private set; }
 
         /// <summary>
         /// Get default field name when need convert simple BsonValue into BsonDocument
@@ -292,42 +283,60 @@ namespace LiteDB
 
         #region Static method
 
-        private static readonly ConcurrentDictionary<string, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<string, BsonExpressionEnumerableDelegate>();
-        private static readonly ConcurrentDictionary<string, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<string, BsonExpressionScalarDelegate>();
-
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overload that accepts IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression)
         {
-            return Create(expression, new BsonDocument());
+            return Create(expression, DefaultRegistry);
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overload that accepts IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression, params BsonValue[] args)
         {
+            return Create(expression, DefaultRegistry, args);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        [Obsolete("Use overload that accepts IExpressionRegistry explicitly.")]
+        public static BsonExpression Create(string expression, BsonDocument parameters)
+        {
+            return Create(expression, parameters, DefaultRegistry);
+        }
+
+        public static BsonExpression Create(string expression, IExpressionRegistry registry)
+        {
+            return Create(expression, registry, Array.Empty<BsonValue>());
+        }
+
+        public static BsonExpression Create(string expression, IExpressionRegistry registry, params BsonValue[] args)
+        {
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
+
             var parameters = new BsonDocument();
 
-            for(var i = 0; i < args.Length; i++)
+            for (var i = 0; i < args.Length; i++)
             {
                 parameters[i.ToString()] = args[i];
             }
 
-            return Create(expression, parameters);
+            return Create(expression, parameters, registry);
         }
 
-        /// <summary>
-        /// Parse string and create new instance of BsonExpression - can be cached
-        /// </summary>
-        public static BsonExpression Create(string expression, BsonDocument parameters)
+        public static BsonExpression Create(string expression, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
-            var tokenizer = new Tokenizer(expression);
+            var tokenizer = new Tokenizer(expression, registry);
 
-            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters);
+            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters, registry);
 
             tokenizer.LookAhead().Expect(TokenType.EOF);
 
@@ -337,27 +346,30 @@ namespace LiteDB
         /// <summary>
         /// Parse tokenizer and create new instance of BsonExpression - for now, do not use cache
         /// </summary>
-        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters)
+        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
 
-            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root);
+            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root, registry ?? DefaultRegistry);
         }
 
         /// <summary>
         /// Parse and compile string expression and return BsonExpression
         /// </summary>
-        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope)
+        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
             var context = new ExpressionContext();
 
             var expr =
-                mode == BsonExpressionParserMode.Full ? BsonExpressionParser.ParseFullExpression(tokenizer, context, parameters, scope) :
-                mode == BsonExpressionParserMode.Single ? BsonExpressionParser.ParseSingleExpression(tokenizer, context, parameters, scope) :
-                mode == BsonExpressionParserMode.SelectDocument ? BsonExpressionParser.ParseSelectDocumentBuilder(tokenizer, context, parameters) :
-                BsonExpressionParser.ParseUpdateDocumentBuilder(tokenizer, context, parameters);
+                mode == BsonExpressionParserMode.Full ? BsonExpressionParser.ParseFullExpression(tokenizer, context, parameters, scope, registry) :
+                mode == BsonExpressionParserMode.Single ? BsonExpressionParser.ParseSingleExpression(tokenizer, context, parameters, scope, registry) :
+                mode == BsonExpressionParserMode.SelectDocument ? BsonExpressionParser.ParseSelectDocumentBuilder(tokenizer, context, parameters, registry) :
+                BsonExpressionParser.ParseUpdateDocumentBuilder(tokenizer, context, parameters, registry);
+
+            SetRegistry(expr, registry);
 
             // compile linq expression (with left+right expressions)
             Compile(expr, context);
@@ -367,11 +379,15 @@ namespace LiteDB
 
         internal static void Compile(BsonExpression expr, ExpressionContext context)
         {
+            var registry = expr.Registry ?? DefaultRegistry;
+
             // compile linq expression according with return type (scalar or enumerable)
             // in both case, try use cached compiled version
             if (expr.IsScalar)
             {
-                var cached = _cacheScalar.GetOrAdd(expr.Source, s =>
+                var key = new ExpressionCacheKey(registry, expr.Source);
+
+                var cached = _cacheScalar.GetOrAdd(key, s =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionScalarDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -382,7 +398,9 @@ namespace LiteDB
             }
             else
             {
-                var cached = _cacheEnumerable.GetOrAdd(expr.Source, s =>
+                var key = new ExpressionCacheKey(registry, expr.Source);
+
+                var cached = _cacheEnumerable.GetOrAdd(key, s =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionEnumerableDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -408,10 +426,14 @@ namespace LiteDB
             if (expr.Right != null) SetParameters(expr.Right, parameters);
         }
 
-        /// <summary>
-        /// Get root document $ expression
-        /// </summary>
-        public static BsonExpression Root = Create("$");
+        private static readonly IExpressionRegistry DefaultRegistryInstance = new ExpressionRegistry();
+        private static IExpressionRegistry _defaultRegistry = DefaultRegistryInstance;
+
+        public static IExpressionRegistry DefaultRegistry
+        {
+            get => _defaultRegistry;
+            set => _defaultRegistry = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         #endregion
 
@@ -473,23 +495,62 @@ namespace LiteDB
             return $"`{this.Source}` [{this.Type}]";
         }
 
-        private sealed class RegistryScope : IDisposable
+        private readonly struct ExpressionCacheKey : IEquatable<ExpressionCacheKey>
         {
-            private readonly IExpressionRegistry _previous;
-            private bool _disposed;
+            private readonly IExpressionRegistry _registry;
+            private readonly string _source;
 
-            public RegistryScope(IExpressionRegistry previous)
+            public ExpressionCacheKey(IExpressionRegistry registry, string source)
             {
-                _previous = previous;
+                _registry = registry;
+                _source = source ?? throw new ArgumentNullException(nameof(source));
             }
 
-            public void Dispose()
+            public bool Equals(ExpressionCacheKey other)
             {
-                if (!_disposed)
+                return ReferenceEquals(_registry, other._registry) && string.Equals(_source, other._source, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is ExpressionCacheKey other && this.Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
                 {
-                    _currentRegistry.Value = _previous;
-                    _disposed = true;
+                    var hash = _source.GetHashCode();
+                    if (_registry != null)
+                    {
+                        hash = (hash * 397) ^ RuntimeHelpers.GetHashCode(_registry);
+                    }
+
+                    return hash;
                 }
+            }
+        }
+
+        private static readonly ConcurrentDictionary<ExpressionCacheKey, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<ExpressionCacheKey, BsonExpressionEnumerableDelegate>();
+        private static readonly ConcurrentDictionary<ExpressionCacheKey, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<ExpressionCacheKey, BsonExpressionScalarDelegate>();
+
+        /// <summary>
+        /// Get root document $ expression
+        /// </summary>
+        public static BsonExpression Root = Create("$", DefaultRegistry);
+
+        private static void SetRegistry(BsonExpression expr, IExpressionRegistry registry)
+        {
+            expr.Registry = registry;
+
+            if (expr.Left != null)
+            {
+                SetRegistry(expr.Left, registry);
+            }
+
+            if (expr.Right != null)
+            {
+                SetRegistry(expr.Right, registry);
             }
         }
     }

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -111,11 +111,9 @@ namespace LiteDB
             new OperatorDefinition("OR", " OR ", null, BsonExpressionType.Or, (int)BinaryOperatorPrecedence.LogicalOr)
         };
 
-        private static List<OperatorDefinition> GetOperatorTable()
+        private static List<OperatorDefinition> GetOperatorTable(IExpressionRegistry registry)
         {
             var table = new List<OperatorDefinition>(_builtInOperators);
-
-            var registry = BsonExpression.CurrentRegistry;
 
             if (registry != null)
             {
@@ -156,9 +154,9 @@ namespace LiteDB
         /// <summary>
         /// Start parse string into linq expression. Read path, function or base type bson values (int, double, bool, string)
         /// </summary>
-        public static BsonExpression ParseFullExpression(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        public static BsonExpression ParseFullExpression(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
-            var first = ParseSingleExpression(tokenizer, context, parameters, scope);
+            var first = ParseSingleExpression(tokenizer, context, parameters, scope, registry);
             var values = new List<BsonExpression> { first };
             var ops = new List<string>();
 
@@ -170,14 +168,14 @@ namespace LiteDB
 
                 if (op == null) break;
 
-                var expr = ParseSingleExpression(tokenizer, context, parameters, scope);
+                var expr = ParseSingleExpression(tokenizer, context, parameters, scope, registry);
 
                 // special BETWEEN "AND" read
                 if (op.EndsWith("BETWEEN", StringComparison.OrdinalIgnoreCase))
                 {
                     var and = tokenizer.ReadToken(true).Expect("AND");
 
-                    var expr2 = ParseSingleExpression(tokenizer, context, parameters, scope);
+                    var expr2 = ParseSingleExpression(tokenizer, context, parameters, scope, registry);
 
                     // convert expr and expr2 into an array with 2 values
                     expr = NewArray(expr, expr2);
@@ -188,7 +186,7 @@ namespace LiteDB
             }
 
             var order = 0;
-            var operatorTable = GetOperatorTable();
+            var operatorTable = GetOperatorTable(registry);
 
             // now, process operator in correct order
             while (values.Count >= 2)
@@ -284,7 +282,7 @@ namespace LiteDB
         /// <summary>
         /// Start parse string into linq expression. Read path, function or base type bson values (int, double, bool, string)
         /// </summary>
-        public static BsonExpression ParseSingleExpression(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        public static BsonExpression ParseSingleExpression(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             // read next token and test with all expression parts
             var token = tokenizer.ReadToken();
@@ -295,21 +293,21 @@ namespace LiteDB
                 TryParseBool(tokenizer, parameters) ??
                 TryParseNull(tokenizer, parameters) ??
                 TryParseString(tokenizer, parameters) ??
-                TryParseSource(tokenizer, context, parameters, scope) ??
-                TryParseDocument(tokenizer, context, parameters, scope) ??
-                TryParseArray(tokenizer, context, parameters, scope) ??
+                TryParseSource(tokenizer, context, parameters, scope, registry) ??
+                TryParseDocument(tokenizer, context, parameters, scope, registry) ??
+                TryParseArray(tokenizer, context, parameters, scope, registry) ??
                 TryParseParameter(tokenizer, context, parameters, scope) ??
-                TryParseInnerExpression(tokenizer, context, parameters, scope) ??
-                TryParseFunction(tokenizer, context, parameters, scope) ??
-                TryParseMethodCall(tokenizer, context, parameters, scope) ??
-                TryParsePath(tokenizer, context, parameters, scope) ??
+                TryParseInnerExpression(tokenizer, context, parameters, scope, registry) ??
+                TryParseFunction(tokenizer, context, parameters, scope, registry) ??
+                TryParseMethodCall(tokenizer, context, parameters, scope, registry) ??
+                TryParsePath(tokenizer, context, parameters, scope, registry) ??
                 throw LiteException.UnexpectedToken(token);
         }
 
         /// <summary>
         /// Parse a document builder syntax used in SELECT statment: {expr0} [AS] [{alias}], {expr1} [AS] [{alias}], ...
         /// </summary>
-        public static BsonExpression ParseSelectDocumentBuilder(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters)
+        public static BsonExpression ParseSelectDocumentBuilder(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, IExpressionRegistry registry)
         {
             // creating unique field names
             var fields = new List<KeyValuePair<string, BsonExpression>>();
@@ -332,7 +330,7 @@ namespace LiteDB
 
             while (true)
             {
-                var expr = ParseFullExpression(tokenizer, context, parameters, DocumentScope.Root);
+                var expr = ParseFullExpression(tokenizer, context, parameters, DocumentScope.Root, registry);
 
                 var next = tokenizer.LookAhead();
 
@@ -410,7 +408,7 @@ namespace LiteDB
         /// {key0} = {expr0}, .... will be converted into { key: [expr], ... }
         /// {key: value} ... return return a new document
         /// </summary>
-        public static BsonExpression ParseUpdateDocumentBuilder(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters)
+        public static BsonExpression ParseUpdateDocumentBuilder(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, IExpressionRegistry registry)
         {
             var next = tokenizer.LookAhead();
 
@@ -419,7 +417,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume {
 
-                return TryParseDocument(tokenizer, context, parameters, DocumentScope.Root);
+                return TryParseDocument(tokenizer, context, parameters, DocumentScope.Root, registry);
             }
 
             var keys = new List<Expression>();
@@ -439,7 +437,7 @@ namespace LiteDB
 
                 src.Append(":");
 
-                var value = ParseFullExpression(tokenizer, context, parameters, DocumentScope.Root);
+                var value = ParseFullExpression(tokenizer, context, parameters, DocumentScope.Root, registry);
 
                 if (!value.IsScalar) value = ConvertToArray(value);
 
@@ -671,7 +669,7 @@ namespace LiteDB
         /// <summary>
         /// Try parse json document - return null if not document token
         /// </summary>
-        private static BsonExpression TryParseDocument(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        private static BsonExpression TryParseDocument(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer.Current.Type != TokenType.OpenBrace) return null;
 
@@ -709,7 +707,7 @@ namespace LiteDB
                     // test normal notation { a: 1 }
                     if (tokenizer.Current.Type == TokenType.Colon)
                     {
-                        value = ParseFullExpression(tokenizer, context, parameters, scope);
+                        value = ParseFullExpression(tokenizer, context, parameters, scope, registry);
 
                         // read next token here (, or }) because simplified version already did
                         tokenizer.ReadToken();
@@ -777,7 +775,7 @@ namespace LiteDB
         /// <summary>
         /// Try parse source documents (when passed) * - return null if not source token
         /// </summary>
-        private static BsonExpression TryParseSource(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        private static BsonExpression TryParseSource(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer.Current.Type != TokenType.Asterisk) return null;
 
@@ -798,7 +796,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source);
+                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source, registry);
 
                 if (pathExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -823,7 +821,7 @@ namespace LiteDB
         /// <summary>
         /// Try parse array - return null if not array token
         /// </summary>
-        private static BsonExpression TryParseArray(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        private static BsonExpression TryParseArray(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer.Current.Type != TokenType.OpenBracket) return null;
 
@@ -845,7 +843,7 @@ namespace LiteDB
                 while (!tokenizer.CheckEOF())
                 {
                     // read value expression
-                    var value = ParseFullExpression(tokenizer, context, parameters, scope);
+                    var value = ParseFullExpression(tokenizer, context, parameters, scope, registry);
 
                     // document value must be a scalar value
                     if (!value.IsScalar) value = ConvertToArray(value);
@@ -921,12 +919,12 @@ namespace LiteDB
         /// <summary>
         /// Try parse inner expression - return null if not bracket token
         /// </summary>
-        private static BsonExpression TryParseInnerExpression(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        private static BsonExpression TryParseInnerExpression(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer.Current.Type != TokenType.OpenParenthesis) return null;
 
             // read a inner expression inside ( and )
-            var inner = ParseFullExpression(tokenizer, context, parameters, scope);
+            var inner = ParseFullExpression(tokenizer, context, parameters, scope, registry);
 
             // read close )
             tokenizer.ReadToken().Expect(TokenType.CloseParenthesis);
@@ -949,7 +947,7 @@ namespace LiteDB
         /// <summary>
         /// Try parse method call - return null if not method call
         /// </summary>
-        private static BsonExpression TryParseMethodCall(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        private static BsonExpression TryParseMethodCall(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             var token = tokenizer.Current;
 
@@ -977,7 +975,7 @@ namespace LiteDB
             {
                 while (!tokenizer.CheckEOF())
                 {
-                    var parameter = ParseFullExpression(tokenizer, context, parameters, scope);
+                    var parameter = ParseFullExpression(tokenizer, context, parameters, scope, registry);
 
                     // update isImmutable only when came false
                     if (parameter.IsImmutable == false) isImmutable = false;
@@ -1058,7 +1056,7 @@ namespace LiteDB
         /// <summary>
         /// Parse JSON-Path - return null if not method call
         /// </summary>
-        private static BsonExpression TryParsePath(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        private static BsonExpression TryParsePath(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             // test $ or @ or WORD
             if (tokenizer.Current.Type != TokenType.At && tokenizer.Current.Type != TokenType.Dollar && tokenizer.Current.Type != TokenType.Word) return null;
@@ -1100,7 +1098,7 @@ namespace LiteDB
             // parse the rest of path
             while (!tokenizer.EOF)
             {
-                var result = ParsePath(tokenizer, expr, context, parameters, fields, ref isImmutable, ref useSource, ref isScalar, src);
+                var result = ParsePath(tokenizer, expr, context, parameters, registry, fields, ref isImmutable, ref useSource, ref isScalar, src);
 
                 if (isScalar == false)
                 {
@@ -1131,7 +1129,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current);
+                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current, registry);
 
                 if (mapExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1156,7 +1154,7 @@ namespace LiteDB
         /// <summary>
         /// Implement a JSON-Path like navigation on BsonDocument. Support a simple range of paths
         /// </summary>
-        private static Expression ParsePath(Tokenizer tokenizer, Expression expr, ExpressionContext context, BsonDocument parameters, HashSet<string> fields, ref bool isImmutable, ref bool useSource, ref bool isScalar, StringBuilder src)
+        private static Expression ParsePath(Tokenizer tokenizer, Expression expr, ExpressionContext context, BsonDocument parameters, IExpressionRegistry registry, HashSet<string> fields, ref bool isImmutable, ref bool useSource, ref bool isScalar, StringBuilder src)
         {
             var ahead = tokenizer.LookAhead(false);
 
@@ -1207,7 +1205,7 @@ namespace LiteDB
                 else
                 {
                     // inner expression
-                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current);
+                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current, registry);
 
                     if (inner == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1243,7 +1241,7 @@ namespace LiteDB
         /// <summary>
         /// Try parse FUNCTION methods: MAP, FILTER, SORT, ...
         /// </summary>
-        private static BsonExpression TryParseFunction(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope)
+        private static BsonExpression TryParseFunction(Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer.Current.Type != TokenType.Word) return null;
             if (tokenizer.LookAhead().Type != TokenType.OpenParenthesis) return null;
@@ -1252,18 +1250,18 @@ namespace LiteDB
 
             switch (token)
             {
-                case "MAP": return ParseFunction(token, BsonExpressionType.Map, tokenizer, context, parameters, scope);
-                case "FILTER": return ParseFunction(token, BsonExpressionType.Filter, tokenizer, context, parameters, scope);
-                case "SORT": return ParseFunction(token, BsonExpressionType.Sort, tokenizer, context, parameters, scope);
+                case "MAP": return ParseFunction(token, BsonExpressionType.Map, tokenizer, context, parameters, scope, registry);
+                case "FILTER": return ParseFunction(token, BsonExpressionType.Filter, tokenizer, context, parameters, scope, registry);
+                case "SORT": return ParseFunction(token, BsonExpressionType.Sort, tokenizer, context, parameters, scope, registry);
             }
 
-            if (BsonExpression.CurrentRegistry is ExpressionRegistry registry)
+            if (registry is ExpressionRegistry expressionRegistry)
             {
-                var registration = registry.FindByName(token);
+                var registration = expressionRegistry.FindByName(token);
 
                 if (registration != null)
                 {
-                    return ParseFunction(token, registration.ExpressionType, tokenizer, context, parameters, scope, registration.ConvertScalarLeftToEnumerable, registration.IsScalarResult, registration);
+                    return ParseFunction(token, registration.ExpressionType, tokenizer, context, parameters, scope, registry, registration.ConvertScalarLeftToEnumerable, registration.IsScalarResult, registration);
                 }
             }
 
@@ -1274,7 +1272,7 @@ namespace LiteDB
         /// Parse expression functions, like MAP, FILTER or SORT.
         /// MAP(items[*] => @.Name)
         /// </summary>
-        private static BsonExpression ParseFunction(string functionName, BsonExpressionType type, Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, bool convertScalarLeftToEnumerable = true, bool isScalarResult = false, ExpressionFunctionRegistration registration = null)
+        private static BsonExpression ParseFunction(string functionName, BsonExpressionType type, Tokenizer tokenizer, ExpressionContext context, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry, bool convertScalarLeftToEnumerable = true, bool isScalarResult = false, ExpressionFunctionRegistration registration = null)
         {
             if (registration != null)
             {
@@ -1288,7 +1286,7 @@ namespace LiteDB
             // read (
             tokenizer.ReadToken().Expect(TokenType.OpenParenthesis);
 
-            var left = ParseSingleExpression(tokenizer, context, parameters, scope);
+            var left = ParseSingleExpression(tokenizer, context, parameters, scope, registry);
 
             // if left is a scalar expression, convert into enumerable expression (avoid to use [*] all the time)
             if (convertScalarLeftToEnumerable && left.IsScalar)
@@ -1316,7 +1314,7 @@ namespace LiteDB
                 tokenizer.ReadToken().Expect(TokenType.Greater);
 
                 var right = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters,
-                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current);
+                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current, registry);
 
                 src.Append("=>" + right.Source);
                 args.Add(Expression.Constant(right));
@@ -1332,7 +1330,7 @@ namespace LiteDB
                 // try more parameters ,
                 while (!tokenizer.CheckEOF())
                 {
-                    var parameter = ParseFullExpression(tokenizer, context, parameters, scope);
+                    var parameter = ParseFullExpression(tokenizer, context, parameters, scope, registry);
 
                     // update isImmutable only when came false
                     if (parameter.IsImmutable == false) isImmutable = false;

--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -78,6 +78,8 @@ namespace LiteDB.Engine
                     }
 
                     // first create all user indexes (exclude _id index)
+                    var expressions = _plugins?.Expressions ?? BsonExpression.DefaultRegistry;
+
                     foreach (var index in reader.GetIndexes(collection))
                     {
                         if (index.IndexType == 1 && index.VectorMetadata != null)
@@ -85,7 +87,7 @@ namespace LiteDB.Engine
                             this.EnsureVectorIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                BsonExpression.Create(index.Expression, expressions),
                                 new VectorIndexOptions(index.VectorMetadata.Dimensions, index.VectorMetadata.Metric));
                         }
                         else
@@ -93,7 +95,7 @@ namespace LiteDB.Engine
                             this.EnsureIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                BsonExpression.Create(index.Expression, expressions),
                                 index.Unique);
                         }
                     }

--- a/LiteDB/Engine/FileReader/FileReaderV8.cs
+++ b/LiteDB/Engine/FileReader/FileReaderV8.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using LiteDB;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -374,7 +375,7 @@ namespace LiteDB.Engine
                 try
                 {
                     var page = result.Value;
-                    var collectionPage = new CollectionPage(page.Buffer);
+                    var collectionPage = new CollectionPage(page.Buffer, BsonExpression.DefaultRegistry);
 
                     foreach (var index in collectionPage.GetCollectionIndexes())
                     {

--- a/LiteDB/Engine/Pages/BasePage.cs
+++ b/LiteDB/Engine/Pages/BasePage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -731,12 +732,12 @@ namespace LiteDB.Engine
         /// <summary>
         /// Create new page instance based on buffer (READ)
         /// </summary>
-        public static T ReadPage<T>(PageBuffer buffer)
+        public static T ReadPage<T>(PageBuffer buffer, IExpressionRegistry registry = null)
             where T : BasePage
         {
             if (typeof(T) == typeof(BasePage)) return (T)(object)new BasePage(buffer);
             if (typeof(T) == typeof(HeaderPage)) return (T)(object)new HeaderPage(buffer);
-            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer);
+            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer, registry);
             if (typeof(T) == typeof(IndexPage)) return (T)(object)new IndexPage(buffer);
             if (typeof(T) == typeof(VectorIndexPage)) return (T)(object)new VectorIndexPage(buffer);
             if (typeof(T) == typeof(DataPage)) return (T)(object)new DataPage(buffer);
@@ -747,10 +748,10 @@ namespace LiteDB.Engine
         /// <summary>
         /// Create new page instance with new PageID and passed buffer (NEW)
         /// </summary>
-        public static T CreatePage<T>(PageBuffer buffer, uint pageID)
+        public static T CreatePage<T>(PageBuffer buffer, uint pageID, IExpressionRegistry registry = null)
             where T : BasePage
         {
-            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer, pageID);
+            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer, pageID, registry);
             if (typeof(T) == typeof(IndexPage)) return (T)(object)new IndexPage(buffer, pageID);
             if (typeof(T) == typeof(VectorIndexPage)) return (T)(object)new VectorIndexPage(buffer, pageID);
             if (typeof(T) == typeof(DataPage)) return (T)(object)new DataPage(buffer, pageID);

--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB;
+using LiteDB.Plugins;
 using LiteDB.Vector;
 using static LiteDB.Constants;
 
@@ -29,21 +31,29 @@ namespace LiteDB.Engine
         private readonly Dictionary<string, CollectionIndex> _indexes = new Dictionary<string, CollectionIndex>();
         private readonly Dictionary<string, VectorIndexMetadata> _vectorIndexes = new Dictionary<string, VectorIndexMetadata>();
 
-        public CollectionPage(PageBuffer buffer, uint pageID)
+        private readonly IExpressionRegistry _expressionRegistry;
+
+        public IExpressionRegistry ExpressionRegistry => _expressionRegistry;
+
+        public CollectionPage(PageBuffer buffer, uint pageID, IExpressionRegistry registry = null)
             : base(buffer, pageID, PageType.Collection)
         {
+            _expressionRegistry = registry ?? BsonExpression.DefaultRegistry;
+
             for(var i = 0; i < PAGE_FREE_LIST_SLOTS; i++)
             {
                 this.FreeDataPageList[i] = uint.MaxValue;
             }
         }
 
-        public CollectionPage(PageBuffer buffer)
+        public CollectionPage(PageBuffer buffer, IExpressionRegistry registry = null)
             : base(buffer)
         {
             ENSURE(this.PageType == PageType.Collection, "page type must be collection page");
 
             if (this.PageType != PageType.Collection) throw LiteException.InvalidPageType(PageType.Collection, this);
+
+            _expressionRegistry = registry ?? BsonExpression.DefaultRegistry;
 
             // create new buffer area to store BsonDocument indexes
             var area = _buffer.Slice(PAGE_HEADER_SIZE, PAGE_SIZE - PAGE_HEADER_SIZE);
@@ -63,7 +73,7 @@ namespace LiteDB.Engine
 
                 for(var i = 0; i < count; i++)
                 {
-                    var index = new CollectionIndex(r);
+                    var index = new CollectionIndex(r, _expressionRegistry);
 
                     _indexes[index.Name] = index;
                 }
@@ -204,7 +214,7 @@ namespace LiteDB.Engine
 
             var slot = (byte)(_indexes.Count == 0 ? 0 : (_indexes.Max(x => x.Value.Slot) + 1));
 
-            var index = new CollectionIndex(slot, 0, name, expr, unique);
+            var index = new CollectionIndex(slot, 0, name, expr, unique, _expressionRegistry);
 
             _indexes[name] = index;
 
@@ -226,7 +236,7 @@ namespace LiteDB.Engine
 
             var slot = (byte)(_indexes.Count == 0 ? 0 : (_indexes.Max(x => x.Value.Slot) + 1));
 
-            var index = new CollectionIndex(slot, 1, name, expr, false);
+            var index = new CollectionIndex(slot, 1, name, expr, false, _expressionRegistry);
             var metadata = new VectorIndexMetadata(slot, dimensions, metric);
 
             _indexes[name] = index;

--- a/LiteDB/Engine/Query/QueryExecutor.cs
+++ b/LiteDB/Engine/Query/QueryExecutor.cs
@@ -103,7 +103,7 @@ namespace LiteDB.Engine
                 }
 
                 // execute optimization before run query (will fill missing _query properties instance)
-                var optimizer = new QueryOptimization(snapshot, _query, _source, _pragmas.Collation);
+                var optimizer = new QueryOptimization(snapshot, _query, _source, _pragmas.Collation, _engine.PluginContext?.Expressions);
 
                 var queryPlan = optimizer.ProcessQuery();
 

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -16,14 +17,16 @@ namespace LiteDB.Engine
         private readonly QueryPlan _queryPlan;
         private readonly List<BsonExpression> _terms = new List<BsonExpression>();
         private bool _vectorOrderConsumed;
+        private readonly IExpressionRegistry _expressions;
 
-        public QueryOptimization(Snapshot snapshot, Query query, IEnumerable<BsonDocument> source, Collation collation)
+        public QueryOptimization(Snapshot snapshot, Query query, IEnumerable<BsonDocument> source, Collation collation, IExpressionRegistry expressions)
         {
             if (query.Select == null) throw new ArgumentNullException(nameof(query.Select));
 
             _snapshot = snapshot;
             _query = query;
             _collation = collation;
+            _expressions = expressions ?? BsonExpression.DefaultRegistry;
 
             _queryPlan = new QueryPlan(snapshot.CollectionName)
             {
@@ -128,7 +131,7 @@ namespace LiteDB.Engine
                     term.Type == BsonExpressionType.Equal &&
                     term.Right?.Type == BsonExpressionType.Path)
                 {
-                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters);
+                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters, _expressions);
                 }
             }
         }

--- a/LiteDB/Engine/Query/Structures/IndexCost.cs
+++ b/LiteDB/Engine/Query/Structures/IndexCost.cs
@@ -69,7 +69,7 @@ namespace LiteDB.Engine
         // used when full index search
         public IndexCost(CollectionIndex index)
         {
-            this.Expression = BsonExpression.Create(index.Expression);
+            this.Expression = index.BsonExpr;
             this.Index = new IndexAll(index.Name, Query.Ascending);
             this.Cost = this.Index.GetCost(index);
             this.IndexExpression = index.Expression;

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -226,7 +226,7 @@ namespace LiteDB.Engine
             {
                 // read page from log file
                 var buffer = _reader.ReadPage(walPosition.Position, _mode == LockMode.Write, FileOrigin.Log);
-                var dirty = BasePage.ReadPage<T>(buffer);
+                var dirty = BasePage.ReadPage<T>(buffer, _plugins?.Expressions);
 
                 origin = FileOrigin.Log;
                 position = walPosition.Position;
@@ -244,7 +244,7 @@ namespace LiteDB.Engine
             {
                 // read page from log file
                 var buffer = _reader.ReadPage(pos, _mode == LockMode.Write, FileOrigin.Log);
-                var logPage = BasePage.ReadPage<T>(buffer);
+                var logPage = BasePage.ReadPage<T>(buffer, _plugins?.Expressions);
 
                 // clear some data inside this page (will be override when write on log file)
                 logPage.TransactionID = 0;
@@ -262,7 +262,7 @@ namespace LiteDB.Engine
 
                 // read page from data file
                 var buffer = _reader.ReadPage(pagePosition, _mode == LockMode.Write, FileOrigin.Data);
-                var diskpage = BasePage.ReadPage<T>(buffer);
+                var diskpage = BasePage.ReadPage<T>(buffer, _plugins?.Expressions);
 
                 origin = FileOrigin.Data;
                 position = pagePosition;
@@ -426,7 +426,7 @@ namespace LiteDB.Engine
                 _transPages.NewPages.Add(pageID);
             }
 
-            var page = BasePage.CreatePage<T>(buffer, pageID);
+            var page = BasePage.CreatePage<T>(buffer, pageID, _plugins?.Expressions);
 
             // update local cache with new instance T page type
             if (page.PageType != PageType.Collection)

--- a/LiteDB/Engine/Structures/CollectionIndex.cs
+++ b/LiteDB/Engine/Structures/CollectionIndex.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -65,7 +67,7 @@ namespace LiteDB.Engine
             get { return string.IsNullOrEmpty(this.Name); }
         }
 
-        public CollectionIndex(byte slot, byte indexType, string name, string expr, bool unique)
+        public CollectionIndex(byte slot, byte indexType, string name, string expr, bool unique, IExpressionRegistry registry = null)
         {
             this.Slot = slot;
             this.IndexType = indexType;
@@ -74,10 +76,10 @@ namespace LiteDB.Engine
             this.Unique = unique;
             this.FreeIndexPageList = uint.MaxValue;
 
-            this.BsonExpr = BsonExpression.Create(expr);
+            this.BsonExpr = BsonExpression.Create(expr, registry ?? BsonExpression.DefaultRegistry);
         }
 
-        public CollectionIndex(BufferReader reader)
+        public CollectionIndex(BufferReader reader, IExpressionRegistry registry = null)
         {
             this.Slot = reader.ReadByte();
             this.IndexType = reader.ReadByte();
@@ -89,7 +91,7 @@ namespace LiteDB.Engine
             this.Reserved = reader.ReadByte(); // 1
             this.FreeIndexPageList = reader.ReadUInt32(); // 4
 
-            this.BsonExpr = BsonExpression.Create(this.Expression);
+            this.BsonExpr = BsonExpression.Create(this.Expression, registry ?? BsonExpression.DefaultRegistry);
         }
 
         public void UpdateBuffer(BufferWriter writer)

--- a/LiteDB/Engine/SystemCollections/SysDump.cs
+++ b/LiteDB/Engine/SystemCollections/SysDump.cs
@@ -63,7 +63,7 @@ namespace LiteDB.Engine
 
                 if (page.PageType == PageType.Collection)
                 {
-                    var collectionPage = new CollectionPage(page.Buffer);
+                    var collectionPage = new CollectionPage(page.Buffer, snapshot.Plugins?.Expressions);
                     doc["dataPageList"] = new BsonArray(collectionPage.FreeDataPageList.Select(x => new BsonValue((int)x)));
                     doc["indexes"] = new BsonArray(collectionPage.GetCollectionIndexes().Select(x => new BsonDocument
                     {

--- a/LiteDB/Engine/SystemCollections/SysQuery.cs
+++ b/LiteDB/Engine/SystemCollections/SysQuery.cs
@@ -23,7 +23,8 @@ namespace LiteDB.Engine
         {
             var query = options?.AsString ?? throw new LiteException(0, $"Collection $query(sql) requires `sql` string parameter");
 
-            var sql = new SqlParser(_engine, new Tokenizer(query), null);
+            var expressions = (_engine as LiteEngine)?.PluginContext?.Expressions;
+            var sql = new SqlParser(_engine, new Tokenizer(query, expressions), null, expressions);
 
             using (var reader = sql.Execute())
             {

--- a/LiteDB/Utils/Tokenizer.cs
+++ b/LiteDB/Utils/Tokenizer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -101,11 +102,20 @@ namespace LiteDB
             "OR"
         };
 
-        public Token(TokenType tokenType, string value, long position)
+        private readonly IExpressionRegistry _registry;
+
+        public Token(TokenType tokenType, string value, long position, IExpressionRegistry registry)
         {
             this.Position = position;
             this.Value = value;
             this.Type = tokenType;
+            _registry = registry ?? BsonExpression.DefaultRegistry;
+        }
+
+        [Obsolete("Use the constructor that accepts an IExpressionRegistry.")]
+        public Token(TokenType tokenType, string value, long position)
+            : this(tokenType, value, position, BsonExpression.DefaultRegistry)
+        {
         }
 
         public TokenType Type { get; private set; }
@@ -192,9 +202,7 @@ namespace LiteDB
                             return true;
                         }
 
-                        var registry = BsonExpression.CurrentRegistry;
-
-                        if (registry != null && (registry.ContainsKeyword(Value) || registry.ContainsOperator(Value)))
+                        if (_registry != null && (_registry.ContainsKeyword(Value) || _registry.ContainsOperator(Value)))
                         {
                             return true;
                         }
@@ -221,6 +229,7 @@ namespace LiteDB
     internal class Tokenizer
     {
         private readonly TextReader _reader;
+        private readonly IExpressionRegistry _registry;
         private char _char = '\0';
         private Token _ahead = null;
         private bool _eof = false;
@@ -239,17 +248,30 @@ namespace LiteDB
             return false;
         }
 
-        public Tokenizer(string source)
-            : this(new StringReader(source))
+        public Tokenizer(string source, IExpressionRegistry registry)
+            : this(new StringReader(source), registry)
         {
         }
 
-        public Tokenizer(TextReader reader)
+        public Tokenizer(TextReader reader, IExpressionRegistry registry)
         {
             _reader = reader;
+            _registry = registry ?? BsonExpression.DefaultRegistry;
 
             this.Position = 0;
             this.ReadChar();
+        }
+
+        [Obsolete("Use the constructor that accepts an IExpressionRegistry.")]
+        public Tokenizer(string source)
+            : this(source, BsonExpression.DefaultRegistry)
+        {
+        }
+
+        [Obsolete("Use the constructor that accepts an IExpressionRegistry.")]
+        public Tokenizer(TextReader reader)
+            : this(reader, BsonExpression.DefaultRegistry)
+        {
         }
 
         /// <summary>
@@ -337,7 +359,7 @@ namespace LiteDB
 
             if (_eof)
             {
-                return new Token(TokenType.EOF, null, this.Position);
+                return new Token(TokenType.EOF, null, this.Position, _registry);
             }
 
             Token token = null;
@@ -345,72 +367,72 @@ namespace LiteDB
             switch (_char)
             {
                 case '{':
-                    token = new Token(TokenType.OpenBrace, "{", this.Position);
+                    token = new Token(TokenType.OpenBrace, "{", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '}':
-                    token = new Token(TokenType.CloseBrace, "}", this.Position);
+                    token = new Token(TokenType.CloseBrace, "}", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '[':
-                    token = new Token(TokenType.OpenBracket, "[", this.Position);
+                    token = new Token(TokenType.OpenBracket, "[", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ']':
-                    token = new Token(TokenType.CloseBracket, "]", this.Position);
+                    token = new Token(TokenType.CloseBracket, "]", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '(':
-                    token = new Token(TokenType.OpenParenthesis, "(", this.Position);
+                    token = new Token(TokenType.OpenParenthesis, "(", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ')':
-                    token = new Token(TokenType.CloseParenthesis, ")", this.Position);
+                    token = new Token(TokenType.CloseParenthesis, ")", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ',':
-                    token = new Token(TokenType.Comma, ",", this.Position);
+                    token = new Token(TokenType.Comma, ",", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ':':
-                    token = new Token(TokenType.Colon, ":", this.Position);
+                    token = new Token(TokenType.Colon, ":", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ';':
-                    token = new Token(TokenType.SemiColon, ";", this.Position);
+                    token = new Token(TokenType.SemiColon, ";", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '@':
-                    token = new Token(TokenType.At, "@", this.Position);
+                    token = new Token(TokenType.At, "@", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '#':
-                    token = new Token(TokenType.Hashtag, "#", this.Position);
+                    token = new Token(TokenType.Hashtag, "#", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '~':
-                    token = new Token(TokenType.Til, "~", this.Position);
+                    token = new Token(TokenType.Til, "~", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '.':
-                    token = new Token(TokenType.Period, ".", this.Position);
+                    token = new Token(TokenType.Period, ".", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '&':
-                    token = new Token(TokenType.Ampersand, "&", this.Position);
+                    token = new Token(TokenType.Ampersand, "&", this.Position, _registry);
                     this.ReadChar();
                     break;
 
@@ -418,11 +440,11 @@ namespace LiteDB
                     this.ReadChar();
                     if (IsWordChar(_char, true))
                     {
-                        token = new Token(TokenType.Word, "$" + this.ReadWord(), this.Position);
+                        token = new Token(TokenType.Word, "$" + this.ReadWord(), this.Position, _registry);
                     }
                     else
                     {
-                        token = new Token(TokenType.Dollar, "$", this.Position);
+                        token = new Token(TokenType.Dollar, "$", this.Position, _registry);
                     }
                     break;
 
@@ -430,17 +452,17 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.NotEquals, "!=", this.Position);
+                        token = new Token(TokenType.NotEquals, "!=", this.Position, _registry);
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Exclamation, "!", this.Position);
+                        token = new Token(TokenType.Exclamation, "!", this.Position, _registry);
                     }
                     break;
 
                 case '=':
-                    token = new Token(TokenType.Equals, "=", this.Position);
+                    token = new Token(TokenType.Equals, "=", this.Position, _registry);
                     this.ReadChar();
                     break;
 
@@ -448,12 +470,12 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.GreaterOrEquals, ">=", this.Position);
+                        token = new Token(TokenType.GreaterOrEquals, ">=", this.Position, _registry);
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Greater, ">", this.Position);
+                        token = new Token(TokenType.Greater, ">", this.Position, _registry);
                     }
                     break;
 
@@ -461,12 +483,12 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.LessOrEquals, "<=", this.Position);
+                        token = new Token(TokenType.LessOrEquals, "<=", this.Position, _registry);
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Less, "<", this.Position);
+                        token = new Token(TokenType.Less, "<", this.Position, _registry);
                     }
                     break;
 
@@ -479,37 +501,37 @@ namespace LiteDB
                     }
                     else
                     {
-                        token = new Token(TokenType.Minus, "-", this.Position);
+                        token = new Token(TokenType.Minus, "-", this.Position, _registry);
                     }
                     break;
 
                 case '+':
-                    token = new Token(TokenType.Plus, "+", this.Position);
+                    token = new Token(TokenType.Plus, "+", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '*':
-                    token = new Token(TokenType.Asterisk, "*", this.Position);
+                    token = new Token(TokenType.Asterisk, "*", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '/':
-                    token = new Token(TokenType.Slash, "/", this.Position);
+                    token = new Token(TokenType.Slash, "/", this.Position, _registry);
                     this.ReadChar();
                     break;
                 case '\\':
-                    token = new Token(TokenType.Backslash, @"\", this.Position);
+                    token = new Token(TokenType.Backslash, @"\", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '%':
-                    token = new Token(TokenType.Percent, "%", this.Position);
+                    token = new Token(TokenType.Percent, "%", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '\"':
                 case '\'':
-                    token = new Token(TokenType.String, this.ReadString(_char), this.Position);
+                    token = new Token(TokenType.String, this.ReadString(_char), this.Position, _registry);
                     break;
 
                 case '0':
@@ -524,7 +546,7 @@ namespace LiteDB
                 case '9':
                     var dbl = false;
                     var number = this.ReadNumber(ref dbl);
-                    token = new Token(dbl ? TokenType.Double : TokenType.Int, number, this.Position);
+                    token = new Token(dbl ? TokenType.Double : TokenType.Int, number, this.Position, _registry);
                     break;
 
                 case ' ':
@@ -537,14 +559,14 @@ namespace LiteDB
                         sb.Append(_char);
                         this.ReadChar();
                     }
-                    token = new Token(TokenType.Whitespace, sb.ToString(), this.Position);
+                    token = new Token(TokenType.Whitespace, sb.ToString(), this.Position, _registry);
                     break;
 
                 default:
                     // test if first char is an word 
                     if (IsWordChar(_char, true))
                     {
-                        token = new Token(TokenType.Word, this.ReadWord(), this.Position);
+                        token = new Token(TokenType.Word, this.ReadWord(), this.Position, _registry);
                     }
                     else
                     {
@@ -553,7 +575,7 @@ namespace LiteDB
                     break;
             }
 
-            return token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position);
+            return token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position, _registry);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- thread the database expression registry into CollectionPage and CollectionIndex so persisted index expressions compile with the owning database's plugins
- extend BasePage, Snapshot, and other engine entry points to pass registries when materializing collection pages, including diagnostics helpers and the legacy file reader
- update the expression parser/tokenizer and BsonExpression cache to work with explicit registries, exposing the registry on ILiteDatabase for callers

## Testing
- dotnet test LiteDB.Tests -f net8.0 --filter FullyQualifiedName~VectorIndex

------
https://chatgpt.com/codex/tasks/task_e_68ec409177ac8326a8e1a131e9b60cdd