### PR TITLE
Remove ambient expression registry usage

### DIFF
--- a/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
+++ b/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
@@ -124,11 +124,8 @@ public class BsonVector_Tests
         col.EnsureIndex(x => x.Embedding, new VectorIndexOptions(2));
 
         var target = new float[] { 1.0f, 0.0f };
-        BsonExpression fieldExpr;
-        using (db.EnterExpressionScope())
-        {
-            fieldExpr = BsonExpression.Create("$.Embedding");
-        }
+        var expressions = db.Services.ExpressionRegistry;
+        var fieldExpr = BsonExpression.Create("$.Embedding", expressions);
 
         var results = col.Query()
             .WhereNear(fieldExpr, target, maxDistance: .28)
@@ -142,6 +139,7 @@ public class BsonVector_Tests
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
         var col = db.GetCollection("vectors");
+        var expressions = db.Services.ExpressionRegistry;
 
         col.Insert(new BsonDocument
         {
@@ -159,16 +157,12 @@ public class BsonVector_Tests
             ["Embedding"] = new BsonVector(new float[] { 1.0f, 1.0f })
         });
 
-        using (db.EnterExpressionScope())
-        {
-            col.EnsureIndex(
-                "embedding_idx",
-                BsonExpression.Create("$.Embedding"),
-                new VectorIndexOptions(2));
-        }
+        col.EnsureIndex(
+            "embedding_idx",
+            BsonExpression.Create("$.Embedding", expressions),
+            new VectorIndexOptions(2));
 
         var query = "SELECT * FROM vectors WHERE ($.Embedding VECTOR_SIM [1.0, 0.0]) <= 0.25";
-        using var _ = db.EnterExpressionScope();
         var rawResults = db.Execute(query).ToList();
 
         var docs = rawResults
@@ -196,11 +190,8 @@ public class BsonVector_Tests
     public void VectorSim_InfixExpression_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]");
-        }
+        var expressions = db.Services.ExpressionRegistry;
+        var expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]", expressions);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 
@@ -219,11 +210,8 @@ public class BsonVector_Tests
     public void VectorSim_FunctionCall_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])");
-        }
+        var expressions = db.Services.ExpressionRegistry;
+        var expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])", expressions);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -19,18 +19,12 @@ namespace LiteDB.Tests.QueryTest
     {
         private static BsonExpression CreateExpression(LiteDatabase db, string expression)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression);
-            }
+            return BsonExpression.Create(expression, db.Services.ExpressionRegistry);
         }
 
         private static BsonExpression CreateExpression(LiteDatabase db, string expression, params BsonValue[] args)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression, args);
-            }
+            return BsonExpression.Create(expression, db.Services.ExpressionRegistry, args);
         }
 
         private class VectorDocument

--- a/LiteDB/Client/Database/Collections/Aggregate.cs
+++ b/LiteDB/Client/Database/Collections/Aggregate.cs
@@ -31,29 +31,17 @@ namespace LiteDB
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public int Count(string predicate, BsonDocument parameters)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, parameters));
-            }
-        }
+        public int Count(string predicate, BsonDocument parameters) => this.Count(BsonExpression.Create(predicate, parameters, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public int Count(string predicate, params BsonValue[] args)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, args));
-            }
-        }
+        public int Count(string predicate, params BsonValue[] args) => this.Count(BsonExpression.Create(predicate, _expressions, args));
 
         /// <summary>
         /// Count documents matching a query. This method does not deserialize any documents. Needs indexes on query expression
         /// </summary>
-        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate));
+        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -85,29 +73,17 @@ namespace LiteDB
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public long LongCount(string predicate, BsonDocument parameters)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, parameters));
-            }
-        }
+        public long LongCount(string predicate, BsonDocument parameters) => this.LongCount(BsonExpression.Create(predicate, parameters, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public long LongCount(string predicate, params BsonValue[] args)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, args));
-            }
-        }
+        public long LongCount(string predicate, params BsonValue[] args) => this.LongCount(BsonExpression.Create(predicate, _expressions, args));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate));
+        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -131,29 +107,17 @@ namespace LiteDB
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
         /// </summary>
-        public bool Exists(string predicate, BsonDocument parameters)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, parameters));
-            }
-        }
+        public bool Exists(string predicate, BsonDocument parameters) => this.Exists(BsonExpression.Create(predicate, parameters, _expressions));
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
         /// </summary>
-        public bool Exists(string predicate, params BsonValue[] args)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, args));
-            }
-        }
+        public bool Exists(string predicate, params BsonValue[] args) => this.Exists(BsonExpression.Create(predicate, _expressions, args));
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
         /// </summary>
-        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate));
+        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
@@ -193,7 +157,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Min(expr);
 
@@ -229,7 +193,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Max(expr);
 

--- a/LiteDB/Client/Database/Collections/Delete.cs
+++ b/LiteDB/Client/Database/Collections/Delete.cs
@@ -37,28 +37,16 @@ namespace LiteDB
         /// <summary>
         /// Delete all documents based on predicate expression. Returns how many documents was deleted
         /// </summary>
-        public int DeleteMany(string predicate, BsonDocument parameters)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, parameters));
-            }
-        }
+        public int DeleteMany(string predicate, BsonDocument parameters) => this.DeleteMany(BsonExpression.Create(predicate, parameters, _expressions));
 
         /// <summary>
         /// Delete all documents based on predicate expression. Returns how many documents was deleted
         /// </summary>
-        public int DeleteMany(string predicate, params BsonValue[] args)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, args));
-            }
-        }
+        public int DeleteMany(string predicate, params BsonValue[] args) => this.DeleteMany(BsonExpression.Create(predicate, _expressions, args));
 
         /// <summary>
         /// Delete all documents based on predicate expression. Returns how many documents was deleted
         /// </summary>
-        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate));
+        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate, _expressions));
     }
 }

--- a/LiteDB/Client/Database/Collections/Find.cs
+++ b/LiteDB/Client/Database/Collections/Find.cs
@@ -14,7 +14,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Query()
         {
-            return new LiteQueryable<T>(_engine, _mapper, _collection, new Query(), _expressions).Include(_includes);
+            return new LiteQueryable<T>(_engine, _mapper, _collection, new Query(_expressions), _expressions).Include(_includes);
         }
 
         #region Find
@@ -51,7 +51,7 @@ namespace LiteDB
         /// <summary>
         /// Find documents inside a collection using predicate expression.
         /// </summary>
-        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate), skip, limit);
+        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate, _expressions), skip, limit);
 
         #endregion
 
@@ -64,10 +64,7 @@ namespace LiteDB
         {
             if (id == null || id.IsNull) throw new ArgumentNullException(nameof(id));
 
-            using (this.EnterExpressionScope())
-            {
-                return this.Find(BsonExpression.Create("_id = @0", id)).FirstOrDefault();
-            }
+            return this.Find(BsonExpression.Create("_id = @0", _expressions, id)).FirstOrDefault();
         }
 
         /// <summary>
@@ -78,29 +75,22 @@ namespace LiteDB
         /// <summary>
         /// Find the first document using predicate expression. Returns null if not found
         /// </summary>
-        public T FindOne(string predicate, BsonDocument parameters)
-        {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, parameters));
-            }
-        }
+        public T FindOne(string predicate, BsonDocument parameters) => this.FindOne(BsonExpression.Create(predicate, parameters, _expressions));
 
         /// <summary>
         /// Find the first document using predicate expression. Returns null if not found
         /// </summary>
         public T FindOne(BsonExpression predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, args));
-            }
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            return this.FindOne(BsonExpression.Create(predicate.Source, _expressions, args));
         }
 
         /// <summary>
         /// Find the first document using predicate expression. Returns null if not found
         /// </summary>
-        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate));
+        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Find the first document using defined query structure. Returns null if not found

--- a/LiteDB/Client/Database/Collections/Include.cs
+++ b/LiteDB/Client/Database/Collections/Include.cs
@@ -15,7 +15,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var path = _mapper.GetExpression(keySelector);
+            var path = _mapper.GetExpression(keySelector, _expressions);
 
             return this.Include(path);
         }

--- a/LiteDB/Client/Database/Collections/Update.cs
+++ b/LiteDB/Client/Database/Collections/Update.cs
@@ -74,8 +74,8 @@ namespace LiteDB
             if (extend == null) throw new ArgumentNullException(nameof(extend));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            var ext = _mapper.GetExpression(extend);
-            var pred = _mapper.GetExpression(predicate);
+            var ext = _mapper.GetExpression(extend, _expressions);
+            var pred = _mapper.GetExpression(predicate, _expressions);
 
             if (ext.Type != BsonExpressionType.Document)
             {

--- a/LiteDB/Client/Database/LiteCollection.cs
+++ b/LiteDB/Client/Database/LiteCollection.cs
@@ -32,10 +32,7 @@ namespace LiteDB
         /// </summary>
         public EntityMapper EntityMapper => _entity;
 
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_expressions);
-        }
+        internal IExpressionRegistry Expressions => _expressions;
 
         internal LiteCollection(string name, BsonAutoId autoId, ILiteEngine engine, BsonMapper mapper, IExpressionRegistry expressions)
         {

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -28,6 +28,8 @@ namespace LiteDB
         /// </summary>
         public BsonMapper Mapper => _mapper;
 
+        public LiteDatabaseServices Services { get; }
+
         #endregion
 
         #region Ctor
@@ -52,6 +54,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(connectionString, NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext.Expressions);
 
             this.InitializePlugins(plugins);
         }
@@ -76,6 +79,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext.Expressions);
 
             this.InitializePlugins(plugins);
 
@@ -115,6 +119,7 @@ namespace LiteDB
             _disposeOnClose = disposeOnClose;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext.Expressions);
 
             this.InitializePlugins(plugins);
         }
@@ -159,11 +164,6 @@ namespace LiteDB
             if (name.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(name));
 
             return new LiteCollection<BsonDocument>(name, autoId, _engine, _mapper, _pluginContext.Expressions);
-        }
-
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_pluginContext.Expressions);
         }
 
         #endregion
@@ -298,8 +298,8 @@ namespace LiteDB
         {
             if (commandReader == null) throw new ArgumentNullException(nameof(commandReader));
 
-            var tokenizer = new Tokenizer(commandReader);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var tokenizer = new Tokenizer(commandReader, _pluginContext.Expressions);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;
@@ -312,8 +312,8 @@ namespace LiteDB
         {
             if (command == null) throw new ArgumentNullException(nameof(command));
 
-            var tokenizer = new Tokenizer(command);
-            var sql = new SqlParser(_engine, tokenizer, parameters);
+            var tokenizer = new Tokenizer(command, _pluginContext.Expressions);
+            var sql = new SqlParser(_engine, tokenizer, parameters, _pluginContext.Expressions);
             var reader = sql.Execute();
 
             return reader;
@@ -455,5 +455,15 @@ namespace LiteDB
                 _engine.Dispose();
             }
         }
+    }
+
+    public sealed class LiteDatabaseServices
+    {
+        internal LiteDatabaseServices(IExpressionRegistry expressions)
+        {
+            this.ExpressionRegistry = expressions ?? throw new ArgumentNullException(nameof(expressions));
+        }
+
+        public IExpressionRegistry ExpressionRegistry { get; }
     }
 }

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -40,7 +40,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Include<K>(Expression<Func<T, K>> path)
         {
-            _query.Includes.Add(_mapper.GetExpression(path));
+            _query.Includes.Add(_mapper.GetExpression(path, _expressions));
             return this;
         }
 
@@ -80,10 +80,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, BsonDocument parameters)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, parameters));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, parameters, _expressions));
             return this;
         }
 
@@ -92,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, params BsonValue[] args)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, args));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, _expressions, args));
             return this;
         }
 
@@ -104,7 +98,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(Expression<Func<T, bool>> predicate)
         {
-            return this.Where(_mapper.GetExpression(predicate));
+            return this.Where(_mapper.GetExpression(predicate, _expressions));
         }
 
         #endregion
@@ -127,7 +121,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> OrderBy<K>(Expression<Func<T, K>> keySelector, int order = Query.Ascending)
         {
-            return this.OrderBy(_mapper.GetExpression(keySelector), order);
+            return this.OrderBy(_mapper.GetExpression(keySelector, _expressions), order);
         }
 
         /// <summary>
@@ -156,7 +150,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenBy<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenBy(_mapper.GetExpression(keySelector));
+            return this.ThenBy(_mapper.GetExpression(keySelector, _expressions));
         }
 
         /// <summary>
@@ -175,7 +169,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenByDescending<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenByDescending(_mapper.GetExpression(keySelector));
+            return this.ThenByDescending(_mapper.GetExpression(keySelector, _expressions));
         }
 
         #endregion
@@ -187,7 +181,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<IGrouping<K, T>> GroupBy<K>(Expression<Func<T, K>> keySelector)
         {
-            var expression = _mapper.GetExpression(keySelector);
+            var expression = _mapper.GetExpression(keySelector, _expressions);
 
             this.GroupBy(expression);
 
@@ -241,7 +235,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<K> Select<K>(Expression<Func<T, K>> selector)
         {
-            _query.Select = _mapper.GetExpression(selector);
+            _query.Select = _mapper.GetExpression(selector, _expressions);
 
             return new LiteQueryable<K>(_engine, _mapper, _collection, _query, _expressions);
         }
@@ -260,18 +254,14 @@ namespace LiteDB
             ValidateVectorArguments(target, maxDistance);
 
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", targetArray, new BsonValue(maxDistance));
-            }
+            return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", _expressions, targetArray, new BsonValue(maxDistance));
         }
 
         internal ILiteQueryable<T> VectorWhereNear(string vectorField, float[] target, double maxDistance)
         {
             if (string.IsNullOrWhiteSpace(vectorField)) throw new ArgumentNullException(nameof(vectorField));
 
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{vectorField}");
+            var fieldExpr = BsonExpression.Create($"$.{vectorField}", _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
@@ -292,20 +282,19 @@ namespace LiteDB
         {
             if (field == null) throw new ArgumentNullException(nameof(field));
 
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear<K>(Expression<Func<T, K>> field, float[] target, int k)
         {
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear(string field, float[] target, int k)
         {
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{field}");
+            var fieldExpr = BsonExpression.Create($"$.{field}", _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
@@ -318,18 +307,15 @@ namespace LiteDB
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
 
             // Build VECTOR_SIM as order clause
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", targetArray);
+            var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", _expressions, targetArray);
 
-                _query.VectorField = fieldExpr.Source;
-                _query.VectorTarget = target?.ToArray();
-                _query.VectorMaxDistance = double.MaxValue;
+            _query.VectorField = fieldExpr.Source;
+            _query.VectorTarget = target?.ToArray();
+            _query.VectorMaxDistance = double.MaxValue;
 
-                return this
-                    .OrderBy(simExpr, Query.Ascending)
-                    .Limit(k);
-            }
+            return this
+                .OrderBy(simExpr, Query.Ascending)
+                .Limit(k);
         }
 
         [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -1,3 +1,4 @@
+using LiteDB.Plugins;
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
@@ -167,9 +168,17 @@ namespace LiteDB
         /// <summary>
         /// Resolve LINQ expression into BsonExpression
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            return this.GetExpression(predicate, BsonExpression.LegacyRegistry);
+        }
+
+        public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry registry)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            var visitor = new LinqExpressionVisitor(this, predicate, registry);
 
             var expr = visitor.Resolve(typeof(K) == typeof(bool));
 
@@ -181,9 +190,17 @@ namespace LiteDB
         /// <summary>
         /// Resolve LINQ expression into BsonExpression (for index only)
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            return this.GetIndexExpression(predicate, BsonExpression.LegacyRegistry);
+        }
+
+        public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry registry)
+        {
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+
+            var visitor = new LinqExpressionVisitor(this, predicate, registry);
 
             var expr = visitor.Resolve(false);
 

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LiteDB.Plugins;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,6 +39,7 @@ namespace LiteDB
         private readonly BsonMapper _mapper;
         private readonly Expression _expr;
         private readonly ParameterExpression _rootParameter = null;
+        private readonly IExpressionRegistry _registry;
 
         private readonly BsonDocument _parameters = new BsonDocument();
         private int _paramIndex = 0;
@@ -46,10 +48,11 @@ namespace LiteDB
         private readonly StringBuilder _builder = new StringBuilder();
         private readonly Stack<Expression> _nodes = new Stack<Expression>();
 
-        public LinqExpressionVisitor(BsonMapper mapper, Expression expr)
+        public LinqExpressionVisitor(BsonMapper mapper, Expression expr, IExpressionRegistry registry)
         {
             _mapper = mapper;
             _expr = expr;
+            _registry = registry ?? BsonExpression.LegacyRegistry;
 
             if (expr is LambdaExpression lambda)
             {
@@ -71,14 +74,14 @@ namespace LiteDB
 
             try
             {
-                var e = BsonExpression.Create(expression, _parameters);
+                var e = BsonExpression.Create(expression, _parameters, _registry);
 
                 // if expression must return an predicate but expression result is Path/Parameter/Call add `= true`
                 if (predicate && (e.Type == BsonExpressionType.Path || e.Type == BsonExpressionType.Call || e.Type == BsonExpressionType.Parameter))
                 {
                     expression = "(" + expression + " = true)";
 
-                    e = BsonExpression.Create(expression, _parameters);
+                    e = BsonExpression.Create(expression, _parameters, _registry);
                 }
 
                 return e;
@@ -528,7 +531,7 @@ namespace LiteDB
         /// </summary>
         private void ResolvePattern(string pattern, Expression obj, IList<Expression> args)
         {
-            var tokenizer = new Tokenizer(pattern);
+            var tokenizer = new Tokenizer(pattern, _registry);
 
             // lets use tokenizer to parse this method pattern
             while (!tokenizer.EOF)

--- a/LiteDB/Client/SqlParser/Commands/Create.cs
+++ b/LiteDB/Client/SqlParser/Commands/Create.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             _tokenizer.ReadToken().Expect(TokenType.OpenParenthesis);
 
             // read index expression
-            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument());
+            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument(), _expressions);
 
             // read )
             _tokenizer.ReadToken().Expect(TokenType.CloseParenthesis);

--- a/LiteDB/Client/SqlParser/Commands/Delete.cs
+++ b/LiteDB/Client/SqlParser/Commands/Delete.cs
@@ -24,7 +24,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             _tokenizer.ReadToken().Expect(TokenType.EOF, TokenType.SemiColon);

--- a/LiteDB/Client/SqlParser/Commands/ParseLists.cs
+++ b/LiteDB/Client/SqlParser/Commands/ParseLists.cs
@@ -16,7 +16,7 @@ namespace LiteDB
         {
             while(true)
             {
-                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 yield return expr;
 

--- a/LiteDB/Client/SqlParser/Commands/Select.cs
+++ b/LiteDB/Client/SqlParser/Commands/Select.cs
@@ -26,7 +26,7 @@ namespace LiteDB
         private IBsonDataReader ParseSelect()
         {
             // initialize query definition
-            var query = new Query();
+            var query = new Query(_expressions);
 
             var token = _tokenizer.ReadToken();
 
@@ -37,7 +37,7 @@ namespace LiteDB
             token.Expect("SELECT");
 
             // read required SELECT <expr> and convert into single expression
-            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters);
+            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters, _expressions);
 
             // read FROM|INTO
             var from = _tokenizer.ReadToken();
@@ -88,7 +88,7 @@ namespace LiteDB
                 // read WHERE keyword
                 _tokenizer.ReadToken();
 
-                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.Where.Add(where);
             }
@@ -101,7 +101,7 @@ namespace LiteDB
                 _tokenizer.ReadToken();
                 _tokenizer.ReadToken().Expect("BY");
 
-                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                 query.GroupBy = groupBy;
 
@@ -112,7 +112,7 @@ namespace LiteDB
                     // read HAVING keyword
                     _tokenizer.ReadToken();
 
-                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     query.Having = having;
                 }
@@ -128,7 +128,7 @@ namespace LiteDB
 
                 while (true)
                 {
-                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
 
                     var orderByOrder = Query.Ascending;
                     var orderByToken = _tokenizer.LookAhead();

--- a/LiteDB/Client/SqlParser/Commands/Update.cs
+++ b/LiteDB/Client/SqlParser/Commands/Update.cs
@@ -22,7 +22,7 @@ namespace LiteDB
             var collection = _tokenizer.ReadToken().Expect(TokenType.Word).Value;
             _tokenizer.ReadToken().Expect("SET");
 
-            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters);
+            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters, _expressions);
 
             // optional where
             BsonExpression where = null;
@@ -33,7 +33,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _expressions);
             }
 
             // read eof

--- a/LiteDB/Client/SqlParser/SqlParser.cs
+++ b/LiteDB/Client/SqlParser/SqlParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using LiteDB.Engine;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -15,13 +16,15 @@ namespace LiteDB
         private readonly ILiteEngine _engine;
         private readonly Tokenizer _tokenizer;
         private readonly BsonDocument _parameters;
+        private readonly IExpressionRegistry _expressions;
         private readonly Lazy<Collation> _collation;
 
-        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters)
+        public SqlParser(ILiteEngine engine, Tokenizer tokenizer, BsonDocument parameters, IExpressionRegistry expressions)
         {
             _engine = engine;
             _tokenizer = tokenizer;
             _parameters = parameters ?? new BsonDocument();
+            _expressions = expressions ?? BsonExpression.LegacyRegistry;
             _collation = new Lazy<Collation>(() => new Collation(_engine.Pragma(Pragmas.COLLATION)));
         }
 

--- a/LiteDB/Client/Storage/LiteStorage.cs
+++ b/LiteDB/Client/Storage/LiteStorage.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LiteDB.Plugins;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -15,12 +16,14 @@ namespace LiteDB
         private readonly ILiteDatabase _db;
         private readonly ILiteCollection<LiteFileInfo<TFileId>> _files;
         private readonly ILiteCollection<BsonDocument> _chunks;
+        private readonly IExpressionRegistry _expressions;
 
         public LiteStorage(ILiteDatabase db, string filesCollection, string chunksCollection)
         {
             _db = db;
             _files = db.GetCollection<LiteFileInfo<TFileId>>(filesCollection);
             _chunks = db.GetCollection(chunksCollection);
+            _expressions = db is LiteDatabase liteDb ? liteDb.Services.ExpressionRegistry : BsonExpression.LegacyRegistry;
         }
 
         #region Find Files
@@ -68,17 +71,17 @@ namespace LiteDB
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters, _expressions));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, args));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, _expressions, args));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate) => this.Find(_db.Mapper.GetExpression(predicate));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(Expression<Func<LiteFileInfo<TFileId>, bool>> predicate) => this.Find(_db.Mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Find all files inside file collections

--- a/LiteDB/Client/Structures/Query.cs
+++ b/LiteDB/Client/Structures/Query.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 
 using System;
 using System.Collections.Generic;
@@ -13,6 +14,8 @@ namespace LiteDB
     /// </summary>
     public partial class Query
     {
+        private readonly IExpressionRegistry _expressions;
+
         /// <summary>
         /// Indicate when a query must execute in ascending order
         /// </summary>
@@ -22,6 +25,31 @@ namespace LiteDB
         /// Indicate when a query must execute in descending order
         /// </summary>
         public const int Descending = -1;
+
+        /// <summary>
+        /// Returns all documents
+        /// </summary>
+        public Query()
+            : this(BsonExpression.LegacyRegistry)
+        {
+        }
+
+        internal Query(IExpressionRegistry expressions)
+        {
+            _expressions = expressions ?? BsonExpression.LegacyRegistry;
+        }
+
+        internal IExpressionRegistry Expressions => _expressions;
+
+        private BsonExpression CreateExpression(string expression)
+        {
+            return BsonExpression.Create(expression, _expressions);
+        }
+
+        private BsonExpression CreateExpression(string expression, params BsonValue[] args)
+        {
+            return BsonExpression.Create(expression, _expressions, args);
+        }
 
         /// <summary>
         /// Returns all documents
@@ -37,7 +65,7 @@ namespace LiteDB
         public static Query All(int order = Ascending)
         {
             var query = new Query();
-            query.OrderBy.Add(new QueryOrder(BsonExpression.Create("_id"), order));
+            query.OrderBy.Add(new QueryOrder(query.CreateExpression("_id"), order));
             return query;
         }
 
@@ -47,7 +75,7 @@ namespace LiteDB
         public static Query All(string field, int order = Ascending)
         {
             var query = new Query();
-            query.OrderBy.Add(new QueryOrder(BsonExpression.Create(field), order));
+            query.OrderBy.Add(new QueryOrder(query.CreateExpression(field), order));
             return query;
         }
 
@@ -58,7 +86,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} = {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} = {value ?? BsonValue.Null}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -68,7 +96,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} < {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} < {value ?? BsonValue.Null}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -78,7 +106,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} <= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} <= {value ?? BsonValue.Null}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -88,7 +116,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} > {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} > {value ?? BsonValue.Null}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -98,7 +126,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} >= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} >= {value ?? BsonValue.Null}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -108,7 +136,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -119,7 +147,7 @@ namespace LiteDB
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} LIKE {(new BsonValue(value + "%"))}");
+            return BsonExpression.Create($"{field} LIKE {(new BsonValue(value + "%"))}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -130,7 +158,7 @@ namespace LiteDB
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value.IsNullOrEmpty()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} LIKE {(new BsonValue("%" + value + "%"))}");
+            return BsonExpression.Create($"{field} LIKE {(new BsonValue("%" + value + "%"))}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -140,7 +168,7 @@ namespace LiteDB
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} != {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{field} != {value ?? BsonValue.Null}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>
@@ -151,7 +179,7 @@ namespace LiteDB
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value == null) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} IN {value}");
+            return BsonExpression.Create($"{field} IN {value}", BsonExpression.LegacyRegistry);
         }
 
         /// <summary>

--- a/LiteDB/Client/Structures/QueryAny.cs
+++ b/LiteDB/Client/Structures/QueryAny.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,18 @@ namespace LiteDB
 {
     public class QueryAny
     {
+        private readonly IExpressionRegistry _expressions;
+
+        public QueryAny()
+            : this(BsonExpression.LegacyRegistry)
+        {
+        }
+
+        internal QueryAny(IExpressionRegistry expressions)
+        {
+            _expressions = expressions ?? BsonExpression.LegacyRegistry;
+        }
+
         /// <summary>
         /// Returns all documents for which at least one value in arrayFields is equal to value
         /// </summary>
@@ -15,7 +28,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY = {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY = {value ?? BsonValue.Null}", _expressions);
         }
 
         /// <summary>
@@ -25,7 +38,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY < {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY < {value ?? BsonValue.Null}", _expressions);
         }
 
         /// <summary>
@@ -35,7 +48,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY <= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY <= {value ?? BsonValue.Null}", _expressions);
         }
 
         /// <summary>
@@ -45,7 +58,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY > {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY > {value ?? BsonValue.Null}", _expressions);
 
         }
 
@@ -56,7 +69,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY >= {value ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY >= {value ?? BsonValue.Null}", _expressions);
         }
 
         /// <summary>
@@ -66,7 +79,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}");
+            return BsonExpression.Create($"{arrayField} ANY BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}", _expressions);
         }
 
         /// <summary>
@@ -77,7 +90,7 @@ namespace LiteDB
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
             if (value.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{arrayField} ANY LIKE {(new BsonValue(value + "%"))}");
+            return BsonExpression.Create($"{arrayField} ANY LIKE {(new BsonValue(value + "%"))}", _expressions);
         }
 
         /// <summary>
@@ -87,7 +100,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY != {value ?? BsonValue.Null}");
-        }
+            return BsonExpression.Create($"{arrayField} ANY != {value ?? BsonValue.Null}", _expressions);
     }
+}
 }

--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -6,9 +6,9 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using LiteDB.Plugins;
 using static LiteDB.Constants;
 
@@ -126,17 +126,6 @@ namespace LiteDB
         /// </summary>
         private BsonExpressionScalarDelegate _funcScalar;
 
-        private static readonly AsyncLocal<IExpressionRegistry> _currentRegistry = new AsyncLocal<IExpressionRegistry>();
-
-        internal static IDisposable UseRegistry(IExpressionRegistry registry)
-        {
-            var previous = _currentRegistry.Value;
-            _currentRegistry.Value = registry;
-            return new RegistryScope(previous);
-        }
-
-        internal static IExpressionRegistry CurrentRegistry => _currentRegistry.Value;
-
         /// <summary>
         /// Get default field name when need convert simple BsonValue into BsonDocument
         /// </summary>
@@ -167,7 +156,7 @@ namespace LiteDB
         /// </summary>
         public static implicit operator BsonExpression(String expr)
         {
-            return BsonExpression.Create(expr);
+            return BsonExpression.Create(expr, LegacyRegistry);
         }
 
         #region Execute Enumerable
@@ -292,42 +281,110 @@ namespace LiteDB
 
         #region Static method
 
-        private static readonly ConcurrentDictionary<string, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<string, BsonExpressionEnumerableDelegate>();
-        private static readonly ConcurrentDictionary<string, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<string, BsonExpressionScalarDelegate>();
+        private static readonly ExpressionRegistry _legacyRegistry = new ExpressionRegistry();
+
+        internal static IExpressionRegistry LegacyRegistry => _legacyRegistry;
+
+        private readonly struct RegistryCacheKey : IEquatable<RegistryCacheKey>
+        {
+            private readonly IExpressionRegistry _registry;
+            private readonly string _source;
+
+            public RegistryCacheKey(IExpressionRegistry registry, string source)
+            {
+                _registry = registry;
+                _source = source ?? throw new ArgumentNullException(nameof(source));
+            }
+
+            public bool Equals(RegistryCacheKey other)
+            {
+                return ReferenceEquals(_registry, other._registry) &&
+                    string.Equals(_source, other._source, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is RegistryCacheKey other && this.Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var registryHash = _registry != null ? RuntimeHelpers.GetHashCode(_registry) : 0;
+                    return (registryHash * 397) ^ StringComparer.Ordinal.GetHashCode(_source);
+                }
+            }
+        }
+
+        private static readonly ConcurrentDictionary<RegistryCacheKey, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<RegistryCacheKey, BsonExpressionEnumerableDelegate>();
+        private static readonly ConcurrentDictionary<RegistryCacheKey, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<RegistryCacheKey, BsonExpressionScalarDelegate>();
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression)
         {
-            return Create(expression, new BsonDocument());
+            return Create(expression, new BsonDocument(), LegacyRegistry);
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static BsonExpression Create(string expression, params BsonValue[] args)
         {
+            return Create(expression, LegacyRegistry, args);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Create(string expression, BsonDocument parameters)
+        {
+            return Create(expression, parameters, LegacyRegistry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry)
+        {
+            return Create(expression, new BsonDocument(), registry);
+        }
+
+        /// <summary>
+        /// Parse string and create new instance of BsonExpression - can be cached
+        /// </summary>
+        public static BsonExpression Create(string expression, IExpressionRegistry registry, params BsonValue[] args)
+        {
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
+
             var parameters = new BsonDocument();
 
-            for(var i = 0; i < args.Length; i++)
+            for (var i = 0; i < args.Length; i++)
             {
                 parameters[i.ToString()] = args[i];
             }
 
-            return Create(expression, parameters);
+            return Create(expression, parameters, registry);
         }
 
         /// <summary>
         /// Parse string and create new instance of BsonExpression - can be cached
         /// </summary>
-        public static BsonExpression Create(string expression, BsonDocument parameters)
+        public static BsonExpression Create(string expression, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
-            var tokenizer = new Tokenizer(expression);
+            parameters ??= new BsonDocument();
 
-            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters);
+            var tokenizer = new Tokenizer(expression, registry);
+
+            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters, registry);
 
             tokenizer.LookAhead().Expect(TokenType.EOF);
 
@@ -337,21 +394,23 @@ namespace LiteDB
         /// <summary>
         /// Parse tokenizer and create new instance of BsonExpression - for now, do not use cache
         /// </summary>
-        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters)
+        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
-            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root);
+            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root, registry);
         }
 
         /// <summary>
         /// Parse and compile string expression and return BsonExpression
         /// </summary>
-        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope)
+        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
 
-            var context = new ExpressionContext();
+            var context = new ExpressionContext(registry);
 
             var expr =
                 mode == BsonExpressionParserMode.Full ? BsonExpressionParser.ParseFullExpression(tokenizer, context, parameters, scope) :
@@ -360,18 +419,24 @@ namespace LiteDB
                 BsonExpressionParser.ParseUpdateDocumentBuilder(tokenizer, context, parameters);
 
             // compile linq expression (with left+right expressions)
-            Compile(expr, context);
+            Compile(expr, context, registry);
 
             return expr;
         }
 
-        internal static void Compile(BsonExpression expr, ExpressionContext context)
+        public static BsonExpression Compile(string expression, IExpressionRegistry registry)
+        {
+            return Create(expression, registry);
+        }
+
+        internal static void Compile(BsonExpression expr, ExpressionContext context, IExpressionRegistry registry)
         {
             // compile linq expression according with return type (scalar or enumerable)
             // in both case, try use cached compiled version
             if (expr.IsScalar)
             {
-                var cached = _cacheScalar.GetOrAdd(expr.Source, s =>
+                var key = new RegistryCacheKey(registry, expr.Source);
+                var cached = _cacheScalar.GetOrAdd(key, _ =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionScalarDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -382,7 +447,8 @@ namespace LiteDB
             }
             else
             {
-                var cached = _cacheEnumerable.GetOrAdd(expr.Source, s =>
+                var key = new RegistryCacheKey(registry, expr.Source);
+                var cached = _cacheEnumerable.GetOrAdd(key, _ =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionEnumerableDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -393,8 +459,8 @@ namespace LiteDB
             }
 
             // compile child expressions (left/right)
-            if (expr.Left != null) Compile(expr.Left, context);
-            if (expr.Right != null) Compile(expr.Right, context);
+            if (expr.Left != null) Compile(expr.Left, context, registry);
+            if (expr.Right != null) Compile(expr.Right, context, registry);
         }
 
         /// <summary>
@@ -411,7 +477,7 @@ namespace LiteDB
         /// <summary>
         /// Get root document $ expression
         /// </summary>
-        public static BsonExpression Root = Create("$");
+        public static BsonExpression Root = Create("$", LegacyRegistry);
 
         #endregion
 
@@ -473,24 +539,5 @@ namespace LiteDB
             return $"`{this.Source}` [{this.Type}]";
         }
 
-        private sealed class RegistryScope : IDisposable
-        {
-            private readonly IExpressionRegistry _previous;
-            private bool _disposed;
-
-            public RegistryScope(IExpressionRegistry previous)
-            {
-                _previous = previous;
-            }
-
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    _currentRegistry.Value = _previous;
-                    _disposed = true;
-                }
-            }
-        }
     }
 }

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -111,11 +111,9 @@ namespace LiteDB
             new OperatorDefinition("OR", " OR ", null, BsonExpressionType.Or, (int)BinaryOperatorPrecedence.LogicalOr)
         };
 
-        private static List<OperatorDefinition> GetOperatorTable()
+        private static List<OperatorDefinition> GetOperatorTable(IExpressionRegistry registry)
         {
             var table = new List<OperatorDefinition>(_builtInOperators);
-
-            var registry = BsonExpression.CurrentRegistry;
 
             if (registry != null)
             {
@@ -188,7 +186,7 @@ namespace LiteDB
             }
 
             var order = 0;
-            var operatorTable = GetOperatorTable();
+            var operatorTable = GetOperatorTable(context.ExpressionRegistry);
 
             // now, process operator in correct order
             while (values.Count >= 2)
@@ -798,7 +796,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source);
+                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source, context.ExpressionRegistry);
 
                 if (pathExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1131,7 +1129,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current);
+                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current, context.ExpressionRegistry);
 
                 if (mapExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1207,7 +1205,7 @@ namespace LiteDB
                 else
                 {
                     // inner expression
-                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current);
+                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current, context.ExpressionRegistry);
 
                     if (inner == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1257,9 +1255,9 @@ namespace LiteDB
                 case "SORT": return ParseFunction(token, BsonExpressionType.Sort, tokenizer, context, parameters, scope);
             }
 
-            if (BsonExpression.CurrentRegistry is ExpressionRegistry registry)
+            if (context.ExpressionRegistry != null)
             {
-                var registration = registry.FindByName(token);
+                var registration = context.ExpressionRegistry.FindByName(token);
 
                 if (registration != null)
                 {
@@ -1316,7 +1314,7 @@ namespace LiteDB
                 tokenizer.ReadToken().Expect(TokenType.Greater);
 
                 var right = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters,
-                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current);
+                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current, context.ExpressionRegistry);
 
                 src.Append("=>" + right.Source);
                 args.Add(Expression.Constant(right));

--- a/LiteDB/Document/Expression/Parser/ExpressionContext.cs
+++ b/LiteDB/Document/Expression/Parser/ExpressionContext.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,13 +12,20 @@ namespace LiteDB
 {
     internal class ExpressionContext
     {
-        public ExpressionContext()
+        private static readonly ParameterExpression _sourceParameter = Expression.Parameter(typeof(IEnumerable<BsonDocument>), "source");
+        private static readonly ParameterExpression _rootParameter = Expression.Parameter(typeof(BsonDocument), "root");
+        private static readonly ParameterExpression _currentParameter = Expression.Parameter(typeof(BsonValue), "current");
+        private static readonly ParameterExpression _collationParameter = Expression.Parameter(typeof(Collation), "collation");
+        private static readonly ParameterExpression _parametersParameter = Expression.Parameter(typeof(BsonDocument), "parameters");
+
+        public ExpressionContext(IExpressionRegistry registry)
         {
-            this.Source = Expression.Parameter(typeof(IEnumerable<BsonDocument>), "source");
-            this.Root = Expression.Parameter(typeof(BsonDocument), "root");
-            this.Current = Expression.Parameter(typeof(BsonValue), "current");
-            this.Collation = Expression.Parameter(typeof(Collation), "collation");
-            this.Parameters = Expression.Parameter(typeof(BsonDocument), "parameters");
+            this.Source = _sourceParameter;
+            this.Root = _rootParameter;
+            this.Current = _currentParameter;
+            this.Collation = _collationParameter;
+            this.Parameters = _parametersParameter;
+            this.ExpressionRegistry = registry;
         }
 
         public ParameterExpression Source { get; }
@@ -25,5 +33,7 @@ namespace LiteDB
         public ParameterExpression Current { get; }
         public ParameterExpression Collation { get; }
         public ParameterExpression Parameters { get; }
+
+        public IExpressionRegistry ExpressionRegistry { get; }
     }
 }

--- a/LiteDB/Engine/SystemCollections/SysQuery.cs
+++ b/LiteDB/Engine/SystemCollections/SysQuery.cs
@@ -23,7 +23,8 @@ namespace LiteDB.Engine
         {
             var query = options?.AsString ?? throw new LiteException(0, $"Collection $query(sql) requires `sql` string parameter");
 
-            var sql = new SqlParser(_engine, new Tokenizer(query), null);
+            var expressions = (_engine as LiteEngine)?.PluginContext?.Expressions ?? BsonExpression.LegacyRegistry;
+            var sql = new SqlParser(_engine, new Tokenizer(query, expressions), null, expressions);
 
             using (var reader = sql.Execute())
             {

--- a/LiteDB/Plugins/DefaultPluginContext.cs
+++ b/LiteDB/Plugins/DefaultPluginContext.cs
@@ -134,7 +134,7 @@ namespace LiteDB.Plugins
             }
         }
 
-        internal bool TryGetFunction(string name, int additionalArgumentCount, out ExpressionFunctionRegistration registration)
+        public bool TryGetFunction(string name, int additionalArgumentCount, out ExpressionFunctionRegistration registration)
         {
             var key = GetFunctionKey(name, additionalArgumentCount);
 
@@ -144,7 +144,7 @@ namespace LiteDB.Plugins
             }
         }
 
-        internal ExpressionFunctionRegistration FindByName(string name)
+        public ExpressionFunctionRegistration FindByName(string name)
         {
             lock (_sync)
             {

--- a/LiteDB/Plugins/ILitePlugin.cs
+++ b/LiteDB/Plugins/ILitePlugin.cs
@@ -76,6 +76,10 @@ namespace LiteDB.Plugins
         bool ContainsOperator(string token);
 
         bool ContainsKeyword(string keyword);
+
+        bool TryGetFunction(string name, int additionalArgumentCount, out ExpressionFunctionRegistration registration);
+
+        ExpressionFunctionRegistration FindByName(string name);
     }
 
     /// <summary>

--- a/LiteDB/Utils/Tokenizer.cs
+++ b/LiteDB/Utils/Tokenizer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using LiteDB.Plugins;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -101,11 +102,14 @@ namespace LiteDB
             "OR"
         };
 
-        public Token(TokenType tokenType, string value, long position)
+        private readonly IExpressionRegistry _registry;
+
+        public Token(TokenType tokenType, string value, long position, IExpressionRegistry registry)
         {
             this.Position = position;
             this.Value = value;
             this.Type = tokenType;
+            _registry = registry;
         }
 
         public TokenType Type { get; private set; }
@@ -192,9 +196,7 @@ namespace LiteDB
                             return true;
                         }
 
-                        var registry = BsonExpression.CurrentRegistry;
-
-                        if (registry != null && (registry.ContainsKeyword(Value) || registry.ContainsOperator(Value)))
+                        if (_registry != null && (_registry.ContainsKeyword(Value) || _registry.ContainsOperator(Value)))
                         {
                             return true;
                         }
@@ -221,6 +223,7 @@ namespace LiteDB
     internal class Tokenizer
     {
         private readonly TextReader _reader;
+        private readonly IExpressionRegistry _expressionRegistry;
         private char _char = '\0';
         private Token _ahead = null;
         private bool _eof = false;
@@ -239,17 +242,23 @@ namespace LiteDB
             return false;
         }
 
-        public Tokenizer(string source)
-            : this(new StringReader(source))
+        public Tokenizer(string source, IExpressionRegistry expressionRegistry = null)
+            : this(new StringReader(source), expressionRegistry)
         {
         }
 
-        public Tokenizer(TextReader reader)
+        public Tokenizer(TextReader reader, IExpressionRegistry expressionRegistry = null)
         {
-            _reader = reader;
+            _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+            _expressionRegistry = expressionRegistry;
 
             this.Position = 0;
             this.ReadChar();
+        }
+
+        private Token CreateToken(TokenType type, string value)
+        {
+            return new Token(type, value, this.Position, _expressionRegistry);
         }
 
         /// <summary>
@@ -337,7 +346,7 @@ namespace LiteDB
 
             if (_eof)
             {
-                return new Token(TokenType.EOF, null, this.Position);
+                return this.CreateToken(TokenType.EOF, null);
             }
 
             Token token = null;
@@ -345,72 +354,72 @@ namespace LiteDB
             switch (_char)
             {
                 case '{':
-                    token = new Token(TokenType.OpenBrace, "{", this.Position);
+                    token = this.CreateToken(TokenType.OpenBrace, "{");
                     this.ReadChar();
                     break;
 
                 case '}':
-                    token = new Token(TokenType.CloseBrace, "}", this.Position);
+                    token = this.CreateToken(TokenType.CloseBrace, "}");
                     this.ReadChar();
                     break;
 
                 case '[':
-                    token = new Token(TokenType.OpenBracket, "[", this.Position);
+                    token = this.CreateToken(TokenType.OpenBracket, "[");
                     this.ReadChar();
                     break;
 
                 case ']':
-                    token = new Token(TokenType.CloseBracket, "]", this.Position);
+                    token = this.CreateToken(TokenType.CloseBracket, "]");
                     this.ReadChar();
                     break;
 
                 case '(':
-                    token = new Token(TokenType.OpenParenthesis, "(", this.Position);
+                    token = this.CreateToken(TokenType.OpenParenthesis, "(");
                     this.ReadChar();
                     break;
 
                 case ')':
-                    token = new Token(TokenType.CloseParenthesis, ")", this.Position);
+                    token = this.CreateToken(TokenType.CloseParenthesis, ")");
                     this.ReadChar();
                     break;
 
                 case ',':
-                    token = new Token(TokenType.Comma, ",", this.Position);
+                    token = this.CreateToken(TokenType.Comma, ",");
                     this.ReadChar();
                     break;
 
                 case ':':
-                    token = new Token(TokenType.Colon, ":", this.Position);
+                    token = this.CreateToken(TokenType.Colon, ":");
                     this.ReadChar();
                     break;
 
                 case ';':
-                    token = new Token(TokenType.SemiColon, ";", this.Position);
+                    token = this.CreateToken(TokenType.SemiColon, ";");
                     this.ReadChar();
                     break;
 
                 case '@':
-                    token = new Token(TokenType.At, "@", this.Position);
+                    token = this.CreateToken(TokenType.At, "@");
                     this.ReadChar();
                     break;
 
                 case '#':
-                    token = new Token(TokenType.Hashtag, "#", this.Position);
+                    token = this.CreateToken(TokenType.Hashtag, "#");
                     this.ReadChar();
                     break;
 
                 case '~':
-                    token = new Token(TokenType.Til, "~", this.Position);
+                    token = this.CreateToken(TokenType.Til, "~");
                     this.ReadChar();
                     break;
 
                 case '.':
-                    token = new Token(TokenType.Period, ".", this.Position);
+                    token = this.CreateToken(TokenType.Period, ".");
                     this.ReadChar();
                     break;
 
                 case '&':
-                    token = new Token(TokenType.Ampersand, "&", this.Position);
+                    token = this.CreateToken(TokenType.Ampersand, "&");
                     this.ReadChar();
                     break;
 
@@ -418,11 +427,11 @@ namespace LiteDB
                     this.ReadChar();
                     if (IsWordChar(_char, true))
                     {
-                        token = new Token(TokenType.Word, "$" + this.ReadWord(), this.Position);
+                        token = this.CreateToken(TokenType.Word, "$" + this.ReadWord());
                     }
                     else
                     {
-                        token = new Token(TokenType.Dollar, "$", this.Position);
+                        token = this.CreateToken(TokenType.Dollar, "$");
                     }
                     break;
 
@@ -430,17 +439,17 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.NotEquals, "!=", this.Position);
+                        token = this.CreateToken(TokenType.NotEquals, "!=");
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Exclamation, "!", this.Position);
+                        token = this.CreateToken(TokenType.Exclamation, "!");
                     }
                     break;
 
                 case '=':
-                    token = new Token(TokenType.Equals, "=", this.Position);
+                    token = this.CreateToken(TokenType.Equals, "=");
                     this.ReadChar();
                     break;
 
@@ -448,12 +457,12 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.GreaterOrEquals, ">=", this.Position);
+                        token = this.CreateToken(TokenType.GreaterOrEquals, ">=");
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Greater, ">", this.Position);
+                        token = this.CreateToken(TokenType.Greater, ">");
                     }
                     break;
 
@@ -461,12 +470,12 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.LessOrEquals, "<=", this.Position);
+                        token = this.CreateToken(TokenType.LessOrEquals, "<=");
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Less, "<", this.Position);
+                        token = this.CreateToken(TokenType.Less, "<");
                     }
                     break;
 
@@ -479,37 +488,37 @@ namespace LiteDB
                     }
                     else
                     {
-                        token = new Token(TokenType.Minus, "-", this.Position);
+                        token = this.CreateToken(TokenType.Minus, "-");
                     }
                     break;
 
                 case '+':
-                    token = new Token(TokenType.Plus, "+", this.Position);
+                    token = this.CreateToken(TokenType.Plus, "+");
                     this.ReadChar();
                     break;
 
                 case '*':
-                    token = new Token(TokenType.Asterisk, "*", this.Position);
+                    token = this.CreateToken(TokenType.Asterisk, "*");
                     this.ReadChar();
                     break;
 
                 case '/':
-                    token = new Token(TokenType.Slash, "/", this.Position);
+                    token = this.CreateToken(TokenType.Slash, "/");
                     this.ReadChar();
                     break;
                 case '\\':
-                    token = new Token(TokenType.Backslash, @"\", this.Position);
+                    token = this.CreateToken(TokenType.Backslash, @"\");
                     this.ReadChar();
                     break;
 
                 case '%':
-                    token = new Token(TokenType.Percent, "%", this.Position);
+                    token = this.CreateToken(TokenType.Percent, "%");
                     this.ReadChar();
                     break;
 
                 case '\"':
                 case '\'':
-                    token = new Token(TokenType.String, this.ReadString(_char), this.Position);
+                    token = this.CreateToken(TokenType.String, this.ReadString(_char));
                     break;
 
                 case '0':
@@ -524,7 +533,7 @@ namespace LiteDB
                 case '9':
                     var dbl = false;
                     var number = this.ReadNumber(ref dbl);
-                    token = new Token(dbl ? TokenType.Double : TokenType.Int, number, this.Position);
+                    token = this.CreateToken(dbl ? TokenType.Double : TokenType.Int, number);
                     break;
 
                 case ' ':
@@ -537,14 +546,14 @@ namespace LiteDB
                         sb.Append(_char);
                         this.ReadChar();
                     }
-                    token = new Token(TokenType.Whitespace, sb.ToString(), this.Position);
+                    token = this.CreateToken(TokenType.Whitespace, sb.ToString());
                     break;
 
                 default:
                     // test if first char is an word 
                     if (IsWordChar(_char, true))
                     {
-                        token = new Token(TokenType.Word, this.ReadWord(), this.Position);
+                        token = this.CreateToken(TokenType.Word, this.ReadWord());
                     }
                     else
                     {
@@ -553,7 +562,7 @@ namespace LiteDB
                     break;
             }
 
-            return token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position);
+            return token ?? this.CreateToken(TokenType.Unknown, _char.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- require an explicit IExpressionRegistry for BsonExpression parsing/compilation and remove the AsyncLocal scope helpers
- flow each LiteDatabase instance's registry through collections, query builders, SQL parser, LINQ, and storage entry points
- expose LiteDatabase.Services.ExpressionRegistry for consumers and adjust tests and default helpers to honor per-database registries

## Testing
- dotnet test LiteDB.Tests -c Release -f net8.0

------
https://chatgpt.com/codex/tasks/task_e_68ec46af1b88832681f70b2cdc986d83