### PR TITLE
Propagate expression registry through engine index path

### DIFF
--- a/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
+++ b/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
@@ -124,11 +124,8 @@ public class BsonVector_Tests
         col.EnsureIndex(x => x.Embedding, new VectorIndexOptions(2));
 
         var target = new float[] { 1.0f, 0.0f };
-        BsonExpression fieldExpr;
-        using (db.EnterExpressionScope())
-        {
-            fieldExpr = BsonExpression.Create("$.Embedding");
-        }
+        var expressions = db.Services.Expressions;
+        var fieldExpr = BsonExpression.Create("$.Embedding", expressions);
 
         var results = col.Query()
             .WhereNear(fieldExpr, target, maxDistance: .28)
@@ -159,16 +156,12 @@ public class BsonVector_Tests
             ["Embedding"] = new BsonVector(new float[] { 1.0f, 1.0f })
         });
 
-        using (db.EnterExpressionScope())
-        {
-            col.EnsureIndex(
-                "embedding_idx",
-                BsonExpression.Create("$.Embedding"),
-                new VectorIndexOptions(2));
-        }
+        col.EnsureIndex(
+            "embedding_idx",
+            BsonExpression.Create("$.Embedding", db.Services.Expressions),
+            new VectorIndexOptions(2));
 
         var query = "SELECT * FROM vectors WHERE ($.Embedding VECTOR_SIM [1.0, 0.0]) <= 0.25";
-        using var _ = db.EnterExpressionScope();
         var rawResults = db.Execute(query).ToList();
 
         var docs = rawResults
@@ -196,11 +189,7 @@ public class BsonVector_Tests
     public void VectorSim_InfixExpression_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]");
-        }
+        var expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]", db.Services.Expressions);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 
@@ -219,11 +208,7 @@ public class BsonVector_Tests
     public void VectorSim_FunctionCall_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])");
-        }
+        var expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])", db.Services.Expressions);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -19,18 +19,12 @@ namespace LiteDB.Tests.QueryTest
     {
         private static BsonExpression CreateExpression(LiteDatabase db, string expression)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression);
-            }
+            return BsonExpression.Create(expression, db.Services.Expressions);
         }
 
         private static BsonExpression CreateExpression(LiteDatabase db, string expression, params BsonValue[] args)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression, args);
-            }
+            return BsonExpression.Create(expression, db.Services.Expressions, args);
         }
 
         private class VectorDocument

--- a/LiteDB/Client/Database/Collections/Aggregate.cs
+++ b/LiteDB/Client/Database/Collections/Aggregate.cs
@@ -33,10 +33,7 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Count(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -44,16 +41,13 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, args));
-            }
+            return this.Count(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Count documents matching a query. This method does not deserialize any documents. Needs indexes on query expression
         /// </summary>
-        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate));
+        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -87,10 +81,7 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, parameters));
-            }
+            return this.LongCount(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -98,16 +89,13 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, args));
-            }
+            return this.LongCount(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate));
+        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -133,10 +121,7 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Exists(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -144,16 +129,13 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, args));
-            }
+            return this.Exists(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
         /// </summary>
-        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate));
+        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
@@ -193,7 +175,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Min(expr);
 
@@ -229,7 +211,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Max(expr);
 

--- a/LiteDB/Client/Database/Collections/Delete.cs
+++ b/LiteDB/Client/Database/Collections/Delete.cs
@@ -39,10 +39,7 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, parameters));
-            }
+            return this.DeleteMany(BsonExpression.Create(predicate, parameters, _expressions));
         }
 
         /// <summary>
@@ -50,15 +47,12 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, args));
-            }
+            return this.DeleteMany(BsonExpression.Create(predicate, _expressions, args));
         }
 
         /// <summary>
         /// Delete all documents based on predicate expression. Returns how many documents was deleted
         /// </summary>
-        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate));
+        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate, _expressions));
     }
 }

--- a/LiteDB/Client/Database/Collections/Find.cs
+++ b/LiteDB/Client/Database/Collections/Find.cs
@@ -51,7 +51,7 @@ namespace LiteDB
         /// <summary>
         /// Find documents inside a collection using predicate expression.
         /// </summary>
-        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate), skip, limit);
+        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate, _expressions), skip, limit);
 
         #endregion
 
@@ -64,10 +64,9 @@ namespace LiteDB
         {
             if (id == null || id.IsNull) throw new ArgumentNullException(nameof(id));
 
-            using (this.EnterExpressionScope())
-            {
-                return this.Find(BsonExpression.Create("_id = @0", id)).FirstOrDefault();
-            }
+            var filter = BsonExpression.Create("_id = @0", _expressions, id);
+
+            return this.Find(filter).FirstOrDefault();
         }
 
         /// <summary>
@@ -80,10 +79,9 @@ namespace LiteDB
         /// </summary>
         public T FindOne(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, parameters));
-            }
+            var expression = BsonExpression.Create(predicate, parameters, _expressions);
+
+            return this.FindOne(expression);
         }
 
         /// <summary>
@@ -91,16 +89,15 @@ namespace LiteDB
         /// </summary>
         public T FindOne(BsonExpression predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, args));
-            }
+            var expression = BsonExpression.Create(predicate, _expressions, args);
+
+            return this.FindOne(expression);
         }
 
         /// <summary>
         /// Find the first document using predicate expression. Returns null if not found
         /// </summary>
-        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate));
+        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Find the first document using defined query structure. Returns null if not found

--- a/LiteDB/Client/Database/Collections/Include.cs
+++ b/LiteDB/Client/Database/Collections/Include.cs
@@ -15,7 +15,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var path = _mapper.GetExpression(keySelector);
+            var path = _mapper.GetExpression(keySelector, _expressions);
 
             return this.Include(path);
         }

--- a/LiteDB/Client/Database/Collections/Index.cs
+++ b/LiteDB/Client/Database/Collections/Index.cs
@@ -129,7 +129,7 @@ namespace LiteDB
         /// </summary>
         private BsonExpression GetIndexExpression<K>(Expression<Func<T, K>> keySelector, bool convertEnumerableToMultiKey = true)
         {
-            var expression = _mapper.GetIndexExpression(keySelector);
+            var expression = _mapper.GetIndexExpression(keySelector, _expressions);
 
             if (convertEnumerableToMultiKey && typeof(K).IsEnumerable() && expression.IsScalar == true)
             {

--- a/LiteDB/Client/Database/Collections/Update.cs
+++ b/LiteDB/Client/Database/Collections/Update.cs
@@ -74,8 +74,8 @@ namespace LiteDB
             if (extend == null) throw new ArgumentNullException(nameof(extend));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            var ext = _mapper.GetExpression(extend);
-            var pred = _mapper.GetExpression(predicate);
+            var ext = _mapper.GetExpression(extend, _expressions);
+            var pred = _mapper.GetExpression(predicate, _expressions);
 
             if (ext.Type != BsonExpressionType.Document)
             {

--- a/LiteDB/Client/Database/ILiteDatabase.cs
+++ b/LiteDB/Client/Database/ILiteDatabase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using LiteDB.Engine;
+using LiteDB.Plugins;
 
 namespace LiteDB
 {
@@ -11,6 +12,11 @@ namespace LiteDB
         /// Get current instance of BsonMapper used in this database instance (can be BsonMapper.Global)
         /// </summary>
         BsonMapper Mapper { get; }
+
+        /// <summary>
+        /// Gets the plugin services registered for this database instance.
+        /// </summary>
+        ILitePluginContext Services { get; }
 
         /// <summary>
         /// Returns a special collection for storage files/stream inside datafile. Use _files and _chunks collection names. FileId is implemented as string. Use "GetStorage" for custom options

--- a/LiteDB/Client/Database/LiteCollection.cs
+++ b/LiteDB/Client/Database/LiteCollection.cs
@@ -32,11 +32,6 @@ namespace LiteDB
         /// </summary>
         public EntityMapper EntityMapper => _entity;
 
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_expressions);
-        }
-
         internal LiteCollection(string name, BsonAutoId autoId, ILiteEngine engine, BsonMapper mapper, IExpressionRegistry expressions)
         {
             _collection = name ?? mapper.ResolveCollectionName(typeof(T));

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -24,9 +24,16 @@ namespace LiteDB
         private readonly DefaultPluginContext _pluginContext;
 
         /// <summary>
+        /// Gets the plugin services registered for this database instance.
+        /// </summary>
+        public ILitePluginContext Services => _pluginContext;
+
+        /// <summary>
         /// Get current instance of BsonMapper used in this database instance (can be BsonMapper.Global)
         /// </summary>
         public BsonMapper Mapper => _mapper;
+
+        internal IExpressionRegistry ExpressionRegistry => _pluginContext.Expressions;
 
         #endregion
 
@@ -161,11 +168,6 @@ namespace LiteDB
             return new LiteCollection<BsonDocument>(name, autoId, _engine, _mapper, _pluginContext.Expressions);
         }
 
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_pluginContext.Expressions);
-        }
-
         #endregion
 
         private void InitializePlugins(IEnumerable<ILitePlugin> plugins)
@@ -298,8 +300,8 @@ namespace LiteDB
         {
             if (commandReader == null) throw new ArgumentNullException(nameof(commandReader));
 
-            var tokenizer = new Tokenizer(commandReader);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var tokenizer = new Tokenizer(commandReader, _pluginContext.Expressions);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;
@@ -312,8 +314,8 @@ namespace LiteDB
         {
             if (command == null) throw new ArgumentNullException(nameof(command));
 
-            var tokenizer = new Tokenizer(command);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var tokenizer = new Tokenizer(command, _pluginContext.Expressions);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -40,7 +40,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Include<K>(Expression<Func<T, K>> path)
         {
-            _query.Includes.Add(_mapper.GetExpression(path));
+            _query.Includes.Add(_mapper.GetExpression(path, _expressions));
             return this;
         }
 
@@ -80,10 +80,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, BsonDocument parameters)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, parameters));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, parameters, _expressions));
             return this;
         }
 
@@ -92,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, params BsonValue[] args)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, args));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, _expressions, args));
             return this;
         }
 
@@ -104,7 +98,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(Expression<Func<T, bool>> predicate)
         {
-            return this.Where(_mapper.GetExpression(predicate));
+            return this.Where(_mapper.GetExpression(predicate, _expressions));
         }
 
         #endregion
@@ -127,7 +121,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> OrderBy<K>(Expression<Func<T, K>> keySelector, int order = Query.Ascending)
         {
-            return this.OrderBy(_mapper.GetExpression(keySelector), order);
+            return this.OrderBy(_mapper.GetExpression(keySelector, _expressions), order);
         }
 
         /// <summary>
@@ -156,7 +150,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenBy<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenBy(_mapper.GetExpression(keySelector));
+            return this.ThenBy(_mapper.GetExpression(keySelector, _expressions));
         }
 
         /// <summary>
@@ -175,7 +169,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenByDescending<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenByDescending(_mapper.GetExpression(keySelector));
+            return this.ThenByDescending(_mapper.GetExpression(keySelector, _expressions));
         }
 
         #endregion
@@ -187,7 +181,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<IGrouping<K, T>> GroupBy<K>(Expression<Func<T, K>> keySelector)
         {
-            var expression = _mapper.GetExpression(keySelector);
+            var expression = _mapper.GetExpression(keySelector, _expressions);
 
             this.GroupBy(expression);
 
@@ -241,7 +235,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<K> Select<K>(Expression<Func<T, K>> selector)
         {
-            _query.Select = _mapper.GetExpression(selector);
+            _query.Select = _mapper.GetExpression(selector, _expressions);
 
             return new LiteQueryable<K>(_engine, _mapper, _collection, _query, _expressions);
         }
@@ -260,18 +254,15 @@ namespace LiteDB
             ValidateVectorArguments(target, maxDistance);
 
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", targetArray, new BsonValue(maxDistance));
-            }
+
+            return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", _expressions, targetArray, new BsonValue(maxDistance));
         }
 
         internal ILiteQueryable<T> VectorWhereNear(string vectorField, float[] target, double maxDistance)
         {
             if (string.IsNullOrWhiteSpace(vectorField)) throw new ArgumentNullException(nameof(vectorField));
 
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{vectorField}");
+            var fieldExpr = BsonExpression.Create($"$.{vectorField}", _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
@@ -292,20 +283,19 @@ namespace LiteDB
         {
             if (field == null) throw new ArgumentNullException(nameof(field));
 
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear<K>(Expression<Func<T, K>> field, float[] target, int k)
         {
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear(string field, float[] target, int k)
         {
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{field}");
+            var fieldExpr = BsonExpression.Create($"$.{field}", _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
@@ -318,18 +308,15 @@ namespace LiteDB
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
 
             // Build VECTOR_SIM as order clause
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", targetArray);
+            var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", _expressions, targetArray);
 
-                _query.VectorField = fieldExpr.Source;
-                _query.VectorTarget = target?.ToArray();
-                _query.VectorMaxDistance = double.MaxValue;
+            _query.VectorField = fieldExpr.Source;
+            _query.VectorTarget = target?.ToArray();
+            _query.VectorMaxDistance = double.MaxValue;
 
-                return this
-                    .OrderBy(simExpr, Query.Ascending)
-                    .Limit(k);
-            }
+            return this
+                .OrderBy(simExpr, Query.Ascending)
+                .Limit(k);
         }
 
         [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -169,13 +170,14 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            return this.GetExpressionInternal(predicate, typeof(K) == typeof(bool), null);
+        }
 
-            var expr = visitor.Resolve(typeof(K) == typeof(bool));
+        internal BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry expressions)
+        {
+            if (expressions == null) throw new ArgumentNullException(nameof(expressions));
 
-            LOG($"`{predicate.ToString()}` -> `{expr.Source}`", "LINQ");
-
-            return expr;
+            return this.GetExpressionInternal(predicate, typeof(K) == typeof(bool), expressions);
         }
 
         /// <summary>
@@ -183,9 +185,21 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            return this.GetExpressionInternal(predicate, false, null);
+        }
 
-            var expr = visitor.Resolve(false);
+        internal BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry expressions)
+        {
+            if (expressions == null) throw new ArgumentNullException(nameof(expressions));
+
+            return this.GetExpressionInternal(predicate, false, expressions);
+        }
+
+        private BsonExpression GetExpressionInternal<T, K>(Expression<Func<T, K>> predicate, bool expectPredicate, IExpressionRegistry expressions)
+        {
+            var visitor = new LinqExpressionVisitor(this, predicate, expressions);
+
+            var expr = visitor.Resolve(expectPredicate);
 
             LOG($"`{predicate.ToString()}` -> `{expr.Source}`", "LINQ");
 

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -38,6 +39,7 @@ namespace LiteDB
         private readonly BsonMapper _mapper;
         private readonly Expression _expr;
         private readonly ParameterExpression _rootParameter = null;
+        private readonly IExpressionRegistry _expressions;
 
         private readonly BsonDocument _parameters = new BsonDocument();
         private int _paramIndex = 0;
@@ -46,10 +48,11 @@ namespace LiteDB
         private readonly StringBuilder _builder = new StringBuilder();
         private readonly Stack<Expression> _nodes = new Stack<Expression>();
 
-        public LinqExpressionVisitor(BsonMapper mapper, Expression expr)
+        public LinqExpressionVisitor(BsonMapper mapper, Expression expr, IExpressionRegistry expressions = null)
         {
             _mapper = mapper;
             _expr = expr;
+            _expressions = expressions;
 
             if (expr is LambdaExpression lambda)
             {
@@ -71,14 +74,14 @@ namespace LiteDB
 
             try
             {
-                var e = BsonExpression.Create(expression, _parameters);
+                var e = _expressions != null ? BsonExpression.Create(expression, _parameters, _expressions) : BsonExpression.Create(expression, _parameters);
 
                 // if expression must return an predicate but expression result is Path/Parameter/Call add `= true`
                 if (predicate && (e.Type == BsonExpressionType.Path || e.Type == BsonExpressionType.Call || e.Type == BsonExpressionType.Parameter))
                 {
                     expression = "(" + expression + " = true)";
 
-                    e = BsonExpression.Create(expression, _parameters);
+                    e = _expressions != null ? BsonExpression.Create(expression, _parameters, _expressions) : BsonExpression.Create(expression, _parameters);
                 }
 
                 return e;

--- a/LiteDB/Client/SqlParser/Commands/Create.cs
+++ b/LiteDB/Client/SqlParser/Commands/Create.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             _tokenizer.ReadToken().Expect(TokenType.OpenParenthesis);
 
             // read index expression
-            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument());
+            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument(), _expressions);
 
             // read )
             _tokenizer.ReadToken().Expect(TokenType.CloseParenthesis);

--- a/LiteDB/Client/SqlParser/Commands/Delete.cs
+++ b/LiteDB/Client/SqlParser/Commands/Delete.cs
@@ -24,7 +24,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             _tokenizer.ReadToken().Expect(TokenType.EOF, TokenType.SemiColon);

--- a/LiteDB/Client/SqlParser/Commands/ParseLists.cs
+++ b/LiteDB/Client/SqlParser/Commands/ParseLists.cs
@@ -16,7 +16,7 @@ namespace LiteDB
         {
             while(true)
             {
-                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 yield return expr;
 

--- a/LiteDB/Client/SqlParser/Commands/Select.cs
+++ b/LiteDB/Client/SqlParser/Commands/Select.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             token.Expect("SELECT");
 
             // read required SELECT <expr> and convert into single expression
-            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters);
+            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters, _expressions);
 
             // read FROM|INTO
             var from = _tokenizer.ReadToken();
@@ -88,7 +88,7 @@ namespace LiteDB
                 // read WHERE keyword
                 _tokenizer.ReadToken();
 
-                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.Where.Add(where);
             }
@@ -101,7 +101,7 @@ namespace LiteDB
                 _tokenizer.ReadToken();
                 _tokenizer.ReadToken().Expect("BY");
 
-                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.GroupBy = groupBy;
 
@@ -112,7 +112,7 @@ namespace LiteDB
                     // read HAVING keyword
                     _tokenizer.ReadToken();
 
-                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     query.Having = having;
                 }
@@ -128,7 +128,7 @@ namespace LiteDB
 
                 while (true)
                 {
-                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     var orderByOrder = Query.Ascending;
                     var orderByToken = _tokenizer.LookAhead();

--- a/LiteDB/Client/SqlParser/Commands/Update.cs
+++ b/LiteDB/Client/SqlParser/Commands/Update.cs
@@ -22,7 +22,7 @@ namespace LiteDB
             var collection = _tokenizer.ReadToken().Expect(TokenType.Word).Value;
             _tokenizer.ReadToken().Expect("SET");
 
-            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters);
+            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters, _expressions);
 
             // optional where
             BsonExpression where = null;
@@ -33,7 +33,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             // read eof

--- a/LiteDB/Client/SqlParser/SqlParser.cs
+++ b/LiteDB/Client/SqlParser/SqlParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using LiteDB.Engine;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -16,12 +17,14 @@ namespace LiteDB
         private readonly Tokenizer _tokenizer;
         private readonly BsonDocument _parameters;
         private readonly Lazy<Collation> _collation;
+        private readonly IExpressionRegistry _expressions;
 
-        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters)
+        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters, IExpressionRegistry expressions)
         {
             _engine = engine;
             _tokenizer = tokenizer;
             _parameters = parameters ?? new BsonDocument();
+            _expressions = expressions ?? throw new ArgumentNullException(nameof(expressions));
             _collation = new Lazy<Collation>(() => new Collation(_engine.Pragma(Pragmas.COLLATION)));
         }
 

--- a/LiteDB/Client/Storage/LiteStorage.cs
+++ b/LiteDB/Client/Storage/LiteStorage.cs
@@ -68,17 +68,17 @@ namespace LiteDB
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters, _db.Services.Expressions));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, args));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, _db.Services.Expressions, args));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate) => this.Find(_db.Mapper.GetExpression(predicate));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate) => this.Find(_db.Mapper.GetExpression(predicate, _db.Services.Expressions));
 
         /// <summary>
         /// Find all files inside file collections

--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -8,7 +8,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using LiteDB.Plugins;
 using static LiteDB.Constants;
 
@@ -126,16 +125,37 @@ namespace LiteDB
         /// </summary>
         private BsonExpressionScalarDelegate _funcScalar;
 
-        private static readonly AsyncLocal<IExpressionRegistry> _currentRegistry = new AsyncLocal<IExpressionRegistry>();
+        private static readonly Lazy<IExpressionRegistry> _legacyRegistry = new Lazy<IExpressionRegistry>(() => new ExpressionRegistry());
 
-        internal static IDisposable UseRegistry(IExpressionRegistry registry)
+        internal static Func<IExpressionRegistry> LegacyRegistryProvider { get; set; }
+
+        private static readonly ConcurrentDictionary<(IExpressionRegistry Registry, string Source), BsonExpressionScalarDelegate> _cacheScalar =
+            new ConcurrentDictionary<(IExpressionRegistry Registry, string Source), BsonExpressionScalarDelegate>();
+
+        private static readonly ConcurrentDictionary<(IExpressionRegistry Registry, string Source), BsonExpressionEnumerableDelegate> _cacheEnumerable =
+            new ConcurrentDictionary<(IExpressionRegistry Registry, string Source), BsonExpressionEnumerableDelegate>();
+
+        private static readonly IReadOnlyDictionary<string, Func<ExpressionContext, ParameterExpression>> _parameterResolvers =
+            new Dictionary<string, Func<ExpressionContext, ParameterExpression>>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["source"] = context => context.Source,
+                ["root"] = context => context.Root,
+                ["current"] = context => context.Current,
+                ["collation"] = context => context.Collation,
+                ["parameters"] = context => context.Parameters
+            };
+
+        private static IExpressionRegistry ResolveLegacyRegistry()
         {
-            var previous = _currentRegistry.Value;
-            _currentRegistry.Value = registry;
-            return new RegistryScope(previous);
-        }
+            var registry = LegacyRegistryProvider?.Invoke();
 
-        internal static IExpressionRegistry CurrentRegistry => _currentRegistry.Value;
+            if (registry != null)
+            {
+                return registry;
+            }
+
+            return _legacyRegistry.Value;
+        }
 
         /// <summary>
         /// Get default field name when need convert simple BsonValue into BsonDocument
@@ -292,42 +312,76 @@ namespace LiteDB
 
         #region Static method
 
-        private static readonly ConcurrentDictionary<string, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<string, BsonExpressionEnumerableDelegate>();
-        private static readonly ConcurrentDictionary<string, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<string, BsonExpressionScalarDelegate>();
-
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression)
         {
-            return Create(expression, new BsonDocument());
+            return Create(expression, ResolveLegacyRegistry());
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression, params BsonValue[] args)
         {
-            var parameters = new BsonDocument();
-
-            for(var i = 0; i < args.Length; i++)
-            {
-                parameters[i.ToString()] = args[i];
-            }
-
-            return Create(expression, parameters);
+            return Create(expression, ResolveLegacyRegistry(), args);
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression, BsonDocument parameters)
         {
+            return Create(expression, parameters, ResolveLegacyRegistry());
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry)
+        {
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
+
+            return Create(expression, new BsonDocument(), registry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry, params BsonValue[] args)
+        {
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
+
+            var parameters = new BsonDocument();
+
+            if (args != null)
+            {
+                for (var i = 0; i < args.Length; i++)
+                {
+                    parameters[i.ToString()] = args[i];
+                }
+            }
+
+            return Create(expression, parameters, registry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, BsonDocument parameters, IExpressionRegistry registry)
+        {
             if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
-            var tokenizer = new Tokenizer(expression);
+            parameters ??= new BsonDocument();
 
-            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters);
+            var tokenizer = new Tokenizer(expression, registry);
+
+            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters, registry);
 
             tokenizer.LookAhead().Expect(TokenType.EOF);
 
@@ -335,23 +389,44 @@ namespace LiteDB
         }
 
         /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Compile(string expression)
+        {
+            return Compile(expression, ResolveLegacyRegistry());
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Compile(string expression, IExpressionRegistry registry)
+        {
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
+
+            return Create(expression, registry);
+        }
+
+        /// <summary>
         /// Parse tokenizer and create new instance of BsonExpression - for now, do not use cache
         /// </summary>
-        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters)
+        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
-            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root);
+            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root, registry);
         }
 
         /// <summary>
         /// Parse and compile string expression and return BsonExpression
         /// </summary>
-        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope)
+        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
-            var context = new ExpressionContext();
+            var context = new ExpressionContext(registry);
 
             var expr =
                 mode == BsonExpressionParserMode.Full ? BsonExpressionParser.ParseFullExpression(tokenizer, context, parameters, scope) :
@@ -360,18 +435,22 @@ namespace LiteDB
                 BsonExpressionParser.ParseUpdateDocumentBuilder(tokenizer, context, parameters);
 
             // compile linq expression (with left+right expressions)
-            Compile(expr, context);
+            Compile(expr, context, registry);
 
             return expr;
         }
 
-        internal static void Compile(BsonExpression expr, ExpressionContext context)
+        internal static void Compile(BsonExpression expr, ExpressionContext context, IExpressionRegistry registry)
         {
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
+
+            expr.Expression = ContextParameterReplacer.Replace(expr.Expression, context);
+
             // compile linq expression according with return type (scalar or enumerable)
             // in both case, try use cached compiled version
             if (expr.IsScalar)
             {
-                var cached = _cacheScalar.GetOrAdd(expr.Source, s =>
+                var cached = _cacheScalar.GetOrAdd((registry, expr.Source), key =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionScalarDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -382,7 +461,7 @@ namespace LiteDB
             }
             else
             {
-                var cached = _cacheEnumerable.GetOrAdd(expr.Source, s =>
+                var cached = _cacheEnumerable.GetOrAdd((registry, expr.Source), key =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionEnumerableDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -393,8 +472,39 @@ namespace LiteDB
             }
 
             // compile child expressions (left/right)
-            if (expr.Left != null) Compile(expr.Left, context);
-            if (expr.Right != null) Compile(expr.Right, context);
+            if (expr.Left != null) Compile(expr.Left, context, registry);
+            if (expr.Right != null) Compile(expr.Right, context, registry);
+        }
+
+        private sealed class ContextParameterReplacer : ExpressionVisitor
+        {
+            private readonly ExpressionContext _context;
+
+            private ContextParameterReplacer(ExpressionContext context)
+            {
+                _context = context;
+            }
+
+            public static Expression Replace(Expression expression, ExpressionContext context)
+            {
+                var replacer = new ContextParameterReplacer(context);
+                return replacer.Visit(expression);
+            }
+
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                if (node != null && node.Name != null && _parameterResolvers.TryGetValue(node.Name, out var resolver))
+                {
+                    var target = resolver(_context);
+
+                    if (!ReferenceEquals(node, target))
+                    {
+                        return target;
+                    }
+                }
+
+                return base.VisitParameter(node);
+            }
         }
 
         /// <summary>
@@ -473,24 +583,5 @@ namespace LiteDB
             return $"`{this.Source}` [{this.Type}]";
         }
 
-        private sealed class RegistryScope : IDisposable
-        {
-            private readonly IExpressionRegistry _previous;
-            private bool _disposed;
-
-            public RegistryScope(IExpressionRegistry previous)
-            {
-                _previous = previous;
-            }
-
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    _currentRegistry.Value = _previous;
-                    _disposed = true;
-                }
-            }
-        }
     }
 }

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -111,11 +111,11 @@ namespace LiteDB
             new OperatorDefinition("OR", " OR ", null, BsonExpressionType.Or, (int)BinaryOperatorPrecedence.LogicalOr)
         };
 
-        private static List<OperatorDefinition> GetOperatorTable()
+        private static List<OperatorDefinition> GetOperatorTable(ExpressionContext context)
         {
             var table = new List<OperatorDefinition>(_builtInOperators);
 
-            var registry = BsonExpression.CurrentRegistry;
+            var registry = context?.Registry;
 
             if (registry != null)
             {
@@ -188,7 +188,7 @@ namespace LiteDB
             }
 
             var order = 0;
-            var operatorTable = GetOperatorTable();
+            var operatorTable = GetOperatorTable(context);
 
             // now, process operator in correct order
             while (values.Count >= 2)
@@ -798,7 +798,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source);
+                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source, context.Registry);
 
                 if (pathExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1131,7 +1131,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current);
+                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current, context.Registry);
 
                 if (mapExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1207,7 +1207,7 @@ namespace LiteDB
                 else
                 {
                     // inner expression
-                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current);
+                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current, context.Registry);
 
                     if (inner == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1257,7 +1257,7 @@ namespace LiteDB
                 case "SORT": return ParseFunction(token, BsonExpressionType.Sort, tokenizer, context, parameters, scope);
             }
 
-            if (BsonExpression.CurrentRegistry is ExpressionRegistry registry)
+            if (context.Registry is ExpressionRegistry registry)
             {
                 var registration = registry.FindByName(token);
 
@@ -1316,7 +1316,7 @@ namespace LiteDB
                 tokenizer.ReadToken().Expect(TokenType.Greater);
 
                 var right = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters,
-                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current);
+                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current, context.Registry);
 
                 src.Append("=>" + right.Source);
                 args.Add(Expression.Constant(right));

--- a/LiteDB/Document/Expression/Parser/ExpressionContext.cs
+++ b/LiteDB/Document/Expression/Parser/ExpressionContext.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,8 +12,9 @@ namespace LiteDB
 {
     internal class ExpressionContext
     {
-        public ExpressionContext()
+        public ExpressionContext(IExpressionRegistry registry = null)
         {
+            this.Registry = registry;
             this.Source = Expression.Parameter(typeof(IEnumerable<BsonDocument>), "source");
             this.Root = Expression.Parameter(typeof(BsonDocument), "root");
             this.Current = Expression.Parameter(typeof(BsonValue), "current");
@@ -25,5 +27,6 @@ namespace LiteDB
         public ParameterExpression Current { get; }
         public ParameterExpression Collation { get; }
         public ParameterExpression Parameters { get; }
+        public IExpressionRegistry Registry { get; }
     }
 }

--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -58,6 +58,8 @@ namespace LiteDB.Engine
 
             try
             {
+                var expressions = _plugins?.Expressions;
+
                 foreach (var collection in reader.GetCollections())
                 {
                     // get snapshot, indexer and data services
@@ -85,7 +87,9 @@ namespace LiteDB.Engine
                             this.EnsureVectorIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                expressions != null
+                                    ? BsonExpression.Create(index.Expression, expressions)
+                                    : BsonExpression.Create(index.Expression),
                                 new VectorIndexOptions(index.VectorMetadata.Dimensions, index.VectorMetadata.Metric));
                         }
                         else
@@ -93,7 +97,9 @@ namespace LiteDB.Engine
                             this.EnsureIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                expressions != null
+                                    ? BsonExpression.Create(index.Expression, expressions)
+                                    : BsonExpression.Create(index.Expression),
                                 index.Unique);
                         }
                     }

--- a/LiteDB/Engine/Pages/BasePage.cs
+++ b/LiteDB/Engine/Pages/BasePage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -731,12 +732,12 @@ namespace LiteDB.Engine
         /// <summary>
         /// Create new page instance based on buffer (READ)
         /// </summary>
-        public static T ReadPage<T>(PageBuffer buffer)
+        public static T ReadPage<T>(PageBuffer buffer, IExpressionRegistry expressions = null)
             where T : BasePage
         {
             if (typeof(T) == typeof(BasePage)) return (T)(object)new BasePage(buffer);
             if (typeof(T) == typeof(HeaderPage)) return (T)(object)new HeaderPage(buffer);
-            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer);
+            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer, expressions);
             if (typeof(T) == typeof(IndexPage)) return (T)(object)new IndexPage(buffer);
             if (typeof(T) == typeof(VectorIndexPage)) return (T)(object)new VectorIndexPage(buffer);
             if (typeof(T) == typeof(DataPage)) return (T)(object)new DataPage(buffer);
@@ -747,10 +748,10 @@ namespace LiteDB.Engine
         /// <summary>
         /// Create new page instance with new PageID and passed buffer (NEW)
         /// </summary>
-        public static T CreatePage<T>(PageBuffer buffer, uint pageID)
+        public static T CreatePage<T>(PageBuffer buffer, uint pageID, IExpressionRegistry expressions = null)
             where T : BasePage
         {
-            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer, pageID);
+            if (typeof(T) == typeof(CollectionPage)) return (T)(object)new CollectionPage(buffer, pageID, expressions);
             if (typeof(T) == typeof(IndexPage)) return (T)(object)new IndexPage(buffer, pageID);
             if (typeof(T) == typeof(VectorIndexPage)) return (T)(object)new VectorIndexPage(buffer, pageID);
             if (typeof(T) == typeof(DataPage)) return (T)(object)new DataPage(buffer, pageID);

--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Plugins;
 using LiteDB.Vector;
 using static LiteDB.Constants;
 
@@ -28,19 +29,29 @@ namespace LiteDB.Engine
         /// </summary>
         private readonly Dictionary<string, CollectionIndex> _indexes = new Dictionary<string, CollectionIndex>();
         private readonly Dictionary<string, VectorIndexMetadata> _vectorIndexes = new Dictionary<string, VectorIndexMetadata>();
+        private readonly IExpressionRegistry _expressions;
 
-        public CollectionPage(PageBuffer buffer, uint pageID)
+        public CollectionPage(PageBuffer buffer, uint pageID, IExpressionRegistry expressions)
             : base(buffer, pageID, PageType.Collection)
         {
+            _expressions = expressions;
+
             for(var i = 0; i < PAGE_FREE_LIST_SLOTS; i++)
             {
                 this.FreeDataPageList[i] = uint.MaxValue;
             }
         }
 
-        public CollectionPage(PageBuffer buffer)
+        public CollectionPage(PageBuffer buffer, uint pageID)
+            : this(buffer, pageID, null)
+        {
+        }
+
+        public CollectionPage(PageBuffer buffer, IExpressionRegistry expressions)
             : base(buffer)
         {
+            _expressions = expressions;
+
             ENSURE(this.PageType == PageType.Collection, "page type must be collection page");
 
             if (this.PageType != PageType.Collection) throw LiteException.InvalidPageType(PageType.Collection, this);
@@ -63,7 +74,7 @@ namespace LiteDB.Engine
 
                 for(var i = 0; i < count; i++)
                 {
-                    var index = new CollectionIndex(r);
+                    var index = new CollectionIndex(r, _expressions);
 
                     _indexes[index.Name] = index;
                 }
@@ -78,6 +89,11 @@ namespace LiteDB.Engine
                     _vectorIndexes[name] = metadata;
                 }
             }
+        }
+
+        public CollectionPage(PageBuffer buffer)
+            : this(buffer, null)
+        {
         }
 
         public override PageBuffer UpdateBuffer()
@@ -204,7 +220,7 @@ namespace LiteDB.Engine
 
             var slot = (byte)(_indexes.Count == 0 ? 0 : (_indexes.Max(x => x.Value.Slot) + 1));
 
-            var index = new CollectionIndex(slot, 0, name, expr, unique);
+            var index = new CollectionIndex(slot, 0, name, expr, unique, _expressions);
 
             _indexes[name] = index;
 
@@ -226,7 +242,7 @@ namespace LiteDB.Engine
 
             var slot = (byte)(_indexes.Count == 0 ? 0 : (_indexes.Max(x => x.Value.Slot) + 1));
 
-            var index = new CollectionIndex(slot, 1, name, expr, false);
+            var index = new CollectionIndex(slot, 1, name, expr, false, _expressions);
             var metadata = new VectorIndexMetadata(slot, dimensions, metric);
 
             _indexes[name] = index;

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -117,6 +117,8 @@ namespace LiteDB.Engine
         private void OptimizeTerms()
         {
             // simple optimization
+            var expressions = _snapshot.Plugins?.Expressions;
+
             for (var i = 0; i < _terms.Count; i++)
             {
                 var term = _terms[i];
@@ -128,7 +130,9 @@ namespace LiteDB.Engine
                     term.Type == BsonExpressionType.Equal &&
                     term.Right?.Type == BsonExpressionType.Path)
                 {
-                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters);
+                    _terms[i] = expressions != null
+                        ? BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters, expressions)
+                        : BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters);
                 }
             }
         }

--- a/LiteDB/Engine/Query/Structures/IndexCost.cs
+++ b/LiteDB/Engine/Query/Structures/IndexCost.cs
@@ -69,7 +69,7 @@ namespace LiteDB.Engine
         // used when full index search
         public IndexCost(CollectionIndex index)
         {
-            this.Expression = BsonExpression.Create(index.Expression);
+            this.Expression = index.BsonExpr;
             this.Index = new IndexAll(index.Name, Query.Ascending);
             this.Cost = this.Index.GetCost(index);
             this.IndexExpression = index.Expression;

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -226,7 +226,7 @@ namespace LiteDB.Engine
             {
                 // read page from log file
                 var buffer = _reader.ReadPage(walPosition.Position, _mode == LockMode.Write, FileOrigin.Log);
-                var dirty = BasePage.ReadPage<T>(buffer);
+                var dirty = BasePage.ReadPage<T>(buffer, _plugins?.Expressions);
 
                 origin = FileOrigin.Log;
                 position = walPosition.Position;
@@ -244,7 +244,7 @@ namespace LiteDB.Engine
             {
                 // read page from log file
                 var buffer = _reader.ReadPage(pos, _mode == LockMode.Write, FileOrigin.Log);
-                var logPage = BasePage.ReadPage<T>(buffer);
+                var logPage = BasePage.ReadPage<T>(buffer, _plugins?.Expressions);
 
                 // clear some data inside this page (will be override when write on log file)
                 logPage.TransactionID = 0;
@@ -262,7 +262,7 @@ namespace LiteDB.Engine
 
                 // read page from data file
                 var buffer = _reader.ReadPage(pagePosition, _mode == LockMode.Write, FileOrigin.Data);
-                var diskpage = BasePage.ReadPage<T>(buffer);
+                var diskpage = BasePage.ReadPage<T>(buffer, _plugins?.Expressions);
 
                 origin = FileOrigin.Data;
                 position = pagePosition;
@@ -426,7 +426,7 @@ namespace LiteDB.Engine
                 _transPages.NewPages.Add(pageID);
             }
 
-            var page = BasePage.CreatePage<T>(buffer, pageID);
+            var page = BasePage.CreatePage<T>(buffer, pageID, _plugins?.Expressions);
 
             // update local cache with new instance T page type
             if (page.PageType != PageType.Collection)

--- a/LiteDB/Engine/Structures/CollectionIndex.cs
+++ b/LiteDB/Engine/Structures/CollectionIndex.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -65,7 +66,7 @@ namespace LiteDB.Engine
             get { return string.IsNullOrEmpty(this.Name); }
         }
 
-        public CollectionIndex(byte slot, byte indexType, string name, string expr, bool unique)
+        public CollectionIndex(byte slot, byte indexType, string name, string expr, bool unique, IExpressionRegistry expressions = null)
         {
             this.Slot = slot;
             this.IndexType = indexType;
@@ -74,10 +75,10 @@ namespace LiteDB.Engine
             this.Unique = unique;
             this.FreeIndexPageList = uint.MaxValue;
 
-            this.BsonExpr = BsonExpression.Create(expr);
+            this.BsonExpr = CreateExpression(expr, expressions);
         }
 
-        public CollectionIndex(BufferReader reader)
+        public CollectionIndex(BufferReader reader, IExpressionRegistry expressions = null)
         {
             this.Slot = reader.ReadByte();
             this.IndexType = reader.ReadByte();
@@ -89,7 +90,12 @@ namespace LiteDB.Engine
             this.Reserved = reader.ReadByte(); // 1
             this.FreeIndexPageList = reader.ReadUInt32(); // 4
 
-            this.BsonExpr = BsonExpression.Create(this.Expression);
+            this.BsonExpr = CreateExpression(this.Expression, expressions);
+        }
+
+        private static BsonExpression CreateExpression(string expression, IExpressionRegistry expressions)
+        {
+            return expressions != null ? BsonExpression.Create(expression, expressions) : BsonExpression.Create(expression);
         }
 
         public void UpdateBuffer(BufferWriter writer)

--- a/LiteDB/Engine/SystemCollections/SysQuery.cs
+++ b/LiteDB/Engine/SystemCollections/SysQuery.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -23,7 +24,8 @@ namespace LiteDB.Engine
         {
             var query = options?.AsString ?? throw new LiteException(0, $"Collection $query(sql) requires `sql` string parameter");
 
-            var sql = new SqlParser(_engine, new Tokenizer(query), null);
+            var expressions = (_engine as LiteEngine)?.PluginContext?.Expressions ?? throw new LiteException(0, "$query requires access to expression registry");
+            var sql = new SqlParser(_engine, new Tokenizer(query, expressions), null, expressions);
 
             using (var reader = sql.Execute())
             {

--- a/LiteDB/Utils/Tokenizer.cs
+++ b/LiteDB/Utils/Tokenizer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -108,6 +109,8 @@ namespace LiteDB
             this.Type = tokenType;
         }
 
+        internal IExpressionRegistry Registry { get; set; }
+
         public TokenType Type { get; private set; }
         public string Value { get; private set; }
         public long Position { get; private set; }
@@ -192,7 +195,7 @@ namespace LiteDB
                             return true;
                         }
 
-                        var registry = BsonExpression.CurrentRegistry;
+                        var registry = this.Registry;
 
                         if (registry != null && (registry.ContainsKeyword(Value) || registry.ContainsOperator(Value)))
                         {
@@ -221,6 +224,7 @@ namespace LiteDB
     internal class Tokenizer
     {
         private readonly TextReader _reader;
+        private readonly IExpressionRegistry _registry;
         private char _char = '\0';
         private Token _ahead = null;
         private bool _eof = false;
@@ -239,14 +243,15 @@ namespace LiteDB
             return false;
         }
 
-        public Tokenizer(string source)
-            : this(new StringReader(source))
+        public Tokenizer(string source, IExpressionRegistry registry = null)
+            : this(new StringReader(source ?? throw new ArgumentNullException(nameof(source))), registry)
         {
         }
 
-        public Tokenizer(TextReader reader)
+        public Tokenizer(TextReader reader, IExpressionRegistry registry = null)
         {
-            _reader = reader;
+            _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+            _registry = registry;
 
             this.Position = 0;
             this.ReadChar();
@@ -337,7 +342,7 @@ namespace LiteDB
 
             if (_eof)
             {
-                return new Token(TokenType.EOF, null, this.Position);
+                return this.AttachRegistry(new Token(TokenType.EOF, null, this.Position));
             }
 
             Token token = null;
@@ -553,7 +558,17 @@ namespace LiteDB
                     break;
             }
 
-            return token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position);
+            return this.AttachRegistry(token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position));
+        }
+
+        private Token AttachRegistry(Token token)
+        {
+            if (token != null)
+            {
+                token.Registry = _registry;
+            }
+
+            return token;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- pass the database expression registry through CollectionIndex, CollectionPage, page factories, and snapshot accessors so engine-side parsing no longer relies on ambient state
- update SQL parsing, LINQ translation, and tokenizer plumbing to require an explicit IExpressionRegistry and reuse cached delegates per registry
- adjust BsonExpression compilation to key caches by registry and normalize parameter references before reuse

## Testing
- dotnet test LiteDB.Tests -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68ec46af1b88832681f70b2cdc986d83