### PR TITLE
Refactor expression registry plumbing

### DIFF
--- a/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
+++ b/LiteDB.Tests/BsonValue/BsonVector_Tests.cs
@@ -124,11 +124,8 @@ public class BsonVector_Tests
         col.EnsureIndex(x => x.Embedding, new VectorIndexOptions(2));
 
         var target = new float[] { 1.0f, 0.0f };
-        BsonExpression fieldExpr;
-        using (db.EnterExpressionScope())
-        {
-            fieldExpr = BsonExpression.Create("$.Embedding");
-        }
+        var registry = db.Services.ExpressionRegistry;
+        var fieldExpr = BsonExpression.Create("$.Embedding", registry);
 
         var results = col.Query()
             .WhereNear(fieldExpr, target, maxDistance: .28)
@@ -159,16 +156,13 @@ public class BsonVector_Tests
             ["Embedding"] = new BsonVector(new float[] { 1.0f, 1.0f })
         });
 
-        using (db.EnterExpressionScope())
-        {
-            col.EnsureIndex(
-                "embedding_idx",
-                BsonExpression.Create("$.Embedding"),
-                new VectorIndexOptions(2));
-        }
+        var registry = db.Services.ExpressionRegistry;
+        col.EnsureIndex(
+            "embedding_idx",
+            BsonExpression.Create("$.Embedding", registry),
+            new VectorIndexOptions(2));
 
         var query = "SELECT * FROM vectors WHERE ($.Embedding VECTOR_SIM [1.0, 0.0]) <= 0.25";
-        using var _ = db.EnterExpressionScope();
         var rawResults = db.Execute(query).ToList();
 
         var docs = rawResults
@@ -196,11 +190,8 @@ public class BsonVector_Tests
     public void VectorSim_InfixExpression_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]");
-        }
+        var registry = db.Services.ExpressionRegistry;
+        var expr = BsonExpression.Create("$.Embedding VECTOR_SIM [1.0, 0.0]", registry);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 
@@ -219,11 +210,8 @@ public class BsonVector_Tests
     public void VectorSim_FunctionCall_ParsesAndEvaluates()
     {
         using var db = new LiteDatabase(":memory:", plugins: new[] { VectorSearchPlugin.Instance });
-        BsonExpression expr;
-        using (db.EnterExpressionScope())
-        {
-            expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])");
-        }
+        var registry = db.Services.ExpressionRegistry;
+        var expr = BsonExpression.Create("VECTOR_SIM($.Embedding, [1.0, 0.0])", registry);
 
         expr.Type.Should().Be(BsonExpressionType.VectorSim);
 

--- a/LiteDB.Tests/Query/VectorIndex_Tests.cs
+++ b/LiteDB.Tests/Query/VectorIndex_Tests.cs
@@ -19,18 +19,12 @@ namespace LiteDB.Tests.QueryTest
     {
         private static BsonExpression CreateExpression(LiteDatabase db, string expression)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression);
-            }
+            return BsonExpression.Create(expression, db.Services.ExpressionRegistry);
         }
 
         private static BsonExpression CreateExpression(LiteDatabase db, string expression, params BsonValue[] args)
         {
-            using (db.EnterExpressionScope())
-            {
-                return BsonExpression.Create(expression, args);
-            }
+            return BsonExpression.Create(expression, db.Services.ExpressionRegistry, args);
         }
 
         private class VectorDocument

--- a/LiteDB/Client/Database/Collections/Aggregate.cs
+++ b/LiteDB/Client/Database/Collections/Aggregate.cs
@@ -33,10 +33,7 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Count(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -44,16 +41,13 @@ namespace LiteDB
         /// </summary>
         public int Count(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Count(BsonExpression.Create(predicate, args));
-            }
+            return this.Count(this.CreateExpression(predicate, args));
         }
 
         /// <summary>
         /// Count documents matching a query. This method does not deserialize any documents. Needs indexes on query expression
         /// </summary>
-        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate));
+        public int Count(Expression<Func<T, bool>> predicate) => this.Count(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -87,10 +81,7 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, parameters));
-            }
+            return this.LongCount(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -98,16 +89,13 @@ namespace LiteDB
         /// </summary>
         public long LongCount(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.LongCount(BsonExpression.Create(predicate, args));
-            }
+            return this.LongCount(this.CreateExpression(predicate, args));
         }
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
         /// </summary>
-        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate));
+        public long LongCount(Expression<Func<T, bool>> predicate) => this.LongCount(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get document count in collection using predicate filter expression
@@ -133,10 +121,7 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, parameters));
-            }
+            return this.Exists(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -144,16 +129,13 @@ namespace LiteDB
         /// </summary>
         public bool Exists(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.Exists(BsonExpression.Create(predicate, args));
-            }
+            return this.Exists(this.CreateExpression(predicate, args));
         }
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
         /// </summary>
-        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate));
+        public bool Exists(Expression<Func<T, bool>> predicate) => this.Exists(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Get true if collection contains at least 1 document that satisfies the predicate expression
@@ -193,7 +175,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Min(expr);
 
@@ -229,7 +211,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var expr = _mapper.GetExpression(keySelector);
+            var expr = _mapper.GetExpression(keySelector, _expressions);
 
             var value = this.Max(expr);
 

--- a/LiteDB/Client/Database/Collections/Delete.cs
+++ b/LiteDB/Client/Database/Collections/Delete.cs
@@ -39,10 +39,7 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, parameters));
-            }
+            return this.DeleteMany(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -50,15 +47,12 @@ namespace LiteDB
         /// </summary>
         public int DeleteMany(string predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.DeleteMany(BsonExpression.Create(predicate, args));
-            }
+            return this.DeleteMany(this.CreateExpression(predicate, args));
         }
 
         /// <summary>
         /// Delete all documents based on predicate expression. Returns how many documents was deleted
         /// </summary>
-        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate));
+        public int DeleteMany(Expression<Func<T, bool>> predicate) => this.DeleteMany(_mapper.GetExpression(predicate, _expressions));
     }
 }

--- a/LiteDB/Client/Database/Collections/Find.cs
+++ b/LiteDB/Client/Database/Collections/Find.cs
@@ -51,7 +51,7 @@ namespace LiteDB
         /// <summary>
         /// Find documents inside a collection using predicate expression.
         /// </summary>
-        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate), skip, limit);
+        public IEnumerable<T> Find(Expression<Func<T, bool>> predicate, int skip = 0, int limit = int.MaxValue) => this.Find(_mapper.GetExpression(predicate, _expressions), skip, limit);
 
         #endregion
 
@@ -63,11 +63,7 @@ namespace LiteDB
         public T FindById(BsonValue id)
         {
             if (id == null || id.IsNull) throw new ArgumentNullException(nameof(id));
-
-            using (this.EnterExpressionScope())
-            {
-                return this.Find(BsonExpression.Create("_id = @0", id)).FirstOrDefault();
-            }
+            return this.Find(this.CreateExpression("_id = @0", id)).FirstOrDefault();
         }
 
         /// <summary>
@@ -80,10 +76,7 @@ namespace LiteDB
         /// </summary>
         public T FindOne(string predicate, BsonDocument parameters)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, parameters));
-            }
+            return this.FindOne(this.CreateExpression(predicate, parameters));
         }
 
         /// <summary>
@@ -91,16 +84,13 @@ namespace LiteDB
         /// </summary>
         public T FindOne(BsonExpression predicate, params BsonValue[] args)
         {
-            using (this.EnterExpressionScope())
-            {
-                return this.FindOne(BsonExpression.Create(predicate, args));
-            }
+            return this.FindOne(this.CreateExpression(predicate, args));
         }
 
         /// <summary>
         /// Find the first document using predicate expression. Returns null if not found
         /// </summary>
-        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate));
+        public T FindOne(Expression<Func<T, bool>> predicate) => this.FindOne(_mapper.GetExpression(predicate, _expressions));
 
         /// <summary>
         /// Find the first document using defined query structure. Returns null if not found

--- a/LiteDB/Client/Database/Collections/Include.cs
+++ b/LiteDB/Client/Database/Collections/Include.cs
@@ -15,7 +15,7 @@ namespace LiteDB
         {
             if (keySelector == null) throw new ArgumentNullException(nameof(keySelector));
 
-            var path = _mapper.GetExpression(keySelector);
+            var path = _mapper.GetExpression(keySelector, _expressions);
 
             return this.Include(path);
         }

--- a/LiteDB/Client/Database/Collections/Update.cs
+++ b/LiteDB/Client/Database/Collections/Update.cs
@@ -74,8 +74,8 @@ namespace LiteDB
             if (extend == null) throw new ArgumentNullException(nameof(extend));
             if (predicate == null) throw new ArgumentNullException(nameof(predicate));
 
-            var ext = _mapper.GetExpression(extend);
-            var pred = _mapper.GetExpression(predicate);
+            var ext = _mapper.GetExpression(extend, _expressions);
+            var pred = _mapper.GetExpression(predicate, _expressions);
 
             if (ext.Type != BsonExpressionType.Document)
             {

--- a/LiteDB/Client/Database/ILiteDatabase.cs
+++ b/LiteDB/Client/Database/ILiteDatabase.cs
@@ -13,6 +13,11 @@ namespace LiteDB
         BsonMapper Mapper { get; }
 
         /// <summary>
+        /// Gets the service registry associated with this database instance.
+        /// </summary>
+        LiteDatabaseServices Services { get; }
+
+        /// <summary>
         /// Returns a special collection for storage files/stream inside datafile. Use _files and _chunks collection names. FileId is implemented as string. Use "GetStorage" for custom options
         /// </summary>
         ILiteStorage<string> FileStorage { get; }

--- a/LiteDB/Client/Database/LiteCollection.cs
+++ b/LiteDB/Client/Database/LiteCollection.cs
@@ -32,11 +32,6 @@ namespace LiteDB
         /// </summary>
         public EntityMapper EntityMapper => _entity;
 
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_expressions);
-        }
-
         internal LiteCollection(string name, BsonAutoId autoId, ILiteEngine engine, BsonMapper mapper, IExpressionRegistry expressions)
         {
             _collection = name ?? mapper.ResolveCollectionName(typeof(T));
@@ -72,6 +67,16 @@ namespace LiteDB
                     _autoId = autoId;
                 }
             }
+        }
+
+        private BsonExpression CreateExpression(string expression, BsonDocument parameters)
+        {
+            return BsonExpression.Create(expression, parameters, _expressions);
+        }
+
+        private BsonExpression CreateExpression(string expression, params BsonValue[] args)
+        {
+            return BsonExpression.Create(expression, _expressions, args ?? Array.Empty<BsonValue>());
         }
     }
 }

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -24,6 +24,11 @@ namespace LiteDB
         private readonly DefaultPluginContext _pluginContext;
 
         /// <summary>
+        /// Provides access to plugin services registered for this database instance.
+        /// </summary>
+        public LiteDatabaseServices Services { get; }
+
+        /// <summary>
         /// Get current instance of BsonMapper used in this database instance (can be BsonMapper.Global)
         /// </summary>
         public BsonMapper Mapper => _mapper;
@@ -52,6 +57,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(connectionString, NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(plugins);
         }
@@ -76,6 +82,7 @@ namespace LiteDB
             _disposeOnClose = true;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(plugins);
 
@@ -115,6 +122,7 @@ namespace LiteDB
             _disposeOnClose = disposeOnClose;
 
             _pluginContext = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(plugins);
         }
@@ -159,11 +167,6 @@ namespace LiteDB
             if (name.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(name));
 
             return new LiteCollection<BsonDocument>(name, autoId, _engine, _mapper, _pluginContext.Expressions);
-        }
-
-        internal IDisposable EnterExpressionScope()
-        {
-            return BsonExpression.UseRegistry(_pluginContext.Expressions);
         }
 
         #endregion
@@ -298,7 +301,7 @@ namespace LiteDB
         {
             if (commandReader == null) throw new ArgumentNullException(nameof(commandReader));
 
-            var tokenizer = new Tokenizer(commandReader);
+            var tokenizer = new Tokenizer(commandReader, _pluginContext.Expressions);
             var sql = new SqlParser(_engine, tokenizer, parameters);
             var reader = sql.Execute();
 
@@ -312,7 +315,7 @@ namespace LiteDB
         {
             if (command == null) throw new ArgumentNullException(nameof(command));
 
-            var tokenizer = new Tokenizer(command);
+            var tokenizer = new Tokenizer(command, _pluginContext.Expressions);
             var sql = new SqlParser(_engine, tokenizer, parameters);
             var reader = sql.Execute();
 

--- a/LiteDB/Client/Database/LiteDatabaseServices.cs
+++ b/LiteDB/Client/Database/LiteDatabaseServices.cs
@@ -1,0 +1,59 @@
+using System;
+using LiteDB.Plugins;
+
+namespace LiteDB
+{
+    /// <summary>
+    /// Provides access to per-database services that plugins can extend.
+    /// </summary>
+    public sealed class LiteDatabaseServices
+    {
+        private readonly ILitePluginContext _context;
+        private static readonly Lazy<LiteDatabaseServices> _default = new Lazy<LiteDatabaseServices>(CreateDefault, true);
+
+        internal LiteDatabaseServices(ILitePluginContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        /// <summary>
+        /// Gets the expression registry associated with the database.
+        /// </summary>
+        public IExpressionRegistry ExpressionRegistry => _context.Expressions;
+
+        /// <summary>
+        /// Gets the index registry associated with the database.
+        /// </summary>
+        public IIndexRegistry IndexRegistry => _context.Indexes;
+
+        /// <summary>
+        /// Gets the query planner registry associated with the database.
+        /// </summary>
+        public IQueryPlannerRegistry QueryPlanner => _context.QueryPlanner;
+
+        /// <summary>
+        /// Gets the service provider exposed to plugins.
+        /// </summary>
+        public IServiceProvider Services => _context.Services;
+
+        /// <summary>
+        /// Gets the logger that plugins can use during initialization.
+        /// </summary>
+        public ILogger Logger => _context.Logger;
+
+        /// <summary>
+        /// Gets the connection string used to configure the database.
+        /// </summary>
+        public ConnectionString ConnectionString => _context.ConnectionString;
+
+        internal ILitePluginContext Context => _context;
+
+        internal static LiteDatabaseServices Default => _default.Value;
+
+        private static LiteDatabaseServices CreateDefault()
+        {
+            var context = new DefaultPluginContext(new ConnectionString(), NullServiceProvider.Instance, NullLogger.Instance);
+            return new LiteDatabaseServices(context);
+        }
+    }
+}

--- a/LiteDB/Client/Database/LiteQueryable.cs
+++ b/LiteDB/Client/Database/LiteQueryable.cs
@@ -40,7 +40,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Include<K>(Expression<Func<T, K>> path)
         {
-            _query.Includes.Add(_mapper.GetExpression(path));
+            _query.Includes.Add(_mapper.GetExpression(path, _expressions));
             return this;
         }
 
@@ -80,10 +80,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, BsonDocument parameters)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, parameters));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, parameters, _expressions));
             return this;
         }
 
@@ -92,10 +89,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(string predicate, params BsonValue[] args)
         {
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                _query.Where.Add(BsonExpression.Create(predicate, args));
-            }
+            _query.Where.Add(BsonExpression.Create(predicate, _expressions, args));
             return this;
         }
 
@@ -104,7 +98,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> Where(Expression<Func<T, bool>> predicate)
         {
-            return this.Where(_mapper.GetExpression(predicate));
+            return this.Where(_mapper.GetExpression(predicate, _expressions));
         }
 
         #endregion
@@ -127,7 +121,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> OrderBy<K>(Expression<Func<T, K>> keySelector, int order = Query.Ascending)
         {
-            return this.OrderBy(_mapper.GetExpression(keySelector), order);
+            return this.OrderBy(_mapper.GetExpression(keySelector, _expressions), order);
         }
 
         /// <summary>
@@ -156,7 +150,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenBy<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenBy(_mapper.GetExpression(keySelector));
+            return this.ThenBy(_mapper.GetExpression(keySelector, _expressions));
         }
 
         /// <summary>
@@ -175,7 +169,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<T> ThenByDescending<K>(Expression<Func<T, K>> keySelector)
         {
-            return this.ThenByDescending(_mapper.GetExpression(keySelector));
+            return this.ThenByDescending(_mapper.GetExpression(keySelector, _expressions));
         }
 
         #endregion
@@ -187,7 +181,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<IGrouping<K, T>> GroupBy<K>(Expression<Func<T, K>> keySelector)
         {
-            var expression = _mapper.GetExpression(keySelector);
+            var expression = _mapper.GetExpression(keySelector, _expressions);
 
             this.GroupBy(expression);
 
@@ -241,7 +235,7 @@ namespace LiteDB
         /// </summary>
         public ILiteQueryable<K> Select<K>(Expression<Func<T, K>> selector)
         {
-            _query.Select = _mapper.GetExpression(selector);
+            _query.Select = _mapper.GetExpression(selector, _expressions);
 
             return new LiteQueryable<K>(_engine, _mapper, _collection, _query, _expressions);
         }
@@ -260,18 +254,14 @@ namespace LiteDB
             ValidateVectorArguments(target, maxDistance);
 
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", targetArray, new BsonValue(maxDistance));
-            }
+            return BsonExpression.Create($"({fieldExpr.Source} VECTOR_SIM @0) <= @1", _expressions, targetArray, new BsonValue(maxDistance));
         }
 
         internal ILiteQueryable<T> VectorWhereNear(string vectorField, float[] target, double maxDistance)
         {
             if (string.IsNullOrWhiteSpace(vectorField)) throw new ArgumentNullException(nameof(vectorField));
 
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{vectorField}");
+            var fieldExpr = BsonExpression.Create($"$.{vectorField}", _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
@@ -292,20 +282,19 @@ namespace LiteDB
         {
             if (field == null) throw new ArgumentNullException(nameof(field));
 
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorWhereNear(fieldExpr, target, maxDistance);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear<K>(Expression<Func<T, K>> field, float[] target, int k)
         {
-            var fieldExpr = _mapper.GetExpression(field);
+            var fieldExpr = _mapper.GetExpression(field, _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
         internal ILiteQueryableResult<T> VectorTopKNear(string field, float[] target, int k)
         {
-            using var _ = BsonExpression.UseRegistry(_expressions);
-            var fieldExpr = BsonExpression.Create($"$.{field}");
+            var fieldExpr = BsonExpression.Create($"$.{field}", _expressions);
             return this.VectorTopKNear(fieldExpr, target, k);
         }
 
@@ -318,18 +307,15 @@ namespace LiteDB
             var targetArray = new BsonArray(target.Select(v => new BsonValue(v)));
 
             // Build VECTOR_SIM as order clause
-            using (BsonExpression.UseRegistry(_expressions))
-            {
-                var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", targetArray);
+            var simExpr = BsonExpression.Create($"VECTOR_SIM({fieldExpr.Source}, @0)", _expressions, targetArray);
 
-                _query.VectorField = fieldExpr.Source;
-                _query.VectorTarget = target?.ToArray();
-                _query.VectorMaxDistance = double.MaxValue;
+            _query.VectorField = fieldExpr.Source;
+            _query.VectorTarget = target?.ToArray();
+            _query.VectorMaxDistance = double.MaxValue;
 
-                return this
-                    .OrderBy(simExpr, Query.Ascending)
-                    .Limit(k);
-            }
+            return this
+                .OrderBy(simExpr, Query.Ascending)
+                .Limit(k);
         }
 
         [Obsolete("Add `using LiteDB.Vector;` and call the LiteQueryableVectorExtensions.WhereNear extension instead.")]

--- a/LiteDB/Client/Mapper/BsonMapper.cs
+++ b/LiteDB/Client/Mapper/BsonMapper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -169,7 +170,12 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            return this.GetExpression(predicate, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        internal BsonExpression GetExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry registry)
+        {
+            var visitor = new LinqExpressionVisitor(this, predicate, registry);
 
             var expr = visitor.Resolve(typeof(K) == typeof(bool));
 
@@ -183,7 +189,12 @@ namespace LiteDB
         /// </summary>
         public BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate)
         {
-            var visitor = new LinqExpressionVisitor(this, predicate);
+            return this.GetIndexExpression(predicate, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        internal BsonExpression GetIndexExpression<T, K>(Expression<Func<T, K>> predicate, IExpressionRegistry registry)
+        {
+            var visitor = new LinqExpressionVisitor(this, predicate, registry);
 
             var expr = visitor.Resolve(false);
 

--- a/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
+++ b/LiteDB/Client/Mapper/Linq/LinqExpressionVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -45,11 +46,13 @@ namespace LiteDB
 
         private readonly StringBuilder _builder = new StringBuilder();
         private readonly Stack<Expression> _nodes = new Stack<Expression>();
+        private readonly IExpressionRegistry _registry;
 
-        public LinqExpressionVisitor(BsonMapper mapper, Expression expr)
+        public LinqExpressionVisitor(BsonMapper mapper, Expression expr, IExpressionRegistry registry = null)
         {
             _mapper = mapper;
             _expr = expr;
+            _registry = registry ?? LiteDatabaseServices.Default.ExpressionRegistry;
 
             if (expr is LambdaExpression lambda)
             {
@@ -71,14 +74,14 @@ namespace LiteDB
 
             try
             {
-                var e = BsonExpression.Create(expression, _parameters);
+                var e = BsonExpression.Create(expression, _parameters, _registry);
 
                 // if expression must return an predicate but expression result is Path/Parameter/Call add `= true`
                 if (predicate && (e.Type == BsonExpressionType.Path || e.Type == BsonExpressionType.Call || e.Type == BsonExpressionType.Parameter))
                 {
                     expression = "(" + expression + " = true)";
 
-                    e = BsonExpression.Create(expression, _parameters);
+                    e = BsonExpression.Create(expression, _parameters, _registry);
                 }
 
                 return e;
@@ -528,7 +531,7 @@ namespace LiteDB
         /// </summary>
         private void ResolvePattern(string pattern, Expression obj, IList<Expression> args)
         {
-            var tokenizer = new Tokenizer(pattern);
+            var tokenizer = new Tokenizer(pattern, _registry);
 
             // lets use tokenizer to parse this method pattern
             while (!tokenizer.EOF)

--- a/LiteDB/Client/SqlParser/Commands/Create.cs
+++ b/LiteDB/Client/SqlParser/Commands/Create.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             _tokenizer.ReadToken().Expect(TokenType.OpenParenthesis);
 
             // read index expression
-            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument());
+            var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, new BsonDocument(), _tokenizer.Registry);
 
             // read )
             _tokenizer.ReadToken().Expect(TokenType.CloseParenthesis);

--- a/LiteDB/Client/SqlParser/Commands/Delete.cs
+++ b/LiteDB/Client/SqlParser/Commands/Delete.cs
@@ -24,7 +24,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.Registry);
             }
 
             _tokenizer.ReadToken().Expect(TokenType.EOF, TokenType.SemiColon);

--- a/LiteDB/Client/SqlParser/Commands/ParseLists.cs
+++ b/LiteDB/Client/SqlParser/Commands/ParseLists.cs
@@ -16,7 +16,7 @@ namespace LiteDB
         {
             while(true)
             {
-                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var expr = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.Registry);
 
                 yield return expr;
 

--- a/LiteDB/Client/SqlParser/Commands/Select.cs
+++ b/LiteDB/Client/SqlParser/Commands/Select.cs
@@ -37,7 +37,7 @@ namespace LiteDB
             token.Expect("SELECT");
 
             // read required SELECT <expr> and convert into single expression
-            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters);
+            query.Select = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.SelectDocument, _parameters, _tokenizer.Registry);
 
             // read FROM|INTO
             var from = _tokenizer.ReadToken();
@@ -88,7 +88,7 @@ namespace LiteDB
                 // read WHERE keyword
                 _tokenizer.ReadToken();
 
-                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.Registry);
 
                 query.Where.Add(where);
             }
@@ -101,7 +101,7 @@ namespace LiteDB
                 _tokenizer.ReadToken();
                 _tokenizer.ReadToken().Expect("BY");
 
-                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                var groupBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.Registry);
 
                 query.GroupBy = groupBy;
 
@@ -112,7 +112,7 @@ namespace LiteDB
                     // read HAVING keyword
                     _tokenizer.ReadToken();
 
-                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var having = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.Registry);
 
                     query.Having = having;
                 }
@@ -128,7 +128,7 @@ namespace LiteDB
 
                 while (true)
                 {
-                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                    var orderBy = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.Registry);
 
                     var orderByOrder = Query.Ascending;
                     var orderByToken = _tokenizer.LookAhead();

--- a/LiteDB/Client/SqlParser/Commands/Update.cs
+++ b/LiteDB/Client/SqlParser/Commands/Update.cs
@@ -22,7 +22,7 @@ namespace LiteDB
             var collection = _tokenizer.ReadToken().Expect(TokenType.Word).Value;
             _tokenizer.ReadToken().Expect("SET");
 
-            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters);
+            var transform = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.UpdateDocument, _parameters, _tokenizer.Registry);
 
             // optional where
             BsonExpression where = null;
@@ -33,7 +33,7 @@ namespace LiteDB
                 // read WHERE
                 _tokenizer.ReadToken();
 
-                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters);
+                where = BsonExpression.Create(_tokenizer, BsonExpressionParserMode.Full, _parameters, _tokenizer.Registry);
             }
 
             // read eof

--- a/LiteDB/Client/Storage/LiteStorage.cs
+++ b/LiteDB/Client/Storage/LiteStorage.cs
@@ -68,12 +68,12 @@ namespace LiteDB
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, BsonDocument parameters) => this.Find(BsonExpression.Create(predicate, parameters, _db.Services.ExpressionRegistry));
 
         /// <summary>
         /// Find all files that match with predicate expression.
         /// </summary>
-        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, args));
+        public IEnumerable<LiteFileInfo<TFileId>> Find(string predicate, params BsonValue[] args) => this.Find(BsonExpression.Create(predicate, _db.Services.ExpressionRegistry, args));
 
         /// <summary>
         /// Find all files that match with predicate expression.

--- a/LiteDB/Client/Structures/Query.cs
+++ b/LiteDB/Client/Structures/Query.cs
@@ -1,11 +1,8 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-
-using static LiteDB.Constants;
-
 namespace LiteDB
 {
     /// <summary>
@@ -32,158 +29,305 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Returns all documents
+        /// Returns all documents ordered by the primary key using the provided registry.
         /// </summary>
-        public static Query All(int order = Ascending)
+        public static Query All(int order, IExpressionRegistry registry)
         {
+            var effectiveRegistry = RequireRegistry(registry);
+
             var query = new Query();
-            query.OrderBy.Add(new QueryOrder(BsonExpression.Create("_id"), order));
+            query.OrderBy.Add(new QueryOrder(BsonExpression.Create("_id", effectiveRegistry), order));
             return query;
         }
 
         /// <summary>
         /// Returns all documents
         /// </summary>
-        public static Query All(string field, int order = Ascending)
+        public static Query All(IExpressionRegistry registry)
         {
+            RequireRegistry(registry);
+            return new Query();
+        }
+
+        /// <summary>
+        /// Returns all documents ordered by the specified field using the provided registry.
+        /// </summary>
+        public static Query All(string field, int order, IExpressionRegistry registry)
+        {
+            if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
+
+            var effectiveRegistry = RequireRegistry(registry);
+
             var query = new Query();
-            query.OrderBy.Add(new QueryOrder(BsonExpression.Create(field), order));
+            query.OrderBy.Add(new QueryOrder(BsonExpression.Create(field, effectiveRegistry), order));
             return query;
+        }
+
+        /// <summary>
+        /// Returns all documents ordered by the specified field using the provided registry.
+        /// </summary>
+        public static Query All(string field, IExpressionRegistry registry)
+        {
+            return All(field, Ascending, registry);
         }
 
         /// <summary>
         /// Returns all documents that value are equals to value (=)
         /// </summary>
-        public static BsonExpression EQ(string field, BsonValue value)
+        public static BsonExpression EQ(string field, BsonValue value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} = {value ?? BsonValue.Null}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} = {value ?? BsonValue.Null}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that value are less than value (&lt;)
         /// </summary>
-        public static BsonExpression LT(string field, BsonValue value)
+        public static BsonExpression LT(string field, BsonValue value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} < {value ?? BsonValue.Null}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} < {value ?? BsonValue.Null}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that value are less than or equals value (&lt;=)
         /// </summary>
-        public static BsonExpression LTE(string field, BsonValue value)
+        public static BsonExpression LTE(string field, BsonValue value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} <= {value ?? BsonValue.Null}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} <= {value ?? BsonValue.Null}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all document that value are greater than value (&gt;)
         /// </summary>
-        public static BsonExpression GT(string field, BsonValue value)
+        public static BsonExpression GT(string field, BsonValue value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} > {value ?? BsonValue.Null}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} > {value ?? BsonValue.Null}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that value are greater than or equals value (&gt;=)
         /// </summary>
-        public static BsonExpression GTE(string field, BsonValue value)
+        public static BsonExpression GTE(string field, BsonValue value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} >= {value ?? BsonValue.Null}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} >= {value ?? BsonValue.Null}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all document that values are between "start" and "end" values (BETWEEN)
         /// </summary>
-        public static BsonExpression Between(string field, BsonValue start, BsonValue end)
+        public static BsonExpression Between(string field, BsonValue start, BsonValue end, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that starts with value (LIKE)
         /// </summary>
-        public static BsonExpression StartsWith(string field, string value)
+        public static BsonExpression StartsWith(string field, string value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} LIKE {(new BsonValue(value + "%"))}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} LIKE {(new BsonValue(value + "%"))}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that contains value (CONTAINS) - string Contains
         /// </summary>
-        public static BsonExpression Contains(string field, string value)
+        public static BsonExpression Contains(string field, string value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value.IsNullOrEmpty()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} LIKE {(new BsonValue("%" + value + "%"))}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} LIKE {(new BsonValue("%" + value + "%"))}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that are not equals to value (not equals)
         /// </summary>
-        public static BsonExpression Not(string field, BsonValue value)
+        public static BsonExpression Not(string field, BsonValue value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
 
-            return BsonExpression.Create($"{field} != {value ?? BsonValue.Null}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} != {value ?? BsonValue.Null}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that has value in values list (IN)
         /// </summary>
-        public static BsonExpression In(string field, BsonArray value)
+        public static BsonExpression In(string field, BsonArray value, IExpressionRegistry registry)
         {
             if (field.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(field));
             if (value == null) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{field} IN {value}");
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"{field} IN {value}", effectiveRegistry);
         }
 
         /// <summary>
         /// Returns all documents that has value in values list (IN)
         /// </summary>
-        public static BsonExpression In(string field, params BsonValue[] values)
+        public static BsonExpression In(string field, IExpressionRegistry registry, params BsonValue[] values)
         {
-            return In(field, new BsonArray(values));
+            return In(field, new BsonArray(values ?? Array.Empty<BsonValue>()), registry);
         }
 
         /// <summary>
         /// Returns all documents that has value in values list (IN)
         /// </summary>
-        public static BsonExpression In(string field, IEnumerable<BsonValue> values)
+        public static BsonExpression In(string field, IEnumerable<BsonValue> values, IExpressionRegistry registry)
         {
-            return In(field, new BsonArray(values));
+            if (values == null) throw new ArgumentNullException(nameof(values));
+
+            return In(field, new BsonArray(values), registry);
         }
 
         /// <summary>
         /// Get all operands to works with array or enumerable values
         /// </summary>
+        public static QueryAny Any(IExpressionRegistry registry) => new QueryAny(RequireRegistry(registry));
+
+        /// <summary>
+        /// Get all operands to works with array or enumerable values
+        /// </summary>
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
         public static QueryAny Any() => new QueryAny();
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static Query All(int order = Ascending)
+        {
+            return All(order, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static Query All(string field, int order = Ascending)
+        {
+            return All(field, order, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression EQ(string field, BsonValue value)
+        {
+            return EQ(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression LT(string field, BsonValue value)
+        {
+            return LT(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression LTE(string field, BsonValue value)
+        {
+            return LTE(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression GT(string field, BsonValue value)
+        {
+            return GT(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression GTE(string field, BsonValue value)
+        {
+            return GTE(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Between(string field, BsonValue start, BsonValue end)
+        {
+            return Between(field, start, end, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression StartsWith(string field, string value)
+        {
+            return StartsWith(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Contains(string field, string value)
+        {
+            return Contains(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Not(string field, BsonValue value)
+        {
+            return Not(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression In(string field, BsonArray value)
+        {
+            return In(field, value, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression In(string field, params BsonValue[] values)
+        {
+            return In(field, LiteDatabaseServices.Default.ExpressionRegistry, values ?? Array.Empty<BsonValue>());
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression In(string field, IEnumerable<BsonValue> values)
+        {
+            return In(field, values, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        /// <summary>
+        /// Returns document that exists in BOTH queries results. If both queries has indexes, left query has index preference (other side will be run in full scan)
+        /// </summary>
+        public static BsonExpression And(BsonExpression left, BsonExpression right, IExpressionRegistry registry)
+        {
+            if (left == null) throw new ArgumentNullException(nameof(left));
+            if (right == null) throw new ArgumentNullException(nameof(right));
+
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"({left.Source} AND {right.Source})", effectiveRegistry);
+        }
 
         /// <summary>
         /// Returns document that exists in BOTH queries results. If both queries has indexes, left query has index preference (other side will be run in full scan)
         /// </summary>
         public static BsonExpression And(BsonExpression left, BsonExpression right)
         {
-            if (left == null) throw new ArgumentNullException(nameof(left));
-            if (right == null) throw new ArgumentNullException(nameof(right));
+            var registry = ResolveRegistry(left, right);
 
-            return $"({left.Source} AND {right.Source})";
+            return And(left, right, registry);
         }
 
         /// <summary>
@@ -193,11 +337,25 @@ namespace LiteDB
         {
             if (queries == null || queries.Length < 2) throw new ArgumentException("At least two Query should be passed");
 
+            var registry = ResolveRegistry(queries);
+
+            return And(registry, queries);
+        }
+
+        /// <summary>
+        /// Returns document that exists in ALL queries results using an explicit registry.
+        /// </summary>
+        public static BsonExpression And(IExpressionRegistry registry, params BsonExpression[] queries)
+        {
+            if (queries == null || queries.Length < 2) throw new ArgumentException("At least two Query should be passed");
+
+            var effectiveRegistry = RequireRegistry(registry);
+
             var left = queries[0];
 
             for (int i = 1; i < queries.Length; i++)
             {
-                left = And(left, queries[i]);
+                left = And(left, queries[i], effectiveRegistry);
             }
 
             return left;
@@ -206,12 +364,24 @@ namespace LiteDB
         /// <summary>
         /// Returns documents that exists in ANY queries results (Union).
         /// </summary>
-        public static BsonExpression Or(BsonExpression left, BsonExpression right)
+        public static BsonExpression Or(BsonExpression left, BsonExpression right, IExpressionRegistry registry)
         {
             if (left == null) throw new ArgumentNullException(nameof(left));
             if (right == null) throw new ArgumentNullException(nameof(right));
 
-            return $"({left.Source} OR {right.Source})";
+            var effectiveRegistry = RequireRegistry(registry);
+
+            return BsonExpression.Create($"({left.Source} OR {right.Source})", effectiveRegistry);
+        }
+
+        /// <summary>
+        /// Returns documents that exists in ANY queries results (Union).
+        /// </summary>
+        public static BsonExpression Or(BsonExpression left, BsonExpression right)
+        {
+            var registry = ResolveRegistry(left, right);
+
+            return Or(left, right, registry);
         }
 
         /// <summary>
@@ -221,14 +391,51 @@ namespace LiteDB
         {
             if (queries == null || queries.Length < 2) throw new ArgumentException("At least two Query should be passed");
 
+            var registry = ResolveRegistry(queries);
+
+            return Or(registry, queries);
+        }
+
+        /// <summary>
+        /// Returns document that exists in ANY queries results (Union) using an explicit registry.
+        /// </summary>
+        public static BsonExpression Or(IExpressionRegistry registry, params BsonExpression[] queries)
+        {
+            if (queries == null || queries.Length < 2) throw new ArgumentException("At least two Query should be passed");
+
+            var effectiveRegistry = RequireRegistry(registry);
+
             var left = queries[0];
 
             for (int i = 1; i < queries.Length; i++)
             {
-                left = Or(left, queries[i]);
+                left = Or(left, queries[i], effectiveRegistry);
             }
 
             return left;
+        }
+
+        private static IExpressionRegistry ResolveRegistry(params BsonExpression[] expressions)
+        {
+            if (expressions == null)
+            {
+                return LiteDatabaseServices.Default.ExpressionRegistry;
+            }
+
+            foreach (var expression in expressions)
+            {
+                if (expression?.Registry != null)
+                {
+                    return expression.Registry;
+                }
+            }
+
+            return LiteDatabaseServices.Default.ExpressionRegistry;
+        }
+
+        private static IExpressionRegistry RequireRegistry(IExpressionRegistry registry)
+        {
+            return registry ?? throw new ArgumentNullException(nameof(registry));
         }
     }
 }

--- a/LiteDB/Client/Structures/QueryAny.cs
+++ b/LiteDB/Client/Structures/QueryAny.cs
@@ -1,4 +1,5 @@
 ﻿using LiteDB.Engine;
+using LiteDB.Plugins;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,31 @@ namespace LiteDB
 {
     public class QueryAny
     {
+        private readonly IExpressionRegistry _registry;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryAny"/> class using the provided expression registry.
+        /// </summary>
+        /// <param name="registry">The registry used to build the generated expressions.</param>
+        public QueryAny(IExpressionRegistry registry)
+        {
+            _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryAny"/> class using the default expression registry.
+        /// </summary>
+        [Obsolete("Use the constructor that accepts IExpressionRegistry explicitly.")]
+        public QueryAny()
+            : this(LiteDatabaseServices.Default.ExpressionRegistry)
+        {
+        }
+
+        private BsonExpression CreateExpression(string expression)
+        {
+            return BsonExpression.Create(expression, _registry);
+        }
+
         /// <summary>
         /// Returns all documents for which at least one value in arrayFields is equal to value
         /// </summary>
@@ -15,7 +41,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY = {value ?? BsonValue.Null}");
+            return this.CreateExpression($"{arrayField} ANY = {value ?? BsonValue.Null}");
         }
 
         /// <summary>
@@ -25,7 +51,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY < {value ?? BsonValue.Null}");
+            return this.CreateExpression($"{arrayField} ANY < {value ?? BsonValue.Null}");
         }
 
         /// <summary>
@@ -35,7 +61,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY <= {value ?? BsonValue.Null}");
+            return this.CreateExpression($"{arrayField} ANY <= {value ?? BsonValue.Null}");
         }
 
         /// <summary>
@@ -45,7 +71,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY > {value ?? BsonValue.Null}");
+            return this.CreateExpression($"{arrayField} ANY > {value ?? BsonValue.Null}");
 
         }
 
@@ -56,7 +82,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY >= {value ?? BsonValue.Null}");
+            return this.CreateExpression($"{arrayField} ANY >= {value ?? BsonValue.Null}");
         }
 
         /// <summary>
@@ -66,7 +92,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}");
+            return this.CreateExpression($"{arrayField} ANY BETWEEN {start ?? BsonValue.Null} AND {end ?? BsonValue.Null}");
         }
 
         /// <summary>
@@ -77,7 +103,7 @@ namespace LiteDB
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
             if (value.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(value));
 
-            return BsonExpression.Create($"{arrayField} ANY LIKE {(new BsonValue(value + "%"))}");
+            return this.CreateExpression($"{arrayField} ANY LIKE {(new BsonValue(value + "%"))}");
         }
 
         /// <summary>
@@ -87,7 +113,7 @@ namespace LiteDB
         {
             if (arrayField.IsNullOrWhiteSpace()) throw new ArgumentNullException(nameof(arrayField));
 
-            return BsonExpression.Create($"{arrayField} ANY != {value ?? BsonValue.Null}");
+            return this.CreateExpression($"{arrayField} ANY != {value ?? BsonValue.Null}");
         }
     }
 }

--- a/LiteDB/Document/Expression/BsonExpression.cs
+++ b/LiteDB/Document/Expression/BsonExpression.cs
@@ -6,9 +6,9 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading;
 using LiteDB.Plugins;
 using static LiteDB.Constants;
 
@@ -48,6 +48,8 @@ namespace LiteDB
         /// Get/Set parameter values that will be used on expression execution
         /// </summary>
         public BsonDocument Parameters { get; internal set; }
+
+        internal IExpressionRegistry Registry { get; private set; }
 
         /// <summary>
         /// In predicate expressions, indicate Left side
@@ -126,17 +128,6 @@ namespace LiteDB
         /// </summary>
         private BsonExpressionScalarDelegate _funcScalar;
 
-        private static readonly AsyncLocal<IExpressionRegistry> _currentRegistry = new AsyncLocal<IExpressionRegistry>();
-
-        internal static IDisposable UseRegistry(IExpressionRegistry registry)
-        {
-            var previous = _currentRegistry.Value;
-            _currentRegistry.Value = registry;
-            return new RegistryScope(previous);
-        }
-
-        internal static IExpressionRegistry CurrentRegistry => _currentRegistry.Value;
-
         /// <summary>
         /// Get default field name when need convert simple BsonValue into BsonDocument
         /// </summary>
@@ -167,7 +158,7 @@ namespace LiteDB
         /// </summary>
         public static implicit operator BsonExpression(String expr)
         {
-            return BsonExpression.Create(expr);
+            return BsonExpression.Create(expr, LiteDatabaseServices.Default.ExpressionRegistry);
         }
 
         #region Execute Enumerable
@@ -292,42 +283,81 @@ namespace LiteDB
 
         #region Static method
 
-        private static readonly ConcurrentDictionary<string, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<string, BsonExpressionEnumerableDelegate>();
-        private static readonly ConcurrentDictionary<string, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<string, BsonExpressionScalarDelegate>();
+        private static IExpressionRegistry EnsureRegistry(IExpressionRegistry registry)
+        {
+            return registry ?? LiteDatabaseServices.Default.ExpressionRegistry;
+        }
+
+        private readonly struct ExpressionCacheKey : IEquatable<ExpressionCacheKey>
+        {
+            public ExpressionCacheKey(IExpressionRegistry registry, string source)
+            {
+                this.Registry = registry;
+                this.Source = source;
+            }
+
+            public IExpressionRegistry Registry { get; }
+
+            public string Source { get; }
+
+            public bool Equals(ExpressionCacheKey other)
+            {
+                return ReferenceEquals(this.Registry, other.Registry) && string.Equals(this.Source, other.Source, StringComparison.Ordinal);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is ExpressionCacheKey other && this.Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                var registryHash = this.Registry != null ? RuntimeHelpers.GetHashCode(this.Registry) : 0;
+                var sourceHash = this.Source != null ? StringComparer.Ordinal.GetHashCode(this.Source) : 0;
+                return (registryHash * 397) ^ sourceHash;
+            }
+        }
+
+        private static readonly ConcurrentDictionary<ExpressionCacheKey, BsonExpressionEnumerableDelegate> _cacheEnumerable = new ConcurrentDictionary<ExpressionCacheKey, BsonExpressionEnumerableDelegate>();
+        private static readonly ConcurrentDictionary<ExpressionCacheKey, BsonExpressionScalarDelegate> _cacheScalar = new ConcurrentDictionary<ExpressionCacheKey, BsonExpressionScalarDelegate>();
 
         /// <summary>
-        /// Parse string and create new instance of BsonExpression - can be cached
+        /// Parse string and create new instance of <see cref="BsonExpression"/> using the provided registry.
         /// </summary>
-        public static BsonExpression Create(string expression)
+        public static BsonExpression Create(string expression, IExpressionRegistry registry)
         {
-            return Create(expression, new BsonDocument());
+            return Create(expression, new BsonDocument(), registry);
         }
 
         /// <summary>
-        /// Parse string and create new instance of BsonExpression - can be cached
+        /// Parse string and create new instance of <see cref="BsonExpression"/> - can be cached.
         /// </summary>
-        public static BsonExpression Create(string expression, params BsonValue[] args)
+        public static BsonExpression Create(string expression, IExpressionRegistry registry, params BsonValue[] args)
         {
+            if (args == null) throw new ArgumentNullException(nameof(args));
+
             var parameters = new BsonDocument();
 
-            for(var i = 0; i < args.Length; i++)
+            for (var i = 0; i < args.Length; i++)
             {
                 parameters[i.ToString()] = args[i];
             }
 
-            return Create(expression, parameters);
+            return Create(expression, parameters, registry);
         }
 
         /// <summary>
-        /// Parse string and create new instance of BsonExpression - can be cached
+        /// Parse string and create new instance of <see cref="BsonExpression"/> - can be cached.
         /// </summary>
-        public static BsonExpression Create(string expression, BsonDocument parameters)
+        public static BsonExpression Create(string expression, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (string.IsNullOrWhiteSpace(expression)) throw new ArgumentNullException(nameof(expression));
 
-            var tokenizer = new Tokenizer(expression);
+            parameters ??= new BsonDocument();
 
-            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters);
+            var tokenizer = new Tokenizer(expression, registry);
+
+            var expr = Create(tokenizer, BsonExpressionParserMode.Full, parameters, registry);
 
             tokenizer.LookAhead().Expect(TokenType.EOF);
 
@@ -335,29 +365,66 @@ namespace LiteDB
         }
 
         /// <summary>
-        /// Parse tokenizer and create new instance of BsonExpression - for now, do not use cache
+        /// Compiles a string expression using the provided registry.
         /// </summary>
-        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters)
+        public static BsonExpression Compile(string expression, IExpressionRegistry registry)
+        {
+            return Create(expression, registry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Compile(string expression)
+        {
+            return Compile(expression, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        /// <summary>
+        /// Parse tokenizer and create new instance of <see cref="BsonExpression"/> - for now, do not use cache
+        /// </summary>
+        internal static BsonExpression Create(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, IExpressionRegistry registry)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
 
-            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root);
+            parameters ??= new BsonDocument();
+
+            return ParseAndCompile(tokenizer, mode, parameters, DocumentScope.Root, registry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Create(string expression)
+        {
+            return Create(expression, LiteDatabaseServices.Default.ExpressionRegistry);
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Create(string expression, params BsonValue[] args)
+        {
+            return Create(expression, LiteDatabaseServices.Default.ExpressionRegistry, args ?? Array.Empty<BsonValue>());
+        }
+
+        [Obsolete("Use overloads that accept IExpressionRegistry explicitly.")]
+        public static BsonExpression Create(string expression, BsonDocument parameters)
+        {
+            return Create(expression, parameters, LiteDatabaseServices.Default.ExpressionRegistry);
         }
 
         /// <summary>
         /// Parse and compile string expression and return BsonExpression
         /// </summary>
-        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope)
+        internal static BsonExpression ParseAndCompile(Tokenizer tokenizer, BsonExpressionParserMode mode, BsonDocument parameters, DocumentScope scope, IExpressionRegistry registry, ExpressionContext context = null)
         {
             if (tokenizer == null) throw new ArgumentNullException(nameof(tokenizer));
 
-            var context = new ExpressionContext();
+            var effectiveRegistry = EnsureRegistry(registry);
+            context ??= new ExpressionContext(effectiveRegistry);
 
             var expr =
                 mode == BsonExpressionParserMode.Full ? BsonExpressionParser.ParseFullExpression(tokenizer, context, parameters, scope) :
                 mode == BsonExpressionParserMode.Single ? BsonExpressionParser.ParseSingleExpression(tokenizer, context, parameters, scope) :
                 mode == BsonExpressionParserMode.SelectDocument ? BsonExpressionParser.ParseSelectDocumentBuilder(tokenizer, context, parameters) :
                 BsonExpressionParser.ParseUpdateDocumentBuilder(tokenizer, context, parameters);
+
+            SetRegistry(expr, effectiveRegistry);
 
             // compile linq expression (with left+right expressions)
             Compile(expr, context);
@@ -371,7 +438,8 @@ namespace LiteDB
             // in both case, try use cached compiled version
             if (expr.IsScalar)
             {
-                var cached = _cacheScalar.GetOrAdd(expr.Source, s =>
+                var key = new ExpressionCacheKey(expr.Registry, expr.Source);
+                var cached = _cacheScalar.GetOrAdd(key, s =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionScalarDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -382,7 +450,8 @@ namespace LiteDB
             }
             else
             {
-                var cached = _cacheEnumerable.GetOrAdd(expr.Source, s =>
+                var key = new ExpressionCacheKey(expr.Registry, expr.Source);
+                var cached = _cacheEnumerable.GetOrAdd(key, s =>
                 {
                     var lambda = System.Linq.Expressions.Expression.Lambda<BsonExpressionEnumerableDelegate>(expr.Expression, context.Source, context.Root, context.Current, context.Collation, context.Parameters);
 
@@ -408,10 +477,23 @@ namespace LiteDB
             if (expr.Right != null) SetParameters(expr.Right, parameters);
         }
 
+        private static void SetRegistry(BsonExpression expr, IExpressionRegistry registry)
+        {
+            if (ReferenceEquals(expr, Root))
+            {
+                return;
+            }
+
+            expr.Registry = registry;
+
+            if (expr.Left != null) SetRegistry(expr.Left, registry);
+            if (expr.Right != null) SetRegistry(expr.Right, registry);
+        }
+
         /// <summary>
         /// Get root document $ expression
         /// </summary>
-        public static BsonExpression Root = Create("$");
+        public static BsonExpression Root = Create("$", LiteDatabaseServices.Default.ExpressionRegistry);
 
         #endregion
 
@@ -473,24 +555,5 @@ namespace LiteDB
             return $"`{this.Source}` [{this.Type}]";
         }
 
-        private sealed class RegistryScope : IDisposable
-        {
-            private readonly IExpressionRegistry _previous;
-            private bool _disposed;
-
-            public RegistryScope(IExpressionRegistry previous)
-            {
-                _previous = previous;
-            }
-
-            public void Dispose()
-            {
-                if (!_disposed)
-                {
-                    _currentRegistry.Value = _previous;
-                    _disposed = true;
-                }
-            }
-        }
     }
 }

--- a/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
+++ b/LiteDB/Document/Expression/Parser/BsonExpressionParser.cs
@@ -111,11 +111,9 @@ namespace LiteDB
             new OperatorDefinition("OR", " OR ", null, BsonExpressionType.Or, (int)BinaryOperatorPrecedence.LogicalOr)
         };
 
-        private static List<OperatorDefinition> GetOperatorTable()
+        private static List<OperatorDefinition> GetOperatorTable(IExpressionRegistry registry)
         {
             var table = new List<OperatorDefinition>(_builtInOperators);
-
-            var registry = BsonExpression.CurrentRegistry;
 
             if (registry != null)
             {
@@ -188,7 +186,7 @@ namespace LiteDB
             }
 
             var order = 0;
-            var operatorTable = GetOperatorTable();
+            var operatorTable = GetOperatorTable(context.Registry);
 
             // now, process operator in correct order
             while (values.Count >= 2)
@@ -798,7 +796,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source);
+                var pathExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Source, context.Registry, context);
 
                 if (pathExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1131,7 +1129,7 @@ namespace LiteDB
             {
                 tokenizer.ReadToken(); // consume .
 
-                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current);
+                var mapExpr = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Single, parameters, DocumentScope.Current, context.Registry, context);
 
                 if (mapExpr == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1207,7 +1205,7 @@ namespace LiteDB
                 else
                 {
                     // inner expression
-                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current);
+                    inner = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters, DocumentScope.Current, context.Registry, context);
 
                     if (inner == null) throw LiteException.UnexpectedToken(tokenizer.Current);
 
@@ -1257,9 +1255,11 @@ namespace LiteDB
                 case "SORT": return ParseFunction(token, BsonExpressionType.Sort, tokenizer, context, parameters, scope);
             }
 
-            if (BsonExpression.CurrentRegistry is ExpressionRegistry registry)
+            var registry = context.Registry;
+
+            if (registry != null)
             {
-                var registration = registry.FindByName(token);
+                var registration = registry.Functions.FirstOrDefault(f => f.Name.Equals(token, StringComparison.OrdinalIgnoreCase));
 
                 if (registration != null)
                 {
@@ -1316,7 +1316,7 @@ namespace LiteDB
                 tokenizer.ReadToken().Expect(TokenType.Greater);
 
                 var right = BsonExpression.ParseAndCompile(tokenizer, BsonExpressionParserMode.Full, parameters,
-                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current);
+                    left.Type == BsonExpressionType.Source ? DocumentScope.Source : DocumentScope.Current, context.Registry, context);
 
                 src.Append("=>" + right.Source);
                 args.Add(Expression.Constant(right));

--- a/LiteDB/Document/Expression/Parser/ExpressionContext.cs
+++ b/LiteDB/Document/Expression/Parser/ExpressionContext.cs
@@ -1,4 +1,5 @@
-﻿using LiteDB.Engine;
+using LiteDB.Engine;
+using LiteDB.Plugins;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -11,8 +12,9 @@ namespace LiteDB
 {
     internal class ExpressionContext
     {
-        public ExpressionContext()
+        public ExpressionContext(IExpressionRegistry registry)
         {
+            this.Registry = registry ?? throw new ArgumentNullException(nameof(registry));
             this.Source = Expression.Parameter(typeof(IEnumerable<BsonDocument>), "source");
             this.Root = Expression.Parameter(typeof(BsonDocument), "root");
             this.Current = Expression.Parameter(typeof(BsonValue), "current");
@@ -20,6 +22,7 @@ namespace LiteDB
             this.Parameters = Expression.Parameter(typeof(BsonDocument), "parameters");
         }
 
+        public IExpressionRegistry Registry { get; }
         public ParameterExpression Source { get; }
         public ParameterExpression Root { get; }
         public ParameterExpression Current { get; }

--- a/LiteDB/Engine/Engine/Query.cs
+++ b/LiteDB/Engine/Engine/Query.cs
@@ -22,7 +22,7 @@ namespace LiteDB.Engine
             // test if is an system collection
             if (collection.StartsWith("$"))
             {
-                SqlParser.ParseCollection(new Tokenizer(collection), out var name, out var options);
+                SqlParser.ParseCollection(new Tokenizer(collection, this.PluginContext?.Expressions), out var name, out var options);
 
                 // get registered system collection to get data source
                 var sys = this.GetSystemCollection(name);

--- a/LiteDB/Engine/Engine/Rebuild.cs
+++ b/LiteDB/Engine/Engine/Rebuild.cs
@@ -85,7 +85,7 @@ namespace LiteDB.Engine
                             this.EnsureVectorIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                index.BsonExpr,
                                 new VectorIndexOptions(index.VectorMetadata.Dimensions, index.VectorMetadata.Metric));
                         }
                         else
@@ -93,7 +93,7 @@ namespace LiteDB.Engine
                             this.EnsureIndex(
                                 collection,
                                 index.Name,
-                                BsonExpression.Create(index.Expression),
+                                index.BsonExpr,
                                 index.Unique);
                         }
                     }

--- a/LiteDB/Engine/FileReader/FileReaderV7.cs
+++ b/LiteDB/Engine/FileReader/FileReaderV7.cs
@@ -110,13 +110,17 @@ namespace LiteDB.Engine
                     name = name.Substring(0, INDEX_NAME_MAX_LENGTH);
                 }
 
-                yield return new IndexInfo
+                var info = new IndexInfo
                 {
                     Collection = collection,
                     Name = name,
                     Expression = index["expression"].AsString,
                     Unique = index["unique"].AsBoolean
                 };
+
+                info.BindExpressionRegistry(null);
+
+                yield return info;
             }
         }
 

--- a/LiteDB/Engine/FileReader/FileReaderV8.cs
+++ b/LiteDB/Engine/FileReader/FileReaderV8.cs
@@ -390,6 +390,8 @@ namespace LiteDB.Engine
                             VectorMetadata = index.IndexType == 1 ? collectionPage.GetVectorIndexMetadata(index.Name) : null
                         };
 
+                        info.BindExpressionRegistry(index.Registry);
+
                         if (_indexes.TryGetValue(collection.Key, out var indexInfos))
                         {
                             indexInfos.Add(info);

--- a/LiteDB/Engine/FileReader/IndexInfo.cs
+++ b/LiteDB/Engine/FileReader/IndexInfo.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -15,5 +16,15 @@ namespace LiteDB.Engine
         public bool Unique { get; set; }
         public byte IndexType { get; set; }
         public VectorIndexMetadata VectorMetadata { get; set; }
+        public BsonExpression BsonExpr { get; private set; }
+        public IExpressionRegistry Registry { get; private set; }
+
+        public void BindExpressionRegistry(IExpressionRegistry registry)
+        {
+            var effective = registry ?? LiteDatabaseServices.Default.ExpressionRegistry;
+
+            this.Registry = effective;
+            this.BsonExpr = BsonExpression.Create(this.Expression, effective);
+        }
     }
 }

--- a/LiteDB/Engine/Pages/CollectionPage.cs
+++ b/LiteDB/Engine/Pages/CollectionPage.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using LiteDB.Plugins;
 using LiteDB.Vector;
 using static LiteDB.Constants;
 
@@ -191,7 +192,7 @@ namespace LiteDB.Engine
         /// <summary>
         /// Insert new index inside this collection page
         /// </summary>
-        public CollectionIndex InsertCollectionIndex(string name, string expr, bool unique)
+        public CollectionIndex InsertCollectionIndex(string name, string expr, bool unique, IExpressionRegistry registry = null)
         {
             if (_indexes.ContainsKey(name) || _vectorIndexes.ContainsKey(name))
             {
@@ -205,6 +206,7 @@ namespace LiteDB.Engine
             var slot = (byte)(_indexes.Count == 0 ? 0 : (_indexes.Max(x => x.Value.Slot) + 1));
 
             var index = new CollectionIndex(slot, 0, name, expr, unique);
+            index.BindExpressionRegistry(registry);
 
             _indexes[name] = index;
 
@@ -213,7 +215,7 @@ namespace LiteDB.Engine
             return index;
         }
 
-        public (CollectionIndex Index, VectorIndexMetadata Metadata) InsertVectorIndex(string name, string expr, ushort dimensions, VectorDistanceMetric metric)
+        public (CollectionIndex Index, VectorIndexMetadata Metadata) InsertVectorIndex(string name, string expr, ushort dimensions, VectorDistanceMetric metric, IExpressionRegistry registry = null)
         {
             if (_indexes.ContainsKey(name) || _vectorIndexes.ContainsKey(name))
             {
@@ -227,6 +229,7 @@ namespace LiteDB.Engine
             var slot = (byte)(_indexes.Count == 0 ? 0 : (_indexes.Max(x => x.Value.Slot) + 1));
 
             var index = new CollectionIndex(slot, 1, name, expr, false);
+            index.BindExpressionRegistry(registry);
             var metadata = new VectorIndexMetadata(slot, dimensions, metric);
 
             _indexes[name] = index;
@@ -256,6 +259,14 @@ namespace LiteDB.Engine
             _vectorIndexes.Remove(name);
 
             this.IsDirty = true;
+        }
+
+        public void BindExpressionRegistry(IExpressionRegistry registry)
+        {
+            foreach (var index in _indexes.Values)
+            {
+                index.BindExpressionRegistry(registry);
+            }
         }
 
     }

--- a/LiteDB/Engine/Query/QueryExecutor.cs
+++ b/LiteDB/Engine/Query/QueryExecutor.cs
@@ -185,7 +185,7 @@ namespace LiteDB.Engine
             // if collection starts with $ it's system collection
             if (into.StartsWith("$"))
             {
-                SqlParser.ParseCollection(new Tokenizer(into), out var name, out var options);
+                SqlParser.ParseCollection(new Tokenizer(into, _engine.PluginContext?.Expressions), out var name, out var options);
 
                 var sys = _engine.GetSystemCollection(name);
 

--- a/LiteDB/Engine/Query/QueryOptimization.cs
+++ b/LiteDB/Engine/Query/QueryOptimization.cs
@@ -128,7 +128,7 @@ namespace LiteDB.Engine
                     term.Type == BsonExpressionType.Equal &&
                     term.Right?.Type == BsonExpressionType.Path)
                 {
-                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters);
+                    _terms[i] = BsonExpression.Create(term.Right.Source + " IN ARRAY(" + term.Left.Source + ")", term.Parameters, _snapshot.Plugins?.Expressions);
                 }
             }
         }

--- a/LiteDB/Engine/Query/Structures/IndexCost.cs
+++ b/LiteDB/Engine/Query/Structures/IndexCost.cs
@@ -69,7 +69,7 @@ namespace LiteDB.Engine
         // used when full index search
         public IndexCost(CollectionIndex index)
         {
-            this.Expression = BsonExpression.Create(index.Expression);
+            this.Expression = index.BsonExpr;
             this.Index = new IndexAll(index.Name, Query.Ascending);
             this.Cost = this.Index.GetCost(index);
             this.IndexExpression = index.Expression;

--- a/LiteDB/Engine/Services/CollectionService.cs
+++ b/LiteDB/Engine/Services/CollectionService.cs
@@ -43,6 +43,7 @@ namespace LiteDB.Engine
             if (pageID != uint.MaxValue)
             {
                 collectionPage = _snapshot.GetPage<CollectionPage>(pageID);
+                collectionPage.BindExpressionRegistry(_snapshot.Plugins?.Expressions);
 
                 return false;
             }
@@ -66,6 +67,7 @@ namespace LiteDB.Engine
 
             // create new collection page
             collectionPage = _snapshot.NewPage<CollectionPage>();
+            collectionPage.BindExpressionRegistry(_snapshot.Plugins?.Expressions);
             var pageID = collectionPage.PageID;
 
             // insert collection name/pageID in header only in commit operation

--- a/LiteDB/Engine/Services/IndexService.cs
+++ b/LiteDB/Engine/Services/IndexService.cs
@@ -37,7 +37,7 @@ namespace LiteDB.Engine
             var indexPage = _snapshot.NewPage<IndexPage>();
 
             // create index ref
-            var index = _snapshot.CollectionPage.InsertCollectionIndex(name, expr, unique);
+            var index = _snapshot.CollectionPage.InsertCollectionIndex(name, expr, unique, _snapshot.Plugins?.Expressions);
 
             // insert head/tail nodes
             var head = indexPage.InsertIndexNode(index.Slot, MAX_LEVEL_LENGTH, BsonValue.MinValue, PageAddress.Empty, bytesLength);

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using LiteDB.Utils.Extensions;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -684,7 +685,7 @@ namespace LiteDB.Engine
             var indexPages = new HashSet<uint>();
 
             // getting all indexes pages from all indexes
-            foreach(var index in _collectionPage.GetCollectionIndexes())
+            foreach(var index in _collectionPage.GetCollectionIndexes().PreventChangeFullFX())
             {
                 if (index.IndexType != 0)
                 {

--- a/LiteDB/Engine/Structures/CollectionIndex.cs
+++ b/LiteDB/Engine/Structures/CollectionIndex.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text;
 using System.Text.RegularExpressions;
+using LiteDB;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB.Engine
@@ -30,7 +32,9 @@ namespace LiteDB.Engine
         /// <summary>
         /// Get BsonExpression from Expression
         /// </summary>
-        public BsonExpression BsonExpr { get; }
+        public BsonExpression BsonExpr { get; private set; }
+
+        internal IExpressionRegistry Registry { get; private set; }
 
         /// <summary>
         /// Indicate if this index has distinct values only
@@ -74,7 +78,7 @@ namespace LiteDB.Engine
             this.Unique = unique;
             this.FreeIndexPageList = uint.MaxValue;
 
-            this.BsonExpr = BsonExpression.Create(expr);
+            this.BindExpressionRegistry(null);
         }
 
         public CollectionIndex(BufferReader reader)
@@ -89,7 +93,7 @@ namespace LiteDB.Engine
             this.Reserved = reader.ReadByte(); // 1
             this.FreeIndexPageList = reader.ReadUInt32(); // 4
 
-            this.BsonExpr = BsonExpression.Create(this.Expression);
+            this.BindExpressionRegistry(null);
         }
 
         public void UpdateBuffer(BufferWriter writer)
@@ -116,6 +120,13 @@ namespace LiteDB.Engine
         /// <summary>
         /// Get index collection size used in CollectionPage
         /// </summary>
+
+        internal void BindExpressionRegistry(IExpressionRegistry registry)
+        {
+            var effective = registry ?? LiteDatabaseServices.Default.ExpressionRegistry;
+            this.Registry = effective;
+            this.BsonExpr = BsonExpression.Create(this.Expression, effective);
+        }
         public static int GetLength(string name, string expr)
         {
             return

--- a/LiteDB/Engine/SystemCollections/SysQuery.cs
+++ b/LiteDB/Engine/SystemCollections/SysQuery.cs
@@ -23,7 +23,8 @@ namespace LiteDB.Engine
         {
             var query = options?.AsString ?? throw new LiteException(0, $"Collection $query(sql) requires `sql` string parameter");
 
-            var sql = new SqlParser(_engine, new Tokenizer(query), null);
+            var registry = (_engine as LiteEngine)?.PluginContext?.Expressions;
+            var sql = new SqlParser(_engine, new Tokenizer(query, registry), null);
 
             using (var reader = sql.Execute())
             {

--- a/LiteDB/Utils/Extensions/CollectionExtensions.cs
+++ b/LiteDB/Utils/Extensions/CollectionExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace LiteDB.Utils.Extensions;
+
+public static class CollectionExtensions
+{
+#if NETSTANDARD
+    // ReSharper disable once InconsistentNaming
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ICollection<T> PreventChangeFullFX<T>(this ICollection<T> collection)
+    {
+        return collection.ToList();
+    }
+#else
+    // ReSharper disable once InconsistentNaming
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static ICollection<T> PreventChangeFullFX<T>(this ICollection<T> collection)
+    {
+        return collection;
+    }
+#endif
+}

--- a/LiteDB/Utils/Tokenizer.cs
+++ b/LiteDB/Utils/Tokenizer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using LiteDB.Plugins;
 using static LiteDB.Constants;
 
 namespace LiteDB
@@ -101,11 +102,14 @@ namespace LiteDB
             "OR"
         };
 
-        public Token(TokenType tokenType, string value, long position)
+        private readonly IExpressionRegistry _registry;
+
+        public Token(TokenType tokenType, string value, long position, IExpressionRegistry registry)
         {
             this.Position = position;
             this.Value = value;
             this.Type = tokenType;
+            _registry = registry;
         }
 
         public TokenType Type { get; private set; }
@@ -192,9 +196,7 @@ namespace LiteDB
                             return true;
                         }
 
-                        var registry = BsonExpression.CurrentRegistry;
-
-                        if (registry != null && (registry.ContainsKeyword(Value) || registry.ContainsOperator(Value)))
+                        if (_registry != null && (_registry.ContainsKeyword(Value) || _registry.ContainsOperator(Value)))
                         {
                             return true;
                         }
@@ -221,6 +223,7 @@ namespace LiteDB
     internal class Tokenizer
     {
         private readonly TextReader _reader;
+        private readonly IExpressionRegistry _registry;
         private char _char = '\0';
         private Token _ahead = null;
         private bool _eof = false;
@@ -228,6 +231,7 @@ namespace LiteDB
         public bool EOF => _eof && _ahead == null;
         public long Position { get; private set; }
         public Token Current { get; private set; }
+        internal IExpressionRegistry Registry => _registry;
 
         /// <summary>
         /// If EOF throw an invalid token exception (used in while()) otherwise return "false" (not EOF)
@@ -239,14 +243,15 @@ namespace LiteDB
             return false;
         }
 
-        public Tokenizer(string source)
-            : this(new StringReader(source))
+        public Tokenizer(string source, IExpressionRegistry registry = null)
+            : this(new StringReader(source), registry)
         {
         }
 
-        public Tokenizer(TextReader reader)
+        public Tokenizer(TextReader reader, IExpressionRegistry registry = null)
         {
             _reader = reader;
+            _registry = registry;
 
             this.Position = 0;
             this.ReadChar();
@@ -337,7 +342,7 @@ namespace LiteDB
 
             if (_eof)
             {
-                return new Token(TokenType.EOF, null, this.Position);
+                return new Token(TokenType.EOF, null, this.Position, _registry);
             }
 
             Token token = null;
@@ -345,72 +350,72 @@ namespace LiteDB
             switch (_char)
             {
                 case '{':
-                    token = new Token(TokenType.OpenBrace, "{", this.Position);
+                    token = new Token(TokenType.OpenBrace, "{", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '}':
-                    token = new Token(TokenType.CloseBrace, "}", this.Position);
+                    token = new Token(TokenType.CloseBrace, "}", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '[':
-                    token = new Token(TokenType.OpenBracket, "[", this.Position);
+                    token = new Token(TokenType.OpenBracket, "[", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ']':
-                    token = new Token(TokenType.CloseBracket, "]", this.Position);
+                    token = new Token(TokenType.CloseBracket, "]", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '(':
-                    token = new Token(TokenType.OpenParenthesis, "(", this.Position);
+                    token = new Token(TokenType.OpenParenthesis, "(", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ')':
-                    token = new Token(TokenType.CloseParenthesis, ")", this.Position);
+                    token = new Token(TokenType.CloseParenthesis, ")", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ',':
-                    token = new Token(TokenType.Comma, ",", this.Position);
+                    token = new Token(TokenType.Comma, ",", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ':':
-                    token = new Token(TokenType.Colon, ":", this.Position);
+                    token = new Token(TokenType.Colon, ":", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case ';':
-                    token = new Token(TokenType.SemiColon, ";", this.Position);
+                    token = new Token(TokenType.SemiColon, ";", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '@':
-                    token = new Token(TokenType.At, "@", this.Position);
+                    token = new Token(TokenType.At, "@", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '#':
-                    token = new Token(TokenType.Hashtag, "#", this.Position);
+                    token = new Token(TokenType.Hashtag, "#", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '~':
-                    token = new Token(TokenType.Til, "~", this.Position);
+                    token = new Token(TokenType.Til, "~", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '.':
-                    token = new Token(TokenType.Period, ".", this.Position);
+                    token = new Token(TokenType.Period, ".", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '&':
-                    token = new Token(TokenType.Ampersand, "&", this.Position);
+                    token = new Token(TokenType.Ampersand, "&", this.Position, _registry);
                     this.ReadChar();
                     break;
 
@@ -418,11 +423,11 @@ namespace LiteDB
                     this.ReadChar();
                     if (IsWordChar(_char, true))
                     {
-                        token = new Token(TokenType.Word, "$" + this.ReadWord(), this.Position);
+                        token = new Token(TokenType.Word, "$" + this.ReadWord(), this.Position, _registry);
                     }
                     else
                     {
-                        token = new Token(TokenType.Dollar, "$", this.Position);
+                        token = new Token(TokenType.Dollar, "$", this.Position, _registry);
                     }
                     break;
 
@@ -430,17 +435,17 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.NotEquals, "!=", this.Position);
+                        token = new Token(TokenType.NotEquals, "!=", this.Position, _registry);
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Exclamation, "!", this.Position);
+                        token = new Token(TokenType.Exclamation, "!", this.Position, _registry);
                     }
                     break;
 
                 case '=':
-                    token = new Token(TokenType.Equals, "=", this.Position);
+                    token = new Token(TokenType.Equals, "=", this.Position, _registry);
                     this.ReadChar();
                     break;
 
@@ -448,12 +453,12 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.GreaterOrEquals, ">=", this.Position);
+                        token = new Token(TokenType.GreaterOrEquals, ">=", this.Position, _registry);
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Greater, ">", this.Position);
+                        token = new Token(TokenType.Greater, ">", this.Position, _registry);
                     }
                     break;
 
@@ -461,12 +466,12 @@ namespace LiteDB
                     this.ReadChar();
                     if (_char == '=')
                     {
-                        token = new Token(TokenType.LessOrEquals, "<=", this.Position);
+                        token = new Token(TokenType.LessOrEquals, "<=", this.Position, _registry);
                         this.ReadChar();
                     }
                     else
                     {
-                        token = new Token(TokenType.Less, "<", this.Position);
+                        token = new Token(TokenType.Less, "<", this.Position, _registry);
                     }
                     break;
 
@@ -479,37 +484,37 @@ namespace LiteDB
                     }
                     else
                     {
-                        token = new Token(TokenType.Minus, "-", this.Position);
+                        token = new Token(TokenType.Minus, "-", this.Position, _registry);
                     }
                     break;
 
                 case '+':
-                    token = new Token(TokenType.Plus, "+", this.Position);
+                    token = new Token(TokenType.Plus, "+", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '*':
-                    token = new Token(TokenType.Asterisk, "*", this.Position);
+                    token = new Token(TokenType.Asterisk, "*", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '/':
-                    token = new Token(TokenType.Slash, "/", this.Position);
+                    token = new Token(TokenType.Slash, "/", this.Position, _registry);
                     this.ReadChar();
                     break;
                 case '\\':
-                    token = new Token(TokenType.Backslash, @"\", this.Position);
+                    token = new Token(TokenType.Backslash, @"\", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '%':
-                    token = new Token(TokenType.Percent, "%", this.Position);
+                    token = new Token(TokenType.Percent, "%", this.Position, _registry);
                     this.ReadChar();
                     break;
 
                 case '\"':
                 case '\'':
-                    token = new Token(TokenType.String, this.ReadString(_char), this.Position);
+                    token = new Token(TokenType.String, this.ReadString(_char), this.Position, _registry);
                     break;
 
                 case '0':
@@ -524,7 +529,7 @@ namespace LiteDB
                 case '9':
                     var dbl = false;
                     var number = this.ReadNumber(ref dbl);
-                    token = new Token(dbl ? TokenType.Double : TokenType.Int, number, this.Position);
+                    token = new Token(dbl ? TokenType.Double : TokenType.Int, number, this.Position, _registry);
                     break;
 
                 case ' ':
@@ -537,14 +542,14 @@ namespace LiteDB
                         sb.Append(_char);
                         this.ReadChar();
                     }
-                    token = new Token(TokenType.Whitespace, sb.ToString(), this.Position);
+                    token = new Token(TokenType.Whitespace, sb.ToString(), this.Position, _registry);
                     break;
 
                 default:
                     // test if first char is an word 
                     if (IsWordChar(_char, true))
                     {
-                        token = new Token(TokenType.Word, this.ReadWord(), this.Position);
+                        token = new Token(TokenType.Word, this.ReadWord(), this.Position, _registry);
                     }
                     else
                     {
@@ -553,7 +558,7 @@ namespace LiteDB
                     break;
             }
 
-            return token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position);
+            return token ?? new Token(TokenType.Unknown, _char.ToString(), this.Position, _registry);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add LiteDatabaseServices to expose per-database plugin registries and thread registries through collection/query code paths
- update query helpers, tokenizer, parser, and engine components to require explicit IExpressionRegistry references and remove ambient AsyncLocal usage
- adjust expression caching/binding to key by registry, clone index metadata with registries, and update tests for new APIs

## Testing
- `dotnet test LiteDB.Tests -f net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68ec46af1b88832681f70b2cdc986d83