### PR TITLE
Make expression registry explicit across rebuild and query helpers

### DIFF
--- a/LiteDB/Client/Database/Collections/Aggregate.cs
+++ b/LiteDB/Client/Database/Collections/Aggregate.cs
@@ -33,10 +33,7 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Count(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -44,16 +41,13 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, args));
-            }
+            return this.Count(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Count documents matching a query. This method does not deserialize any documents. Needs indexes on query expression
         /// </summary>
-        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate));
+        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -87,10 +81,7 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, parameters));
-            }
+            return this.LongCount(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -98,16 +89,13 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, args));
-            }
+            return this.LongCount(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate));
+        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -133,10 +121,7 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Exists(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -144,16 +129,13 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, args));
-            }
+            return this.Exists(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
         /// </summary>
-        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate));
+        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
@@ -193,7 +175,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Min(expr);
 
@@ -229,7 +211,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Max(expr);
 

--- a/LiteDB/Client/Database/Collections/Delete.cs
+++ b/LiteDB/Client/Database/Collections/Delete.cs
@@ -39,10 +39,7 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, parameters));
-            }
+            return this.DeleteMany(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -50,15 +47,12 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, args));
-            }
+            return this.DeleteMany(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Delete all documents based on predicate expression. Returns how many documents was deleted
         /// </summary>
-        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate));
+        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate, _expressions));
     }
 }

--- a/LiteDB/Client/Database/Collections/Find.cs
+++ b/LiteDB/Client/Database/Collections/Find.cs
@@ -51,7 +51,7 @@ namespace LiteDB
         /// <summary>
         /// Find documents inside a collection using predicate expression.
         /// </summary>
-        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate), skip, limit);
+        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate, _expressions), skip, limit);
 
         #endregion
 
@@ -64,10 +64,7 @@ namespace LiteDB
         {
             if (id == null || id.IsNull) throw new ArgumentNullException(nameof(id));
 
-            using (this.EnterExpressionScope())
-            {
-                return this.Find(BsonExpression.Create("_id = @0", id)).FirstOrDefault();
-            }
+            return this.Find(BsonExpression.Create("_id = @0", _expressions, id)).FirstOrDefault();
         }
 
         /// <summary>
@@ -80,10 +77,7 @@ namespace LiteDB
         /// </summary>
         public T FindOne(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, parameters));
-            }
+            return this.FindOne(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -91,16 +85,13 @@ namespace LiteDB
         /// </summary>
         public T FindOne(BsonExpression predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, args));
-            }
+            return this.FindOne(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Find the first document using predicate expression. Returns null if not found
         /// </summary>
-        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate));
+        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Find the first document using defined query structure. Returns null if not found

--- a/LiteDB/Client/Database/Collections/Include.cs
+++ b/LiteDB/Client/Database/Collections/Include.cs
@@ -15,7 +15,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var path = _mapper.GetExpression(keySelector);
+            var path = _mapper.GetExpression(keySelector, _expressions);
 
             return this.Include(path);
         }

--- a/LiteDB/Client/Database/Collections/Index.cs
+++ b/LiteDB/Client/Database/Collections/Index.cs
@@ -129,7 +129,7 @@ namespace LiteDB
         /// </summary>
         private BsonExpression GetIndexExpression<K>(Expression<Func<T, K>> keySelector, bool convertEnumerableToMultiKey = true)
         {
-            var expression = _mapper.GetIndexExpression(keySelector);
+            var expression = _mapper.GetIndexExpression(keySelector, _expressions);
 
             if (convertEnumerableToMultiKey && typeof(K).IsEnumerable() && expression.IsScalar == true)
             {

--- a/LiteDB/Client/Database/Collections/Update.cs
+++ b/LiteDB/Client/Database/Collections/Update.cs
@@ -74,8 +74,8 @@ namespace LiteDB
             if (extend == null) throw new ArgumentNullException(nameof(extend));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            var ext = _mapper.GetExpression(extend);
-            var pred = _mapper.GetExpression(predicate);
+            var ext = _mapper.GetExpression(extend, _expressions);
+            var pred = _mapper.GetExpression(predicate, _expressions);
 
             if (ext.Type != BsonExpressionType.Document)
             {

--- a/LiteDB/Client/Database/LiteCollection.cs
+++ b/LiteDB/Client/Database/LiteCollection.cs
@@ -32,11 +32,6 @@ namespace LiteDB
         /// </summary>
         public EntityMapper EntityMapper => _entity;
 
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_expressions);
-        }
-
         internal LiteCollection(string name, BsonAutoId autoId, ILiteEngine engine, BsonMapper mapper, IExpressionRegistry expressions)
         {
             _collection = name ?? mapper.ResolveCollectionName(typeof(T));

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -28,6 +28,23 @@ namespace LiteDB
         /// </summary>
         public BsonMapper Mapper => _mapper;
 
+        /// <summary>
+        /// Provides access to services and registries associated with this database instance.
+        /// </summary>
+        public LiteDatabaseServices Services { get; }
+
+        public sealed class LiteDatabaseServices
+        {
+            private readonly ILitePluginContext _context;
+
+            internal LiteDatabaseServices(ILitePluginContext context)
+            {
+                _context = context ?? throw new ArgumentNullException(nameof(context));
+            }
+
+            public IExpressionRegistry ExpressionRegistry => _context.Expressions;
+        }
+
         #endregion
 
         #region Ctor
@@ -52,6 +69,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(connectionString, NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(plugins);
         }
@@ -76,6 +94,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(plugins);
 
@@ -115,6 +134,7 @@ namespace LiteDB
             _disposeOnClose = disposeOnClose;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(plugins);
         }
@@ -159,11 +179,6 @@ namespace LiteDB
             if (name.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(name));
 
             return new LiteCollection<BsonDocument>(name, autoId, _engine, _mapper, _pluginContext.Expressions);
-        }
-
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_pluginContext.Expressions);
         }
 
         #endregion
@@ -298,7 +313,7 @@ namespace LiteDB
         {
             if (commandReader == null) throw new ArgumentNullException(nameof(commandReader));
 
-            var tokenizer = new Tokenizer(commandReader);
+            var tokenizer = new Tokenizer(commandReader, _pluginContext.Expressions);
             var sql = new SqlParser(_engine, tokenizer, parameters);
             var reader = sql.Execute();
 
@@ -312,7 +327,7 @@ namespace LiteDB
         {
             if (command == null) throw new ArgumentNullException(nameof(command));
 
-            var tokenizer = new Tokenizer(command);
+            var tokenizer = new Tokenizer(command, _pluginContext.Expressions);
             var sql = new SqlParser(_engine, tokenizer, parameters);
             var reader = sql.Execute();
 

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -40,7 +40,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Include<K>(Expression<Func<T, K>> path)
         {
-            _query.Includes.Add(_mapper.GetExpression(path));
+            _query.Includes.Add(_mapper.GetExpression(path, _expressions));
             return this;
         }
 
@@ -80,10 +80,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, BsonDocument parameters)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, parameters));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, parameters, _expressions));
             return this;
         }
 
@@ -92,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, params BsonValue[] args)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, args));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, _expressions, args));
             return this;
         }
 
@@ -104,7 +98,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(Expression<Func<T, bool>> predicate)
         {
-            return this.Where(_mapper.GetExpression(predicate));
+            return this.Where(_mapper.GetExpression(predicate, _expressions));
         }
 
         #endregion
@@ -127,7 +121,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> OrderBy<K>(Expression<Func<T, K>> keySelector, int order = Query.Ascending)
         {
-            return this.OrderBy(_mapper.GetExpression(keySelector), order);
+            return this.OrderBy(_mapper.GetExpression(keySelector, _expressions), order);
         }
 
         /// <summary>
@@ -156,7 +150,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenBy<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenBy(_mapper.GetExpression(keySelector));
+            return this.ThenBy(_mapper.GetExpression(keySelector, _expressions));
         }
 
         /// <summary>
@@ -175,7 +169,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenByDescending<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenByDescending(_mapper.GetExpression(keySelector));
+            return this.ThenByDescending(_mapper.GetExpression(keySelector, _expressions));
         }
 
         #endregion
@@ -187,7 +181,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<IGrouping<K, T>> GroupBy<K>(Expression<Func<T, K>> keySelector)
         {
-            var expression = _mapper.GetExpression(keySelector);
+            var expression = _mapper.GetExpression(keySelector, _expressions);
 
             this.GroupBy(expression);
 
@@ -241,7 +235,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<K> Select<K>(Expression<Func<T, K>> selector)
         {
-            _query.Select = _mapper.GetExpression(selector);
+            _query.Select = _mapper.GetExpression(selector, _expressions);
 
             return new LiteQueryable<K>(_engine, _mapper, _collection, _query, _expressions);
         }
@@ -260,18 +254,14 @@ namespace LiteDB
             ValidateVectorArguments(target, maxDistance);
 
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", targetArray, new BsonValue(maxDistance));
-            }
+            return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", _expressions, targetArray, new BsonValue(maxDistance));
         }
 
         internal ILiteQueryable<T> VectorWhereNear(string vectorField, float[] target, double maxDistance)
         {
             if (string.IsNullOrWhiteSpace(vectorField)) throw new ArgumentNullException(nameof(vectorField));
 
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{vectorField}");
+            var fieldExpr = BsonExpression.Create($"$.{vectorField}", _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
@@ -292,20 +282,19 @@ namespace LiteDB
         {
             if (field == null) throw new ArgumentNullException(nameof(field));
 
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear<K>(Expression<Func<T, K>> field, float[] target, int k)
         {
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear(string field, float[] target, int k)
         {
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{field}");
+            var fieldExpr = BsonExpression.Create($"$.{field}", _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
@@ -318,18 +307,15 @@ namespace LiteDB
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
 
             // Build VECTOR_SIM as order clause
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", targetArray);
+            var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", _expressions, targetArray);
 
-                _query.VectorField = fieldExpr.Source;
-                _query.VectorTarget = target?.ToArray();
-                _query.VectorMaxDistance = double.MaxValue;
+            _query.VectorField = fieldExpr.Source;
+            _query.VectorTarget = target?.ToArray();
+            _query.VectorMaxDistance = double.MaxValue;
 
-                return this
-                    .OrderBy(simExpr, Query.Ascending)
-                    .Limit(k);
-            }
+            return this
+                .OrderBy(simExpr, Query.Ascending)
+                .Limit(k);
         }
 
         [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -167,9 +168,9 @@ namespace LiteDB
         /// <summary>
         /// Resolve LINQ expression into BsonExpression
         /// </summary>
-        public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate)
+        public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry registry = null)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            var visitor = new LinqExpressionVisitor(this, predicate, registry);
 
             var expr = visitor.Resolve(typeof(K) == typeof(bool));
 
@@ -181,9 +182,9 @@ namespace LiteDB
         /// <summary>
         /// Resolve LINQ expression into BsonExpression (for index only)
         /// </summary>
-        public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate)
+        public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry registry = null)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            var visitor = new LinqExpressionVisitor(this, predicate, registry);
 
             var expr = visitor.Resolve(false);
 

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -46,10 +47,13 @@ namespace LiteDB
         private readonly StringBuilder _builder = new StringBuilder();
         private readonly Stack<Expression> _nodes = new Stack<Expression>();
 
-        public LinqExpressionVisitor(BsonMapper mapper, Expression expr)
+        private readonly IExpressionRegistry _registry;
+
+        public LinqExpressionVisitor(BsonMapper mapper, Expression expr, IExpressionRegistry registry = null)
         {
             _mapper = mapper;
             _expr = expr;
+            _registry = registry;
 
             if (expr is LambdaExpression lambda)
             {
@@ -71,14 +75,14 @@ namespace LiteDB
 
             try
             {
-                var e = BsonExpression.Create(expression, _parameters);
+                var e = BsonExpression.Create(expression, _parameters, _registry);
 
                 // if expression must return an predicate but expression result is Path/Parameter/Call add `= true`
                 if (predicate && (e.Type == BsonExpressionType.Path || e.Type == BsonExpressionType.Call || e.Type == BsonExpressionType.Parameter))
                 {
                     expression = "(" + expression + " = true)";
 
-                    e = BsonExpression.Create(expression, _parameters);
+                    e = BsonExpression.Create(expression, _parameters, _registry);
                 }
 
                 return e;

--- a/LiteDB/Client/Shared/SharedEngine.cs
+++ b/LiteDB/Client/Shared/SharedEngine.cs
@@ -17,6 +17,8 @@ namespace LiteDB
         private bool _transactionRunning = false;
         private ILitePluginContext _plugins;
 
+        internal ILitePluginContext PluginContext => _plugins;
+
         public SharedEngine(EngineSettings settings)
         {
             _settings = settings;

--- a/LiteDB/Client/SqlParser/Commands/Create.cs
+++ b/LiteDB/Client/SqlParser/Commands/Create.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             _tokenizer.ReadToken().Expect(TokenType.OpenParenthesis);
 
             // read index expression
-            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument());
+            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument(), _tokenizer.ExpressionRegistry);
 
             // read )
             _tokenizer.ReadToken().Expect(TokenType.CloseParenthesis);

--- a/LiteDB/Client/SqlParser/Commands/Delete.cs
+++ b/LiteDB/Client/SqlParser/Commands/Delete.cs
@@ -24,7 +24,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.ExpressionRegistry);
             }
 
             _tokenizer.ReadToken().Expect(TokenType.EOF, TokenType.SemiColon);

--- a/LiteDB/Client/SqlParser/Commands/ParseLists.cs
+++ b/LiteDB/Client/SqlParser/Commands/ParseLists.cs
@@ -16,7 +16,7 @@ namespace LiteDB
         {
             while(true)
             {
-                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.ExpressionRegistry);
 
                 yield return expr;
 

--- a/LiteDB/Client/SqlParser/Commands/Select.cs
+++ b/LiteDB/Client/SqlParser/Commands/Select.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             token.Expect("SELECT");
 
             // read required SELECT <expr> and convert into single expression
-            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters);
+            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters, _tokenizer.ExpressionRegistry);
 
             // read FROM|INTO
             var from = _tokenizer.ReadToken();
@@ -88,7 +88,7 @@ namespace LiteDB
                 // read WHERE keyword
                 _tokenizer.ReadToken();
 
-                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.ExpressionRegistry);
 
                 query.Where.Add(where);
             }
@@ -101,7 +101,7 @@ namespace LiteDB
                 _tokenizer.ReadToken();
                 _tokenizer.ReadToken().Expect("BY");
 
-                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.ExpressionRegistry);
 
                 query.GroupBy = groupBy;
 
@@ -112,7 +112,7 @@ namespace LiteDB
                     // read HAVING keyword
                     _tokenizer.ReadToken();
 
-                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.ExpressionRegistry);
 
                     query.Having = having;
                 }
@@ -128,7 +128,7 @@ namespace LiteDB
 
                 while (true)
                 {
-                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.ExpressionRegistry);
 
                     var orderByOrder = Query.Ascending;
                     var orderByToken = _tokenizer.LookAhead();

--- a/LiteDB/Client/SqlParser/Commands/Update.cs
+++ b/LiteDB/Client/SqlParser/Commands/Update.cs
@@ -22,7 +22,7 @@ namespace LiteDB
             var collection = _tokenizer.ReadToken().Expect(TokenType.Word).Value;
             _tokenizer.ReadToken().Expect("SET");
 
-            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters);
+            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters, _tokenizer.ExpressionRegistry);
 
             // optional where
             BsonExpression where = null;
@@ -33,7 +33,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.ExpressionRegistry);
             }
 
             // read eof

--- a/LiteDB/Client/Storage/LiteStorage.cs
+++ b/LiteDB/Client/Storage/LiteStorage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -15,12 +16,14 @@ namespace LiteDB
         private readonly ILiteDatabase _db;
         private readonly ILiteCollection<LiteFileInfo<TFileId>> _files;
         private readonly ILiteCollection<BsonDocument> _chunks;
+        private readonly IExpressionRegistry _expressions;
 
         public LiteStorage(ILiteDatabase db, string filesCollection, string chunksCollection)
         {
             _db = db;
             _files = db.GetCollection<LiteFileInfo<TFileId>>(filesCollection);
             _chunks = db.GetCollection(chunksCollection);
+            _expressions = (db as LiteDatabase)?.Services.ExpressionRegistry;
         }
 
         #region Find Files
@@ -68,17 +71,17 @@ namespace LiteDB
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters, _expressions));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, args));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, _expressions, args));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate) => this.Find(_db.Mapper.GetExpression(predicate));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate) => this.Find(_db.Mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Find all files inside file collections

--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -8,7 +8,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
+using System.Runtime.CompilerServices;
 using LiteDB.Plugins;
 using static LiteDB.Constants;
 
@@ -126,16 +126,12 @@ namespace LiteDB
         /// </summary>
         private BsonExpressionScalarDelegate _funcScalar;
 
-        private static readonly AsyncLocal<IExpressionRegistry> _currentRegistry = new AsyncLocal<IExpressionRegistry>();
+        private static readonly IExpressionRegistry _legacyRegistry = new ExpressionRegistry();
 
-        internal static IDisposable UseRegistry(IExpressionRegistry registry)
+        internal static IExpressionRegistry GetRegistryOrDefault(IExpressionRegistry registry)
         {
-            var previous = _currentRegistry.Value;
-            _currentRegistry.Value = registry;
-            return new RegistryScope(previous);
+            return registry ?? _legacyRegistry;
         }
-
-        internal static IExpressionRegistry CurrentRegistry => _currentRegistry.Value;
 
         /// <summary>
         /// Get default field name when need convert simple BsonValue into BsonDocument
@@ -292,42 +288,100 @@ namespace LiteDB
 
         #region Static method
 
-        private static readonly ConcurrentDictionary<string, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<string, BsonExpressionEnumerableDelegate>();
-        private static readonly ConcurrentDictionary<string, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<string, BsonExpressionScalarDelegate>();
-
-        /// <summary>
-        /// Parse string and create new instance of BsonExpression - can be cached
-        /// </summary>
-        public static BsonExpression Create(string expression)
+        private readonly struct ExpressionCacheKey : IEquatable<ExpressionCacheKey>
         {
-            return Create(expression, new BsonDocument());
-        }
-
-        /// <summary>
-        /// Parse string and create new instance of BsonExpression - can be cached
-        /// </summary>
-        public static BsonExpression Create(string expression, params BsonValue[] args)
-        {
-            var parameters = new BsonDocument();
-
-            for(var i = 0; i < args.Length; i++)
+            public ExpressionCacheKey(IExpressionRegistry registry, string source)
             {
-                parameters[i.ToString()] = args[i];
+                this.Registry = registry;
+                this.Source = source ?? throw new ArgumentNullException(nameof(source));
             }
 
-            return Create(expression, parameters);
+            public IExpressionRegistry Registry { get; }
+
+            public string Source { get; }
+
+            public bool Equals(ExpressionCacheKey other)
+            {
+                return ReferenceEquals(this.Registry, other.Registry) && string.Equals(this.Source, other.Source, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is ExpressionCacheKey other && this.Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                var registryHash = this.Registry != null ? RuntimeHelpers.GetHashCode(this.Registry) : 0;
+                unchecked
+                {
+                    var hash = 17;
+                    hash = (hash * 31) + registryHash;
+                    hash = (hash * 31) + this.Source.GetHashCode();
+                    return hash;
+                }
+            }
+        }
+
+        private static readonly ConcurrentDictionary<ExpressionCacheKey, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<ExpressionCacheKey, BsonExpressionEnumerableDelegate>();
+        private static readonly ConcurrentDictionary<ExpressionCacheKey, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<ExpressionCacheKey, BsonExpressionScalarDelegate>();
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Create(string expression)
+        {
+            return Create(expression, new BsonDocument(), null);
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Create(string expression, params BsonValue[] args)
+        {
+            return Create(expression, BuildParameters(args), null);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression, BsonDocument parameters)
+        {
+            return Create(expression, parameters, null);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry)
+        {
+            return Create(expression, new BsonDocument(), registry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry, params BsonValue[] args)
+        {
+            return Create(expression, BuildParameters(args), registry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
 
-            var tokenizer = new Tokenizer(expression);
+            if (parameters == null) throw new ArgumentNullException(nameof(parameters));
 
-            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters);
+            var effectiveRegistry = GetRegistryOrDefault(registry);
+            var tokenizer = new Tokenizer(expression, effectiveRegistry);
+
+            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters, effectiveRegistry);
 
             tokenizer.LookAhead().Expect(TokenType.EOF);
 
@@ -335,19 +389,44 @@ namespace LiteDB
         }
 
         /// <summary>
+        /// Parse string and compile into a BsonExpression using the provided registry.
+        /// </summary>
+        public static BsonExpression Compile(string expression, IExpressionRegistry registry)
+        {
+            return Create(expression, registry);
+        }
+
+        private static BsonDocument BuildParameters(BsonValue[] args)
+        {
+            var parameters = new BsonDocument();
+
+            if (args == null)
+            {
+                return parameters;
+            }
+
+            for (var i = 0; i < args.Length; i++)
+            {
+                parameters[i.ToString()] = args[i];
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
         /// Parse tokenizer and create new instance of BsonExpression - for now, do not use cache
         /// </summary>
-        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters)
+        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
 
-            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root);
+            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root, registry);
         }
 
         /// <summary>
         /// Parse and compile string expression and return BsonExpression
         /// </summary>
-        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope)
+        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
 
@@ -360,18 +439,22 @@ namespace LiteDB
                 BsonExpressionParser.ParseUpdateDocumentBuilder(tokenizer, context, parameters);
 
             // compile linq expression (with left+right expressions)
-            Compile(expr, context);
+            Compile(expr, context, registry);
 
             return expr;
         }
 
-        internal static void Compile(BsonExpression expr, ExpressionContext context)
+        internal static void Compile(BsonExpression expr, ExpressionContext context, IExpressionRegistry registry)
         {
+            var effectiveRegistry = GetRegistryOrDefault(registry);
+
             // compile linq expression according with return type (scalar or enumerable)
             // in both case, try use cached compiled version
             if (expr.IsScalar)
             {
-                var cached = _cacheScalar.GetOrAdd(expr.Source, s =>
+                var key = new ExpressionCacheKey(effectiveRegistry, expr.Source);
+
+                var cached = _cacheScalar.GetOrAdd(key, _ =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionScalarDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -382,7 +465,9 @@ namespace LiteDB
             }
             else
             {
-                var cached = _cacheEnumerable.GetOrAdd(expr.Source, s =>
+                var key = new ExpressionCacheKey(effectiveRegistry, expr.Source);
+
+                var cached = _cacheEnumerable.GetOrAdd(key, _ =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionEnumerableDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -393,8 +478,8 @@ namespace LiteDB
             }
 
             // compile child expressions (left/right)
-            if (expr.Left != null) Compile(expr.Left, context);
-            if (expr.Right != null) Compile(expr.Right, context);
+            if (expr.Left != null) Compile(expr.Left, context, registry);
+            if (expr.Right != null) Compile(expr.Right, context, registry);
         }
 
         /// <summary>
@@ -411,7 +496,7 @@ namespace LiteDB
         /// <summary>
         /// Get root document $ expression
         /// </summary>
-        public static BsonExpression Root = Create("$");
+        public static BsonExpression Root = Create("$", _legacyRegistry);
 
         #endregion
 
@@ -473,24 +558,5 @@ namespace LiteDB
             return $"`{this.Source}` [{this.Type}]";
         }
 
-        private sealed class RegistryScope : IDisposable
-        {
-            private readonly IExpressionRegistry _previous;
-            private bool _disposed;
-
-            public RegistryScope(IExpressionRegistry previous)
-            {
-                _previous = previous;
-            }
-
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    _currentRegistry.Value = _previous;
-                    _disposed = true;
-                }
-            }
-        }
     }
 }

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -111,11 +111,11 @@ namespace LiteDB
             new OperatorDefinition("OR", " OR ", null, BsonExpressionType.Or, (int)BinaryOperatorPrecedence.LogicalOr)
         };
 
-        private static List<OperatorDefinition> GetOperatorTable()
+        private static List<OperatorDefinition> GetOperatorTable(IExpressionRegistry registry)
         {
             var table = new List<OperatorDefinition>(_builtInOperators);
 
-            var registry = BsonExpression.CurrentRegistry;
+            registry = BsonExpression.GetRegistryOrDefault(registry);
 
             if (registry != null)
             {
@@ -188,7 +188,7 @@ namespace LiteDB
             }
 
             var order = 0;
-            var operatorTable = GetOperatorTable();
+            var operatorTable = GetOperatorTable(tokenizer.ExpressionRegistry);
 
             // now, process operator in correct order
             while (values.Count >= 2)
@@ -798,7 +798,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source);
+                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source, tokenizer.ExpressionRegistry);
 
                 if (pathExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1131,7 +1131,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current);
+                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current, tokenizer.ExpressionRegistry);
 
                 if (mapExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1207,7 +1207,7 @@ namespace LiteDB
                 else
                 {
                     // inner expression
-                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current);
+                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current, tokenizer.ExpressionRegistry);
 
                     if (inner == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1257,7 +1257,7 @@ namespace LiteDB
                 case "SORT": return ParseFunction(token, BsonExpressionType.Sort, tokenizer, context, parameters, scope);
             }
 
-            if (BsonExpression.CurrentRegistry is ExpressionRegistry registry)
+            if (BsonExpression.GetRegistryOrDefault(tokenizer.ExpressionRegistry) is ExpressionRegistry registry)
             {
                 var registration = registry.FindByName(token);
 
@@ -1316,7 +1316,7 @@ namespace LiteDB
                 tokenizer.ReadToken().Expect(TokenType.Greater);
 
                 var right = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters,
-                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current);
+                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current, tokenizer.ExpressionRegistry);
 
                 src.Append("=>" + right.Source);
                 args.Add(Expression.Constant(right));

--- a/LiteDB/Engine/Engine/Query.cs
+++ b/LiteDB/Engine/Engine/Query.cs
@@ -22,7 +22,7 @@ namespace LiteDB.Engine
             // test if is an system collection
             if (collection.StartsWith("$"))
             {
-                SqlParser.ParseCollection(new Tokenizer(collection), out var name, out var options);
+                SqlParser.ParseCollection(new Tokenizer(collection, _plugins?.Expressions), out var name, out var options);
 
                 // get registered system collection to get data source
                 var sys = this.GetSystemCollection(name);

--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -66,6 +66,8 @@ namespace LiteDB.Engine
                     var data = new DataService(snapshot, _disk.MAX_ITEMS_COUNT);
                     var pluginStrategies = _plugins?.Indexes?.All ?? Array.Empty<IIndexStrategy>();
 
+                    var expressions = _plugins?.Expressions;
+
                     // get all documents from current collection
                     var docs = reader.GetDocuments(collection);
 
@@ -85,7 +87,7 @@ namespace LiteDB.Engine
                             this.EnsureVectorIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                BsonExpression.Create(index.Expression, expressions),
                                 new VectorIndexOptions(index.VectorMetadata.Dimensions, index.VectorMetadata.Metric));
                         }
                         else
@@ -93,7 +95,7 @@ namespace LiteDB.Engine
                             this.EnsureIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                BsonExpression.Create(index.Expression, expressions),
                                 index.Unique);
                         }
                     }

--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using LiteDB.Vector;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -28,6 +29,7 @@ namespace LiteDB.Engine
         /// </summary>
         private readonly Dictionary<string, CollectionIndex> _indexes = new Dictionary<string, CollectionIndex>();
         private readonly Dictionary<string, VectorIndexMetadata> _vectorIndexes = new Dictionary<string, VectorIndexMetadata>();
+        private IExpressionRegistry _registry;
 
         public CollectionPage(PageBuffer buffer, uint pageID)
             : base(buffer, pageID, PageType.Collection)
@@ -183,6 +185,16 @@ namespace LiteDB.Engine
             }
         }
 
+        internal void BindExpressions(IExpressionRegistry registry)
+        {
+            _registry = registry;
+
+            foreach (var index in _indexes.Values)
+            {
+                index.BindExpressionRegistry(registry);
+            }
+        }
+
         public VectorIndexMetadata GetVectorIndexMetadata(string name)
         {
             return _vectorIndexes.TryGetValue(name, out var metadata) ? metadata : null;
@@ -208,6 +220,8 @@ namespace LiteDB.Engine
 
             _indexes[name] = index;
 
+            index.BindExpressionRegistry(_registry);
+
             this.IsDirty = true;
 
             return index;
@@ -231,6 +245,8 @@ namespace LiteDB.Engine
 
             _indexes[name] = index;
             _vectorIndexes[name] = metadata;
+
+            index.BindExpressionRegistry(_registry);
 
             this.IsDirty = true;
 

--- a/LiteDB/Engine/Query/QueryExecutor.cs
+++ b/LiteDB/Engine/Query/QueryExecutor.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -185,7 +186,8 @@ namespace LiteDB.Engine
             // if collection starts with $ it's system collection
             if (into.StartsWith("$"))
             {
-                SqlParser.ParseCollection(new Tokenizer(into), out var name, out var options);
+                var expressions = this.ResolveExpressions();
+                SqlParser.ParseCollection(new Tokenizer(into, expressions), out var name, out var options);
 
                 var sys = _engine.GetSystemCollection(name);
 
@@ -198,6 +200,11 @@ namespace LiteDB.Engine
             }
 
             return new BsonDataReader(result);
+        }
+
+        private IExpressionRegistry ResolveExpressions()
+        {
+            return _engine.PluginContext?.Expressions;
         }
     }
 }

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -15,6 +16,7 @@ namespace LiteDB.Engine
         private readonly Collation _collation;
         private readonly QueryPlan _queryPlan;
         private readonly List<BsonExpression> _terms = new List<BsonExpression>();
+        private readonly IExpressionRegistry _registry;
         private bool _vectorOrderConsumed;
 
         public QueryOptimization(Snapshot snapshot, Query query, IEnumerable<BsonDocument> source, Collation collation)
@@ -24,6 +26,7 @@ namespace LiteDB.Engine
             _snapshot = snapshot;
             _query = query;
             _collation = collation;
+            _registry = snapshot?.Plugins?.Expressions;
 
             _queryPlan = new QueryPlan(snapshot.CollectionName)
             {
@@ -128,7 +131,7 @@ namespace LiteDB.Engine
                     term.Type == BsonExpressionType.Equal &&
                     term.Right?.Type == BsonExpressionType.Path)
                 {
-                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters);
+                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters, _registry);
                 }
             }
         }
@@ -300,7 +303,7 @@ namespace LiteDB.Engine
 
                 if (index != null)
                 {
-                    lowest = new IndexCost(index);
+                    lowest = new IndexCost(index, _registry);
                 }
             }
 

--- a/LiteDB/Engine/Query/Structures/IndexCost.cs
+++ b/LiteDB/Engine/Query/Structures/IndexCost.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -67,9 +68,9 @@ namespace LiteDB.Engine
         }
 
         // used when full index search
-        public IndexCost(CollectionIndex index)
+        public IndexCost(CollectionIndex index, IExpressionRegistry registry)
         {
-            this.Expression = BsonExpression.Create(index.Expression);
+            this.Expression = index.BsonExpr ?? BsonExpression.Create(index.Expression, registry);
             this.Index = new IndexAll(index.Name, Query.Ascending);
             this.Cost = this.Index.GetCost(index);
             this.IndexExpression = index.Expression;

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -84,6 +84,8 @@ namespace LiteDB.Engine
             // read collection (create if new - load virtual too)
             srv.Get(_collectionName, addIfNotExists, ref _collectionPage);
 
+            _collectionPage?.BindExpressions(_plugins?.Expressions);
+
             // clear local pages (will clear _collectionPage link reference)
             if (_collectionPage != null)
             {
@@ -427,6 +429,11 @@ namespace LiteDB.Engine
             }
 
             var page = BasePage.CreatePage<T>(buffer, pageID);
+
+            if (page is CollectionPage collectionPage)
+            {
+                collectionPage.BindExpressions(_plugins?.Expressions);
+            }
 
             // update local cache with new instance T page type
             if (page.PageType != PageType.Collection)

--- a/LiteDB/Engine/Structures/CollectionIndex.cs
+++ b/LiteDB/Engine/Structures/CollectionIndex.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -30,7 +31,7 @@ namespace LiteDB.Engine
         /// <summary>
         /// Get BsonExpression from Expression
         /// </summary>
-        public BsonExpression BsonExpr { get; }
+        public BsonExpression BsonExpr { get; private set; }
 
         /// <summary>
         /// Indicate if this index has distinct values only
@@ -74,7 +75,6 @@ namespace LiteDB.Engine
             this.Unique = unique;
             this.FreeIndexPageList = uint.MaxValue;
 
-            this.BsonExpr = BsonExpression.Create(expr);
         }
 
         public CollectionIndex(BufferReader reader)
@@ -89,7 +89,6 @@ namespace LiteDB.Engine
             this.Reserved = reader.ReadByte(); // 1
             this.FreeIndexPageList = reader.ReadUInt32(); // 4
 
-            this.BsonExpr = BsonExpression.Create(this.Expression);
         }
 
         public void UpdateBuffer(BufferWriter writer)
@@ -103,6 +102,11 @@ namespace LiteDB.Engine
             writer.Write(this.Tail);
             writer.Write(this.Reserved);
             writer.Write(this.FreeIndexPageList);
+        }
+
+        internal void BindExpressionRegistry(IExpressionRegistry registry)
+        {
+            this.BsonExpr = BsonExpression.Create(this.Expression, registry);
         }
 
         /// <summary>

--- a/LiteDB/Engine/SystemCollections/SysQuery.cs
+++ b/LiteDB/Engine/SystemCollections/SysQuery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -23,17 +24,33 @@ namespace LiteDB.Engine
         {
             var query = options?.AsString ?? throw new LiteException(0, $"Collection $query(sql) requires `sql` string parameter");
 
-            var sql = new SqlParser(_engine, new Tokenizer(query), null);
+            var expressions = this.ResolveExpressions();
+            var sql = new SqlParser(_engine, new Tokenizer(query, expressions), null);
 
             using (var reader = sql.Execute())
             {
-                while(reader.Read())
+                while (reader.Read())
                 {
                     var value = reader.Current;
 
                     yield return value.IsDocument ? value.AsDocument : new BsonDocument { ["expr"] = value };
                 }
             }
+        }
+
+        private IExpressionRegistry ResolveExpressions()
+        {
+            if (_engine is LiteEngine direct)
+            {
+                return direct.PluginContext?.Expressions;
+            }
+
+            if (_engine is LiteDB.SharedEngine shared)
+            {
+                return shared.PluginContext?.Expressions;
+            }
+
+            return null;
         }
     }
 }

--- a/LiteDB/Utils/Tokenizer.cs
+++ b/LiteDB/Utils/Tokenizer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -112,6 +113,8 @@ namespace LiteDB
         public string Value { get; private set; }
         public long Position { get; private set; }
 
+        internal IExpressionRegistry ExpressionRegistry { get; set; }
+
         /// <summary>
         /// Expect if token is type (if not, throw UnexpectedToken)
         /// </summary>
@@ -192,7 +195,7 @@ namespace LiteDB
                             return true;
                         }
 
-                        var registry = BsonExpression.CurrentRegistry;
+                        var registry = BsonExpression.GetRegistryOrDefault(this.ExpressionRegistry);
 
                         if (registry != null && (registry.ContainsKeyword(Value) || registry.ContainsOperator(Value)))
                         {
@@ -221,6 +224,7 @@ namespace LiteDB
     internal class Tokenizer
     {
         private readonly TextReader _reader;
+        private readonly IExpressionRegistry _expressionRegistry;
         private char _char = '\0';
         private Token _ahead = null;
         private bool _eof = false;
@@ -228,6 +232,8 @@ namespace LiteDB
         public bool EOF => _eof && _ahead == null;
         public long Position { get; private set; }
         public Token Current { get; private set; }
+
+        internal IExpressionRegistry ExpressionRegistry => _expressionRegistry;
 
         /// <summary>
         /// If EOF throw an invalid token exception (used in while()) otherwise return "false" (not EOF)
@@ -239,14 +245,15 @@ namespace LiteDB
             return false;
         }
 
-        public Tokenizer(string source)
-            : this(new StringReader(source))
+        public Tokenizer(string source, IExpressionRegistry registry = null)
+            : this(new StringReader(source), registry)
         {
         }
 
-        public Tokenizer(TextReader reader)
+        public Tokenizer(TextReader reader, IExpressionRegistry registry = null)
         {
-            _reader = reader;
+            _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+            _expressionRegistry = registry;
 
             this.Position = 0;
             this.ReadChar();
@@ -553,7 +560,10 @@ namespace LiteDB
                     break;
             }
 
-            return token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position);
+            var result = token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position);
+            result.ExpressionRegistry = _expressionRegistry;
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure rebuild, query optimization, and system query flows pass the active expression registry when creating expressions
- include the registry in index cost calculations and caching to keep per-database index expressions isolated
- update client helpers that build expressions from strings to call the new registry-first BsonExpression overloads

## Testing
- dotnet build LiteDB/LiteDB.csproj -c Release

------
https://chatgpt.com/codex/tasks/task_e_68ec46a82c98832690cafe9f68d3dfed