### PR TITLE
Thread expression registry through database services

### DIFF
--- a/LiteDB.Benchmarks/Benchmarks/Deletion/DeletionBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Deletion/DeletionBenchmark.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using LiteDB.Benchmarks.Models;
 using LiteDB.Benchmarks.Models.Generators;
+using LiteDB.Plugins;
 
 namespace LiteDB.Benchmarks.Benchmarks.Deletion
 {
@@ -62,7 +63,7 @@ namespace LiteDB.Benchmarks.Benchmarks.Deletion
 			foreach (var indexInfo in droppedCollectionIndexes)
 			{
 				DatabaseInstance.GetCollection(collectionName)
-					.EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+					.EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"], (IExpressionRegistry)null), indexInfo["unique"]);
 			}
 
 			DatabaseInstance.Checkpoint();

--- a/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionIgnoreExpressionPropertyBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionIgnoreExpressionPropertyBenchmark.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using LiteDB.Benchmarks.Models;
 using LiteDB.Benchmarks.Models.Generators;
+using LiteDB.Plugins;
 
 namespace LiteDB.Benchmarks.Benchmarks.Insertion
 {
@@ -71,7 +72,7 @@ namespace LiteDB.Benchmarks.Benchmarks.Insertion
 			foreach (var indexInfo in droppedCollectionIndexes)
 			{
 				DatabaseInstance.GetCollection(indexInfo["collection"])
-					.EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+					.EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"], (IExpressionRegistry)null), indexInfo["unique"]);
 			}
 
 			DatabaseInstance.Checkpoint();

--- a/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionInMemoryBenchmark.cs
+++ b/LiteDB.Benchmarks/Benchmarks/Insertion/InsertionInMemoryBenchmark.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using BenchmarkDotNet.Attributes;
 using LiteDB.Benchmarks.Models;
 using LiteDB.Benchmarks.Models.Generators;
+using LiteDB.Plugins;
 
 namespace LiteDB.Benchmarks.Benchmarks.Insertion
 {
@@ -66,7 +67,7 @@ namespace LiteDB.Benchmarks.Benchmarks.Insertion
 			foreach (var indexInfo in droppedCollectionIndexes)
 			{
 				_databaseInstanceNormal.GetCollection(collectionName)
-					.EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+                                    .EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"], (IExpressionRegistry)null), indexInfo["unique"]);
 			}
 
 			_databaseInstanceNormal.Checkpoint();
@@ -86,7 +87,7 @@ namespace LiteDB.Benchmarks.Benchmarks.Insertion
 			foreach (var indexInfo in droppedCollectionIndexes)
 			{
 				_databaseInstanceInMemory.GetCollection(collectionName)
-					.EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"]), indexInfo["unique"]);
+                                    .EnsureIndex(indexInfo["name"], BsonExpression.Create(indexInfo["expression"], (IExpressionRegistry)null), indexInfo["unique"]);
 			}
 
 			_databaseInstanceInMemory.Checkpoint();

--- a/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
+++ b/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
@@ -124,11 +124,7 @@ public class BsonVector_Tests
         col.EnsureIndex(x => x.Embedding, new VectorIndexOptions(2));
 
         var target = new float[] { 1.0f, 0.0f };
-        BsonExpression fieldExpr;
-        using (db.EnterExpressionScope())
-        {
-            fieldExpr = BsonExpression.Create("$.Embedding");
-        }
+        var fieldExpr = BsonExpression.Create("$.Embedding", db.Expressions);
 
         var results = col.Query()
             .WhereNear(fieldExpr, target, maxDistance: .28)
@@ -159,16 +155,12 @@ public class BsonVector_Tests
             ["Embedding"] = new BsonVector(new float[] { 1.0f, 1.0f })
         });
 
-        using (db.EnterExpressionScope())
-        {
-            col.EnsureIndex(
-                "embedding_idx",
-                BsonExpression.Create("$.Embedding"),
-                new VectorIndexOptions(2));
-        }
+        col.EnsureIndex(
+            "embedding_idx",
+            BsonExpression.Create("$.Embedding", db.Expressions),
+            new VectorIndexOptions(2));
 
         var query = "SELECT * FROM vectors WHERE ($.Embedding VECTOR_SIM [1.0, 0.0]) <= 0.25";
-        using var _ = db.EnterExpressionScope();
         var rawResults = db.Execute(query).ToList();
 
         var docs = rawResults
@@ -196,11 +188,7 @@ public class BsonVector_Tests
     public void VectorSim_InfixExpression_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]");
-        }
+        var expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]", db.Expressions);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 
@@ -219,11 +207,7 @@ public class BsonVector_Tests
     public void VectorSim_FunctionCall_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])");
-        }
+        var expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])", db.Expressions);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -19,18 +19,12 @@ namespace LiteDB.Tests.QueryTest
     {
         private static BsonExpression CreateExpression(LiteDatabase db, string expression)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression);
-            }
+            return BsonExpression.Create(expression, db.Expressions);
         }
 
         private static BsonExpression CreateExpression(LiteDatabase db, string expression, params BsonValue[] args)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression, args);
-            }
+            return BsonExpression.Create(expression, db.Expressions, args);
         }
 
         private class VectorDocument

--- a/LiteDB/Client/Database/Collections/Aggregate.cs
+++ b/LiteDB/Client/Database/Collections/Aggregate.cs
@@ -33,10 +33,7 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Count(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -44,10 +41,7 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, args));
-            }
+            return this.Count(this.CreateExpression(predicate, args));
         }
 
         /// <summary>
@@ -87,10 +81,7 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, parameters));
-            }
+            return this.LongCount(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -98,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, args));
-            }
+            return this.LongCount(this.CreateExpression(predicate, args));
         }
 
         /// <summary>
@@ -133,10 +121,7 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Exists(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -144,10 +129,7 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, args));
-            }
+            return this.Exists(this.CreateExpression(predicate, args));
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/Collections/Delete.cs
+++ b/LiteDB/Client/Database/Collections/Delete.cs
@@ -39,10 +39,7 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, parameters));
-            }
+            return this.DeleteMany(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -50,10 +47,7 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, args));
-            }
+            return this.DeleteMany(this.CreateExpression(predicate, args));
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/Collections/Find.cs
+++ b/LiteDB/Client/Database/Collections/Find.cs
@@ -64,10 +64,7 @@ namespace LiteDB
         {
             if (id == null || id.IsNull) throw new ArgumentNullException(nameof(id));
 
-            using (this.EnterExpressionScope())
-            {
-                return this.Find(BsonExpression.Create("_id = @0", id)).FirstOrDefault();
-            }
+            return this.Find(this.CreateExpression("_id = @0", id)).FirstOrDefault();
         }
 
         /// <summary>
@@ -80,10 +77,7 @@ namespace LiteDB
         /// </summary>
         public T FindOne(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, parameters));
-            }
+            return this.FindOne(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -91,10 +85,7 @@ namespace LiteDB
         /// </summary>
         public T FindOne(BsonExpression predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, args));
-            }
+            return this.FindOne(this.CreateExpression(predicate, args));
         }
 
         /// <summary>

--- a/LiteDB/Client/Database/LiteCollection.cs
+++ b/LiteDB/Client/Database/LiteCollection.cs
@@ -32,11 +32,6 @@ namespace LiteDB
         /// </summary>
         public EntityMapper EntityMapper => _entity;
 
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_expressions);
-        }
-
         internal LiteCollection(string name, BsonAutoId autoId, ILiteEngine engine, BsonMapper mapper, IExpressionRegistry expressions)
         {
             _collection = name ?? mapper.ResolveCollectionName(typeof(T));
@@ -72,6 +67,22 @@ namespace LiteDB
                     _autoId = autoId;
                 }
             }
+        }
+
+        internal BsonExpression CreateExpression(string expression, BsonDocument parameters)
+        {
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
+
+            parameters ??= new BsonDocument();
+
+            return BsonExpression.Create(expression, parameters, _expressions);
+        }
+
+        internal BsonExpression CreateExpression(string expression, params BsonValue[] args)
+        {
+            if (expression == null) throw new ArgumentNullException(nameof(expression));
+
+            return BsonExpression.Create(expression, _expressions, args);
         }
     }
 }

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -28,6 +28,8 @@ namespace LiteDB
         /// </summary>
         public BsonMapper Mapper => _mapper;
 
+        internal IExpressionRegistry Expressions => _pluginContext.Expressions;
+
         #endregion
 
         #region Ctor
@@ -52,6 +54,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(connectionString, NullServiceProvider.Instance, NullLogger.Instance);
+            _mapper.ExpressionRegistry = _pluginContext.Expressions;
 
             this.InitializePlugins(plugins);
         }
@@ -76,6 +79,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            _mapper.ExpressionRegistry = _pluginContext.Expressions;
 
             this.InitializePlugins(plugins);
 
@@ -115,6 +119,7 @@ namespace LiteDB
             _disposeOnClose = disposeOnClose;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            _mapper.ExpressionRegistry = _pluginContext.Expressions;
 
             this.InitializePlugins(plugins);
         }
@@ -159,11 +164,6 @@ namespace LiteDB
             if (name.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(name));
 
             return new LiteCollection<BsonDocument>(name, autoId, _engine, _mapper, _pluginContext.Expressions);
-        }
-
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_pluginContext.Expressions);
         }
 
         #endregion
@@ -299,7 +299,7 @@ namespace LiteDB
             if (commandReader == null) throw new ArgumentNullException(nameof(commandReader));
 
             var tokenizer = new Tokenizer(commandReader);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;
@@ -313,7 +313,7 @@ namespace LiteDB
             if (command == null) throw new ArgumentNullException(nameof(command));
 
             var tokenizer = new Tokenizer(command);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -80,10 +80,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, BsonDocument parameters)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, parameters));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, parameters, _expressions));
             return this;
         }
 
@@ -92,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, params BsonValue[] args)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, args));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, _expressions, args));
             return this;
         }
 
@@ -260,18 +254,14 @@ namespace LiteDB
             ValidateVectorArguments(target, maxDistance);
 
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", targetArray, new BsonValue(maxDistance));
-            }
+            return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", _expressions, targetArray, new BsonValue(maxDistance));
         }
 
         internal ILiteQueryable<T> VectorWhereNear(string vectorField, float[] target, double maxDistance)
         {
             if (string.IsNullOrWhiteSpace(vectorField)) throw new ArgumentNullException(nameof(vectorField));
 
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{vectorField}");
+            var fieldExpr = BsonExpression.Create($"$.{vectorField}", _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
@@ -304,8 +294,7 @@ namespace LiteDB
 
         internal ILiteQueryableResult<T> VectorTopKNear(string field, float[] target, int k)
         {
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{field}");
+            var fieldExpr = BsonExpression.Create($"$.{field}", _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
@@ -318,18 +307,15 @@ namespace LiteDB
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
 
             // Build VECTOR_SIM as order clause
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", targetArray);
+            var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", _expressions, targetArray);
 
-                _query.VectorField = fieldExpr.Source;
-                _query.VectorTarget = target?.ToArray();
-                _query.VectorMaxDistance = double.MaxValue;
+            _query.VectorField = fieldExpr.Source;
+            _query.VectorTarget = target?.ToArray();
+            _query.VectorMaxDistance = double.MaxValue;
 
-                return this
-                    .OrderBy(simExpr, Query.Ascending)
-                    .Limit(k);
-            }
+            return this
+                .OrderBy(simExpr, Query.Ascending)
+                .Limit(k);
         }
 
         [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -46,6 +47,8 @@ namespace LiteDB
         /// Global instance used when no BsonMapper are passed in LiteDatabase ctor
         /// </summary>
         public static BsonMapper Global = new BsonMapper();
+
+        internal IExpressionRegistry ExpressionRegistry { get; set; }
 
         /// <summary>
         /// A resolver name for field
@@ -169,7 +172,7 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            var visitor = new LinqExpressionVisitor(this, predicate, this.ExpressionRegistry);
 
             var expr = visitor.Resolve(typeof(K) == typeof(bool));
 
@@ -183,7 +186,7 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            var visitor = new LinqExpressionVisitor(this, predicate, this.ExpressionRegistry);
 
             var expr = visitor.Resolve(false);
 

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -37,6 +38,7 @@ namespace LiteDB
 
         private readonly BsonMapper _mapper;
         private readonly Expression _expr;
+        private readonly IExpressionRegistry _registry;
         private readonly ParameterExpression _rootParameter = null;
 
         private readonly BsonDocument _parameters = new BsonDocument();
@@ -46,10 +48,11 @@ namespace LiteDB
         private readonly StringBuilder _builder = new StringBuilder();
         private readonly Stack<Expression> _nodes = new Stack<Expression>();
 
-        public LinqExpressionVisitor(BsonMapper mapper, Expression expr)
+        public LinqExpressionVisitor(BsonMapper mapper, Expression expr, IExpressionRegistry registry)
         {
             _mapper = mapper;
             _expr = expr;
+            _registry = registry;
 
             if (expr is LambdaExpression lambda)
             {
@@ -71,14 +74,14 @@ namespace LiteDB
 
             try
             {
-                var e = BsonExpression.Create(expression, _parameters);
+                var e = BsonExpression.Create(expression, _parameters, _registry);
 
                 // if expression must return an predicate but expression result is Path/Parameter/Call add `= true`
                 if (predicate && (e.Type == BsonExpressionType.Path || e.Type == BsonExpressionType.Call || e.Type == BsonExpressionType.Parameter))
                 {
                     expression = "(" + expression + " = true)";
 
-                    e = BsonExpression.Create(expression, _parameters);
+                    e = BsonExpression.Create(expression, _parameters, _registry);
                 }
 
                 return e;

--- a/LiteDB/Client/SqlParser/Commands/Create.cs
+++ b/LiteDB/Client/SqlParser/Commands/Create.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             _tokenizer.ReadToken().Expect(TokenType.OpenParenthesis);
 
             // read index expression
-            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument());
+            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument(), _expressions);
 
             // read )
             _tokenizer.ReadToken().Expect(TokenType.CloseParenthesis);

--- a/LiteDB/Client/SqlParser/Commands/Delete.cs
+++ b/LiteDB/Client/SqlParser/Commands/Delete.cs
@@ -24,7 +24,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             _tokenizer.ReadToken().Expect(TokenType.EOF, TokenType.SemiColon);

--- a/LiteDB/Client/SqlParser/Commands/ParseLists.cs
+++ b/LiteDB/Client/SqlParser/Commands/ParseLists.cs
@@ -16,7 +16,7 @@ namespace LiteDB
         {
             while(true)
             {
-                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 yield return expr;
 

--- a/LiteDB/Client/SqlParser/Commands/Select.cs
+++ b/LiteDB/Client/SqlParser/Commands/Select.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             token.Expect("SELECT");
 
             // read required SELECT <expr> and convert into single expression
-            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters);
+            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters, _expressions);
 
             // read FROM|INTO
             var from = _tokenizer.ReadToken();
@@ -88,7 +88,7 @@ namespace LiteDB
                 // read WHERE keyword
                 _tokenizer.ReadToken();
 
-                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.Where.Add(where);
             }
@@ -101,7 +101,7 @@ namespace LiteDB
                 _tokenizer.ReadToken();
                 _tokenizer.ReadToken().Expect("BY");
 
-                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.GroupBy = groupBy;
 
@@ -112,7 +112,7 @@ namespace LiteDB
                     // read HAVING keyword
                     _tokenizer.ReadToken();
 
-                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     query.Having = having;
                 }
@@ -128,7 +128,7 @@ namespace LiteDB
 
                 while (true)
                 {
-                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     var orderByOrder = Query.Ascending;
                     var orderByToken = _tokenizer.LookAhead();

--- a/LiteDB/Client/SqlParser/Commands/Update.cs
+++ b/LiteDB/Client/SqlParser/Commands/Update.cs
@@ -22,7 +22,7 @@ namespace LiteDB
             var collection = _tokenizer.ReadToken().Expect(TokenType.Word).Value;
             _tokenizer.ReadToken().Expect("SET");
 
-            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters);
+            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters, _expressions);
 
             // optional where
             BsonExpression where = null;
@@ -33,7 +33,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             // read eof

--- a/LiteDB/Client/SqlParser/SqlParser.cs
+++ b/LiteDB/Client/SqlParser/SqlParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using LiteDB.Engine;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -16,13 +17,15 @@ namespace LiteDB
         private readonly Tokenizer _tokenizer;
         private readonly BsonDocument _parameters;
         private readonly Lazy<Collation> _collation;
+        private readonly IExpressionRegistry _expressions;
 
-        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters)
+        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters, IExpressionRegistry expressions)
         {
             _engine = engine;
             _tokenizer = tokenizer;
             _parameters = parameters ?? new BsonDocument();
             _collation = new Lazy<Collation>(() => new Collation(_engine.Pragma(Pragmas.COLLATION)));
+            _expressions = expressions;
         }
 
         public IBsonDataReader Execute()

--- a/LiteDB/Client/Storage/LiteStorage.cs
+++ b/LiteDB/Client/Storage/LiteStorage.cs
@@ -68,12 +68,28 @@ namespace LiteDB
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters)
+        {
+            if (_files is LiteCollection<LiteFileInfo<TFileId>> liteCollection)
+            {
+                return this.Find(liteCollection.CreateExpression(predicate, parameters));
+            }
+
+            return this.Find(BsonExpression.Create(predicate, parameters));
+        }
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, args));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args)
+        {
+            if (_files is LiteCollection<LiteFileInfo<TFileId>> liteCollection)
+            {
+                return this.Find(liteCollection.CreateExpression(predicate, args));
+            }
+
+            return this.Find(BsonExpression.Create(predicate, args));
+        }
 
         /// <summary>
         /// Find all files that match with predicate expression.

--- a/LiteDB/Client/Structures/Query.cs
+++ b/LiteDB/Client/Structures/Query.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 
 using System;
 using System.Collections.Generic;
@@ -37,7 +38,7 @@ namespace LiteDB
         public static Query All(int order = Ascending)
         {
             var query = new Query();
-            query.OrderBy.Add(new QueryOrder(BsonExpression.Create("_id"), order));
+            query.OrderBy.Add(new QueryOrder(BsonExpression.Create("_id", (IExpressionRegistry)null), order));
             return query;
         }
 
@@ -47,7 +48,7 @@ namespace LiteDB
         public static Query All(string field, int order = Ascending)
         {
             var query = new Query();
-            query.OrderBy.Add(new QueryOrder(BsonExpression.Create(field), order));
+            query.OrderBy.Add(new QueryOrder(BsonExpression.Create(field, (IExpressionRegistry)null), order));
             return query;
         }
 
@@ -58,7 +59,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} = {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} = {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -68,7 +69,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} < {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} < {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -78,7 +79,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} <= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} <= {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} > {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} > {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -98,7 +99,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} >= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} >= {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -108,7 +109,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -119,7 +120,7 @@ namespace LiteDB
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} LIKE {(new BsonValue(value + "%"))}");
+            return BsonExpression.Create($"{field} LIKE {(new BsonValue(value + "%"))}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -130,7 +131,7 @@ namespace LiteDB
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value.IsNullOrEmpty()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} LIKE {(new BsonValue("%" + value + "%"))}");
+            return BsonExpression.Create($"{field} LIKE {(new BsonValue("%" + value + "%"))}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -140,7 +141,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} != {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} != {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -151,7 +152,7 @@ namespace LiteDB
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value == null) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} IN {value}");
+            return BsonExpression.Create($"{field} IN {value}", (IExpressionRegistry)null);
         }
 
         /// <summary>

--- a/LiteDB/Client/Structures/QueryAny.cs
+++ b/LiteDB/Client/Structures/QueryAny.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -15,7 +16,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY = {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY = {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -25,7 +26,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY < {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY < {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -35,7 +36,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY <= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY <= {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -45,7 +46,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY > {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY > {value ?? BsonValue.Null}", (IExpressionRegistry)null);
 
         }
 
@@ -56,7 +57,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY >= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY >= {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -77,7 +78,7 @@ namespace LiteDB
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
             if (value.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{arrayField} ANY LIKE {(new BsonValue(value + "%"))}");
+            return BsonExpression.Create($"{arrayField} ANY LIKE {(new BsonValue(value + "%"))}", (IExpressionRegistry)null);
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY != {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY != {value ?? BsonValue.Null}", (IExpressionRegistry)null);
         }
     }
 }

--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -8,7 +8,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using LiteDB.Plugins;
 using static LiteDB.Constants;
 
@@ -126,16 +125,12 @@ namespace LiteDB
         /// </summary>
         private BsonExpressionScalarDelegate _funcScalar;
 
-        private static readonly AsyncLocal<IExpressionRegistry> _currentRegistry = new AsyncLocal<IExpressionRegistry>();
+        private static readonly Lazy<IExpressionRegistry> _legacyRegistry = new Lazy<IExpressionRegistry>(() => new ExpressionRegistry());
 
-        internal static IDisposable UseRegistry(IExpressionRegistry registry)
+        private static IExpressionRegistry ResolveRegistry(IExpressionRegistry registry)
         {
-            var previous = _currentRegistry.Value;
-            _currentRegistry.Value = registry;
-            return new RegistryScope(previous);
+            return registry ?? _legacyRegistry.Value;
         }
-
-        internal static IExpressionRegistry CurrentRegistry => _currentRegistry.Value;
 
         /// <summary>
         /// Get default field name when need convert simple BsonValue into BsonDocument
@@ -298,36 +293,72 @@ namespace LiteDB
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression)
         {
-            return Create(expression, new BsonDocument());
+            return Create(expression, new BsonDocument(), ResolveRegistry(null));
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression, params BsonValue[] args)
         {
             var parameters = new BsonDocument();
 
-            for(var i = 0; i < args.Length; i++)
+            for (var i = 0; i < args.Length; i++)
             {
                 parameters[i.ToString()] = args[i];
             }
 
-            return Create(expression, parameters);
+            return Create(expression, parameters, ResolveRegistry(null));
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression, BsonDocument parameters)
+        {
+            return Create(expression, parameters, ResolveRegistry(null));
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry)
+        {
+            return Create(expression, new BsonDocument(), registry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry, params BsonValue[] args)
+        {
+            if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
+
+            var parameters = new BsonDocument();
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                parameters[i.ToString()] = args[i];
+            }
+
+            return Create(expression, parameters, registry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
 
             var tokenizer = new Tokenizer(expression);
 
-            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters);
+            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters, registry);
 
             tokenizer.LookAhead().Expect(TokenType.EOF);
 
@@ -337,21 +368,22 @@ namespace LiteDB
         /// <summary>
         /// Parse tokenizer and create new instance of BsonExpression - for now, do not use cache
         /// </summary>
-        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters)
+        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
 
-            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root);
+            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root, registry);
         }
 
         /// <summary>
         /// Parse and compile string expression and return BsonExpression
         /// </summary>
-        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope)
+        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
 
-            var context = new ExpressionContext();
+            var resolvedRegistry = ResolveRegistry(registry);
+            var context = new ExpressionContext(resolvedRegistry);
 
             var expr =
                 mode == BsonExpressionParserMode.Full ? BsonExpressionParser.ParseFullExpression(tokenizer, context, parameters, scope) :
@@ -411,7 +443,7 @@ namespace LiteDB
         /// <summary>
         /// Get root document $ expression
         /// </summary>
-        public static BsonExpression Root = Create("$");
+        public static BsonExpression Root = Create("$", ResolveRegistry(null));
 
         #endregion
 
@@ -473,24 +505,5 @@ namespace LiteDB
             return $"`{this.Source}` [{this.Type}]";
         }
 
-        private sealed class RegistryScope : IDisposable
-        {
-            private readonly IExpressionRegistry _previous;
-            private bool _disposed;
-
-            public RegistryScope(IExpressionRegistry previous)
-            {
-                _previous = previous;
-            }
-
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    _currentRegistry.Value = _previous;
-                    _disposed = true;
-                }
-            }
-        }
     }
 }

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -111,11 +111,9 @@ namespace LiteDB
             new OperatorDefinition("OR", " OR ", null, BsonExpressionType.Or, (int)BinaryOperatorPrecedence.LogicalOr)
         };
 
-        private static List<OperatorDefinition> GetOperatorTable()
+        private static List<OperatorDefinition> GetOperatorTable(IExpressionRegistry registry)
         {
             var table = new List<OperatorDefinition>(_builtInOperators);
-
-            var registry = BsonExpression.CurrentRegistry;
 
             if (registry != null)
             {
@@ -166,7 +164,7 @@ namespace LiteDB
             while (!tokenizer.EOF)
             {
                 // read operator between expressions
-                var op = ReadOperant(tokenizer);
+                var op = ReadOperant(tokenizer, context.Registry);
 
                 if (op == null) break;
 
@@ -188,7 +186,7 @@ namespace LiteDB
             }
 
             var order = 0;
-            var operatorTable = GetOperatorTable();
+            var operatorTable = GetOperatorTable(context.Registry);
 
             // now, process operator in correct order
             while (values.Count >= 2)
@@ -798,7 +796,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source);
+                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source, context.Registry);
 
                 if (pathExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1131,7 +1129,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current);
+                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current, context.Registry);
 
                 if (mapExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1207,7 +1205,7 @@ namespace LiteDB
                 else
                 {
                     // inner expression
-                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current);
+                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current, context.Registry);
 
                     if (inner == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1257,9 +1255,9 @@ namespace LiteDB
                 case "SORT": return ParseFunction(token, BsonExpressionType.Sort, tokenizer, context, parameters, scope);
             }
 
-            if (BsonExpression.CurrentRegistry is ExpressionRegistry registry)
+            if (context.Registry != null)
             {
-                var registration = registry.FindByName(token);
+                var registration = context.Registry.Functions.FirstOrDefault(f => f.Name.Equals(token, StringComparison.OrdinalIgnoreCase));
 
                 if (registration != null)
                 {
@@ -1316,7 +1314,8 @@ namespace LiteDB
                 tokenizer.ReadToken().Expect(TokenType.Greater);
 
                 var right = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters,
-                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current);
+                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current,
+                    context.Registry);
 
                 src.Append("=>" + right.Source);
                 args.Add(Expression.Constant(right));
@@ -1483,11 +1482,11 @@ namespace LiteDB
         /// <summary>
         /// Read next token as Operant with ANY|ALL keyword before - returns null if next token are not an operant
         /// </summary>
-        private static string ReadOperant(Tokenizer tokenizer)
+        private static string ReadOperant(Tokenizer tokenizer, IExpressionRegistry registry)
         {
             var token = tokenizer.LookAhead(true);
 
-            if (token.IsOperand)
+            if (token.IsOperand(registry))
             {
                 tokenizer.ReadToken(); // consume operant
 
@@ -1502,7 +1501,7 @@ namespace LiteDB
 
                 token = tokenizer.ReadToken();
 
-                if (token.IsOperand == false) throw LiteException.UnexpectedToken("Expected valid operand", token);
+                if (!token.IsOperand(registry)) throw LiteException.UnexpectedToken("Expected valid operand", token);
 
                 return key + " " + token.Value;
             }

--- a/LiteDB/Document/Expression/Parser/ExpressionContext.cs
+++ b/LiteDB/Document/Expression/Parser/ExpressionContext.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,14 +12,17 @@ namespace LiteDB
 {
     internal class ExpressionContext
     {
-        public ExpressionContext()
+        public ExpressionContext(IExpressionRegistry registry)
         {
+            this.Registry = registry;
             this.Source = Expression.Parameter(typeof(IEnumerable<BsonDocument>), "source");
             this.Root = Expression.Parameter(typeof(BsonDocument), "root");
             this.Current = Expression.Parameter(typeof(BsonValue), "current");
             this.Collation = Expression.Parameter(typeof(Collation), "collation");
             this.Parameters = Expression.Parameter(typeof(BsonDocument), "parameters");
         }
+
+        public IExpressionRegistry Registry { get; }
 
         public ParameterExpression Source { get; }
         public ParameterExpression Root { get; }

--- a/LiteDB/Engine/Engine/Insert.cs
+++ b/LiteDB/Engine/Engine/Insert.cs
@@ -78,7 +78,7 @@ namespace LiteDB.Engine
             {
                 // for each index, get all keys (supports multi-key) - gets distinct values only
                 // if index are unique, get single key only
-                var keys = index.BsonExpr.GetIndexKeys(doc, _header.Pragmas.Collation);
+                var keys = index.GetExpression(_plugins?.Expressions).GetIndexKeys(doc, _header.Pragmas.Collation);
 
                 // do a loop with all keys (multi-key supported)
                 foreach(var key in keys)

--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -85,7 +85,7 @@ namespace LiteDB.Engine
                             this.EnsureVectorIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                BsonExpression.Create(index.Expression, _plugins?.Expressions),
                                 new VectorIndexOptions(index.VectorMetadata.Dimensions, index.VectorMetadata.Metric));
                         }
                         else
@@ -93,7 +93,7 @@ namespace LiteDB.Engine
                             this.EnsureIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                BsonExpression.Create(index.Expression, _plugins?.Expressions),
                                 index.Unique);
                         }
                     }

--- a/LiteDB/Engine/Engine/Update.cs
+++ b/LiteDB/Engine/Engine/Update.cs
@@ -131,7 +131,7 @@ namespace LiteDB.Engine
             foreach (var index in col.GetCollectionIndexes().Where(x => x.Name != "_id" && x.IndexType == 0))
             {
                 // getting all keys from expression over document
-                var keys = index.BsonExpr.GetIndexKeys(doc, _header.Pragmas.Collation);
+                var keys = index.GetExpression(_plugins?.Expressions).GetIndexKeys(doc, _header.Pragmas.Collation);
 
                 foreach (var key in keys)
                 {

--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Plugins;
 using LiteDB.Vector;
 using static LiteDB.Constants;
 
@@ -156,6 +157,15 @@ namespace LiteDB.Engine
             }
 
             return indexes;
+        }
+
+        public void BindExpressions(IExpressionRegistry registry)
+        {
+            foreach (var index in _indexes.Values)
+            {
+                index.ResetExpression();
+                index.GetExpression(registry);
+            }
         }
 
         private int GetSerializedLength(int additionalIndexLength, int additionalVectorLength)

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -128,7 +128,7 @@ namespace LiteDB.Engine
                     term.Type == BsonExpressionType.Equal &&
                     term.Right?.Type == BsonExpressionType.Path)
                 {
-                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters);
+                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters, _snapshot.Plugins?.Expressions);
                 }
             }
         }
@@ -281,7 +281,7 @@ namespace LiteDB.Engine
                 if (index == null) continue;
 
                 // calculate index score and store highest score
-                var current = new IndexCost(index.Item1, expr, index.Item2, _collation);
+                var current = new IndexCost(index.Item1, expr, index.Item2, _collation, _snapshot.Plugins?.Expressions);
 
                 if (lowest == null || current.Cost < lowest.Cost)
                 {
@@ -300,7 +300,7 @@ namespace LiteDB.Engine
 
                 if (index != null)
                 {
-                    lowest = new IndexCost(index);
+                    lowest = new IndexCost(index, _snapshot.Plugins?.Expressions);
                 }
             }
 

--- a/LiteDB/Engine/Query/Structures/IndexCost.cs
+++ b/LiteDB/Engine/Query/Structures/IndexCost.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -28,7 +29,7 @@ namespace LiteDB.Engine
         /// </summary>
         public Index Index { get; }
 
-        public IndexCost(CollectionIndex index, BsonExpression expr, BsonExpression value, Collation collation)
+        public IndexCost(CollectionIndex index, BsonExpression expr, BsonExpression value, Collation collation, IExpressionRegistry registry)
         {
             this.IndexExpression = index.Expression;
             this.Expression = expr;
@@ -67,9 +68,9 @@ namespace LiteDB.Engine
         }
 
         // used when full index search
-        public IndexCost(CollectionIndex index)
+        public IndexCost(CollectionIndex index, IExpressionRegistry registry)
         {
-            this.Expression = BsonExpression.Create(index.Expression);
+            this.Expression = index.GetExpression(registry);
             this.Index = new IndexAll(index.Name, Query.Ascending);
             this.Cost = this.Index.GetCost(index);
             this.IndexExpression = index.Expression;

--- a/LiteDB/Engine/Services/IndexService.cs
+++ b/LiteDB/Engine/Services/IndexService.cs
@@ -39,6 +39,9 @@ namespace LiteDB.Engine
             // create index ref
             var index = _snapshot.CollectionPage.InsertCollectionIndex(name, expr, unique);
 
+            index.ResetExpression();
+            index.GetExpression(_snapshot.Plugins?.Expressions);
+
             // insert head/tail nodes
             var head = indexPage.InsertIndexNode(index.Slot, MAX_LEVEL_LENGTH, BsonValue.MinValue, PageAddress.Empty, bytesLength);
             var tail = indexPage.InsertIndexNode(index.Slot, MAX_LEVEL_LENGTH, BsonValue.MaxValue, PageAddress.Empty, bytesLength);

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -87,6 +87,7 @@ namespace LiteDB.Engine
             // clear local pages (will clear _collectionPage link reference)
             if (_collectionPage != null)
             {
+                _collectionPage.BindExpressions(_plugins?.Expressions);
                 // local pages contains only data/index pages
                 _localPages.Remove(_collectionPage.PageID);
             }

--- a/LiteDB/Engine/Services/VectorIndexService.cs
+++ b/LiteDB/Engine/Services/VectorIndexService.cs
@@ -41,7 +41,7 @@ namespace LiteDB.Engine
 
         public void Upsert(CollectionIndex index, VectorIndexMetadata metadata, BsonDocument document, PageAddress dataBlock)
         {
-            var value = index.BsonExpr.ExecuteScalar(document, _collation);
+            var value = index.GetExpression(_snapshot.Plugins?.Expressions).ExecuteScalar(document, _collation);
 
             if (!TryExtractVector(value, metadata.Dimensions, out var vector))
             {

--- a/LiteDB/Engine/Structures/CollectionIndex.cs
+++ b/LiteDB/Engine/Structures/CollectionIndex.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -27,10 +29,7 @@ namespace LiteDB.Engine
         /// </summary>
         public string Expression { get; }
 
-        /// <summary>
-        /// Get BsonExpression from Expression
-        /// </summary>
-        public BsonExpression BsonExpr { get; }
+        private BsonExpression _bsonExpr;
 
         /// <summary>
         /// Indicate if this index has distinct values only
@@ -73,8 +72,6 @@ namespace LiteDB.Engine
             this.Expression = expr;
             this.Unique = unique;
             this.FreeIndexPageList = uint.MaxValue;
-
-            this.BsonExpr = BsonExpression.Create(expr);
         }
 
         public CollectionIndex(BufferReader reader)
@@ -88,8 +85,25 @@ namespace LiteDB.Engine
             this.Tail = reader.ReadPageAddress(); // 5
             this.Reserved = reader.ReadByte(); // 1
             this.FreeIndexPageList = reader.ReadUInt32(); // 4
+        }
 
-            this.BsonExpr = BsonExpression.Create(this.Expression);
+        public BsonExpression GetExpression(IExpressionRegistry registry)
+        {
+            var cached = Volatile.Read(ref _bsonExpr);
+
+            if (cached == null)
+            {
+                var created = BsonExpression.Create(this.Expression, registry);
+                Interlocked.CompareExchange(ref _bsonExpr, created, null);
+                cached = _bsonExpr;
+            }
+
+            return cached;
+        }
+
+        public void ResetExpression()
+        {
+            Volatile.Write(ref _bsonExpr, null);
         }
 
         public void UpdateBuffer(BufferWriter writer)

--- a/LiteDB/Engine/SystemCollections/SysQuery.cs
+++ b/LiteDB/Engine/SystemCollections/SysQuery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -12,18 +13,20 @@ namespace LiteDB.Engine
     /// </summary>
     internal class SysQuery : SystemCollection
     {
-        private readonly ILiteEngine _engine;
+        private readonly LiteEngine _engine;
+        private readonly IExpressionRegistry _expressions;
 
-        public SysQuery(ILiteEngine engine) : base("$query")
+        public SysQuery(LiteEngine engine) : base("$query")
         {
-            _engine = engine; 
+            _engine = engine;
+            _expressions = engine.PluginContext?.Expressions;
         }
 
         public override IEnumerable<BsonDocument> Input(BsonValue options)
         {
             var query = options?.AsString ?? throw new LiteException(0, $"Collection $query(sql) requires `sql` string parameter");
 
-            var sql = new SqlParser(_engine, new Tokenizer(query), null);
+            var sql = new SqlParser(_engine, new Tokenizer(query), null, _expressions);
 
             using (var reader = sql.Execute())
             {

--- a/LiteDB/Utils/Tokenizer.cs
+++ b/LiteDB/Utils/Tokenizer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -168,41 +169,36 @@ namespace LiteDB
                 value.Equals(this.Value, ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
         }
 
-        public bool IsOperand
+        public bool IsOperand(IExpressionRegistry registry)
         {
-            get
+            switch (this.Type)
             {
-                switch (this.Type)
-                {
-                    case TokenType.Percent:
-                    case TokenType.Slash:
-                    case TokenType.Asterisk:
-                    case TokenType.Plus:
-                    case TokenType.Minus:
-                    case TokenType.Equals:
-                    case TokenType.Greater:
-                    case TokenType.GreaterOrEquals:
-                    case TokenType.Less:
-                    case TokenType.LessOrEquals:
-                    case TokenType.NotEquals:
+                case TokenType.Percent:
+                case TokenType.Slash:
+                case TokenType.Asterisk:
+                case TokenType.Plus:
+                case TokenType.Minus:
+                case TokenType.Equals:
+                case TokenType.Greater:
+                case TokenType.GreaterOrEquals:
+                case TokenType.Less:
+                case TokenType.LessOrEquals:
+                case TokenType.NotEquals:
+                    return true;
+                case TokenType.Word:
+                    if (_keywords.Contains(Value))
+                    {
                         return true;
-                    case TokenType.Word:
-                        if (_keywords.Contains(Value))
-                        {
-                            return true;
-                        }
+                    }
 
-                        var registry = BsonExpression.CurrentRegistry;
+                    if (registry != null && (registry.ContainsKeyword(Value) || registry.ContainsOperator(Value)))
+                    {
+                        return true;
+                    }
 
-                        if (registry != null && (registry.ContainsKeyword(Value) || registry.ContainsOperator(Value)))
-                        {
-                            return true;
-                        }
-
-                        return false;
-                    default:
-                        return false;
-                }
+                    return false;
+                default:
+                    return false;
             }
         }
 


### PR DESCRIPTION
## Summary
- replace the ambient AsyncLocal registry in `BsonExpression` with overloads that accept an `IExpressionRegistry`, keeping obsolete shims that resolve a legacy fallback
- flow the per-database registry from `LiteDatabase` into collections, SQL parsing, LINQ translation, and engine index paths so expression parsing no longer depends on static state
- expose the registry through `LiteDatabase`/`BsonMapper` and update tests and benchmarks to call the new overloads explicitly

## Testing
- dotnet test LiteDB.sln --settings tests.runsettings *(net461/net481 runs abort in this environment because mono is unavailable; net8.0 and other supported TFMs pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ec409177ac8326a8e1a131e9b60cdd