### PR TITLE
Align vector missing-plugin diagnostics

### DIFF
--- a/LiteDB.Vector.Tests/VectorPlugin_Tests.cs
+++ b/LiteDB.Vector.Tests/VectorPlugin_Tests.cs
@@ -23,7 +23,7 @@ namespace LiteDB.Vector.Tests
                     var exception = Assert.Throws<LiteException>(() =>
                         collection.EnsureIndex(x => x.Embedding, new VectorIndexOptions(3)));
 
-                    exception.Message.Should().Contain("Vector index support requires the VectorSearchPlugin");
+                    exception.Message.Should().Contain(VectorCompatibility.MissingPluginMessagePrefix);
                 }
 
                 using (var db = new LiteDatabase(file, plugins: new[] { VectorSearchPlugin.Instance }))

--- a/LiteDB.Vector/Extensions/LiteCollectionVectorExtensions.cs
+++ b/LiteDB.Vector/Extensions/LiteCollectionVectorExtensions.cs
@@ -162,7 +162,13 @@ namespace LiteDB.Vector
 
             if (descriptor == null || pluginContext == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                throw VectorCompatibility.PluginRequired(
+                    operation: "EnsureCustomIndex",
+                    pluginContext: pluginContext,
+                    strategyRegistry: services?.CustomIndexes,
+                    collection: collection.Name,
+                    index: name,
+                    strategyKind: VectorCompatibility.DefaultStrategyKind);
             }
 
             var metadataDescriptor = RequireMetadataDescriptor(pluginContext);

--- a/LiteDB.Vector/Extensions/QueryableExtensions.cs
+++ b/LiteDB.Vector/Extensions/QueryableExtensions.cs
@@ -137,7 +137,13 @@ namespace LiteDB.Vector.Extensions
 
             if (VectorCompatibility.TryGetStrategy(services?.CustomIndexes) == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                throw VectorCompatibility.PluginRequired(
+                    operation: "VectorQueryOperators",
+                    pluginContext: services?.Context,
+                    strategyRegistry: services?.CustomIndexes,
+                    collection: null,
+                    strategyKind: VectorCompatibility.DefaultStrategyKind,
+                    @event: "plugin.query_required");
             }
         }
 

--- a/LiteDB.Vector/Utils/VectorCompatibility.cs
+++ b/LiteDB.Vector/Utils/VectorCompatibility.cs
@@ -15,8 +15,9 @@ namespace LiteDB.Vector.Utils
         internal const string DefaultStrategyId = VectorPlugin.PluginId;
         internal const string DefaultStrategyKind = VectorPlugin.StrategyKind;
         internal const string DefaultIndexKind = VectorPlugin.IndexKind;
+        internal const string MissingPluginMessagePrefix = "Vector index support requires the LiteDB.Vector plugin.";
 
-        private const string PluginRequiredMessage = "Vector index support requires the VectorSearchPlugin. Add the LiteDB.Vector package and enable the plugin when constructing LiteDatabase (e.g., new LiteDatabase(connectionString, plugins: new[] { VectorSearchPlugin.Instance })).";
+        private const string PluginRegistrationGuidance = "Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] { VectorSearchPlugin.Instance })) before performing '{0}'.";
 
         public static CustomIndexStrategyDescriptor TryGetStrategy(ICustomIndexStrategyRegistry registry)
         {
@@ -45,12 +46,75 @@ namespace LiteDB.Vector.Utils
 
             if (descriptor == null)
             {
-                throw new LiteException(0, PluginRequiredMessage);
+                throw CreateMissingPluginException("EnsureCustomIndex", BuildIndexDiagnostics(registry, operation: "EnsureCustomIndex"));
             }
 
             return descriptor;
         }
 
-        public static LiteException PluginRequired() => new LiteException(LiteException.PLUGIN_REQUIRED, PluginRequiredMessage);
+        public static LiteException PluginRequired(
+            string operation = null,
+            ILitePluginContext pluginContext = null,
+            ICustomIndexStrategyRegistry strategyRegistry = null,
+            string collection = null,
+            string index = null,
+            string strategyKind = null,
+            string @event = "plugin.index_required")
+        {
+            var diagnostics = BuildIndexDiagnostics(strategyRegistry ?? pluginContext?.CustomIndexes, pluginContext, collection, index, strategyKind, operation, @event);
+
+            return CreateMissingPluginException(operation, diagnostics);
+        }
+
+        internal static LiteException CreateMissingPluginException(string operation, BsonDocument diagnostics)
+        {
+            var message = BuildMissingPluginMessage(operation);
+            var exception = new LiteException(LiteException.PLUGIN_REQUIRED, message);
+
+            if (diagnostics != null)
+            {
+                try
+                {
+                    exception.Data["VectorDiagnostics"] = diagnostics;
+                }
+                catch (ArgumentException)
+                {
+                    exception.Data["VectorDiagnostics"] = diagnostics.ToString();
+                }
+            }
+
+            return exception;
+        }
+
+        internal static string BuildMissingPluginMessage(string operation)
+        {
+            var subject = operation ?? "the requested operation";
+            return $"{MissingPluginMessagePrefix} {string.Format(PluginRegistrationGuidance, subject)}";
+        }
+
+        private static BsonDocument BuildIndexDiagnostics(
+            ICustomIndexStrategyRegistry registry,
+            ILitePluginContext pluginContext = null,
+            string collection = null,
+            string index = null,
+            string strategyKind = null,
+            string operation = null,
+            string @event = null)
+        {
+            var registeredStrategies = registry?.Registered?.Select(x => x.StrategyId) ?? Enumerable.Empty<string>();
+
+            var diagnostics = new BsonDocument
+            {
+                ["event"] = @event ?? "plugin.index_required",
+                ["operation"] = operation ?? string.Empty,
+                ["strategyKind"] = strategyKind ?? DefaultStrategyKind,
+                ["collection"] = collection ?? string.Empty,
+                ["index"] = index ?? string.Empty,
+                ["pluginContextAvailable"] = pluginContext != null || registry != null,
+                ["registeredStrategies"] = new BsonArray(registeredStrategies.Select(x => new BsonValue(x)))
+            };
+
+            return diagnostics;
+        }
     }
 }

--- a/LiteDB.Vector/Utils/VectorPluginDiagnosticPolicy.cs
+++ b/LiteDB.Vector/Utils/VectorPluginDiagnosticPolicy.cs
@@ -16,24 +16,11 @@ namespace LiteDB.Vector.Utils
         public override LiteException CreateMissingPluginException(string pluginId, string operation, BsonDocument diagnostics)
         {
             var resolvedPluginId = string.IsNullOrWhiteSpace(pluginId) ? VectorPlugin.PluginId : pluginId;
-            var message = $"Vector search requires the LiteDB.Vector plugin. Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] {{ VectorSearchPlugin.Instance }})) before performing '{operation ?? "the requested operation"}'.";
+            var enrichedDiagnostics = diagnostics != null ? new BsonDocument(diagnostics) : new BsonDocument();
 
-            var exception = new LiteException(LiteException.PLUGIN_REQUIRED, message);
+            enrichedDiagnostics["pluginId"] = resolvedPluginId;
 
-            if (diagnostics != null)
-            {
-                try
-                {
-                    diagnostics["pluginId"] = resolvedPluginId;
-                    exception.Data["PluginDiagnostics"] = diagnostics;
-                }
-                catch (System.ArgumentException)
-                {
-                    exception.Data["PluginDiagnostics"] = diagnostics.ToString();
-                }
-            }
-
-            return exception;
+            return VectorCompatibility.CreateMissingPluginException(operation, enrichedDiagnostics);
         }
     }
 }

--- a/LiteDB.Vector/VectorIndexStrategy.cs
+++ b/LiteDB.Vector/VectorIndexStrategy.cs
@@ -11,7 +11,7 @@ namespace LiteDB.Vector
 {
     internal sealed class VectorIndexStrategy : IIndexStrategy
     {
-        private const string PluginNotRegisteredMessage = "Plugin 'LiteDB.Vector' is required for this operation. Install the plugin package and register it via LiteDatabaseOptions.Plugins.";
+        private const string PluginNotRegisteredMessage = VectorCompatibility.MissingPluginMessagePrefix + " Register VectorSearchPlugin.Instance via LiteDatabaseOptions.Plugins.";
 
         private readonly ILogger _logger;
         private readonly VectorDistanceMetric? _defaultMetric;
@@ -65,10 +65,16 @@ namespace LiteDB.Vector
 
             _logger?.Write(LogLevel.Information, $"Creating vector index '{typedSnapshot.CollectionName}.{name}'.");
 
-            var pluginContext = typedSnapshot.Plugins ?? throw VectorCompatibility.PluginRequired();
+            var pluginContext = typedSnapshot.Plugins ?? throw VectorCompatibility.PluginRequired(
+                operation: "EnsureCustomIndex",
+                pluginContext: typedSnapshot.Plugins,
+                strategyRegistry: typedSnapshot.Plugins?.CustomIndexes,
+                collection: typedSnapshot.CollectionName,
+                index: name,
+                strategyKind: this.Kind);
             var registry = pluginContext.Expressions;
             var metadataEnvelope = this.ExtractMetadata(options);
-            var descriptor = this.RequireMetadataDescriptor(pluginContext, metadataEnvelope);
+            var descriptor = this.RequireMetadataDescriptor(pluginContext, metadataEnvelope, typedSnapshot.CollectionName);
 
             var tuple = typedCollection.InsertPluginIndex(
                 name,
@@ -249,11 +255,17 @@ namespace LiteDB.Vector
             return new PluginMetadataEnvelope(pluginIdValue.AsString, indexKindValue.AsString, metadata);
         }
 
-        private PluginIndexMetadataDescriptor RequireMetadataDescriptor(ILitePluginContext pluginContext, PluginMetadataEnvelope envelope)
+        private PluginIndexMetadataDescriptor RequireMetadataDescriptor(ILitePluginContext pluginContext, PluginMetadataEnvelope envelope, string collectionName)
         {
             if (pluginContext?.IndexMetadata == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                throw VectorCompatibility.PluginRequired(
+                    operation: "EnsureCustomIndex",
+                    pluginContext: pluginContext,
+                    strategyRegistry: pluginContext?.CustomIndexes,
+                    collection: collectionName,
+                    index: null,
+                    strategyKind: VectorCompatibility.DefaultStrategyKind);
             }
 
             if (!pluginContext.IndexMetadata.TryGet(envelope.IndexKind, out var descriptor))

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -35,6 +35,7 @@ namespace LiteDB.Engine
         private readonly CollectionPage _collectionPage;
         private readonly ILitePluginContext _plugins;
         private static readonly ConcurrentDictionary<string, byte> _missingPluginWarnings = new ConcurrentDictionary<string, byte>(StringComparer.Ordinal);
+        private bool _constructionSucceeded;
 
         // local page cache - contains only pages about this collection (but do not contains CollectionPage - use this.CollectionPage)
         private readonly Dictionary<uint, BasePage> _localPages = new Dictionary<uint, BasePage>();
@@ -85,16 +86,26 @@ namespace LiteDB.Engine
 
             var srv = new CollectionService(_header, _disk, this, _transPages);
 
-            // read collection (create if new - load virtual too)
-            srv.Get(_collectionName, addIfNotExists, ref _collectionPage);
-
-            // clear local pages (will clear _collectionPage link reference)
-            if (_collectionPage != null)
+            try
             {
-                // local pages contains only data/index pages
-                _localPages.Remove(_collectionPage.PageID);
+                // read collection (create if new - load virtual too)
+                srv.Get(_collectionName, addIfNotExists, ref _collectionPage);
 
-                this.EvaluatePluginAssets();
+                // clear local pages (will clear _collectionPage link reference)
+                if (_collectionPage != null)
+                {
+                    // local pages contains only data/index pages
+                    _localPages.Remove(_collectionPage.PageID);
+
+                    this.EvaluatePluginAssets();
+                }
+
+                _constructionSucceeded = true;
+            }
+            catch
+            {
+                this.Dispose();
+                throw;
             }
         }
 
@@ -238,8 +249,8 @@ namespace LiteDB.Engine
 
             _disposed = true;
 
-            // release collection page (in read mode)
-            if (_mode == LockMode.Read && _collectionPage != null)
+            // release collection page (in read mode or when construction failed)
+            if ((_mode == LockMode.Read || !_constructionSucceeded) && _collectionPage != null)
             {
                 _collectionPage.Buffer.Release();
             }


### PR DESCRIPTION
## Summary
- unify vector missing-plugin error messages and diagnostics, using shared helper logic to attach VectorDiagnostics payloads
- update vector index strategy, query helpers, and tests to follow the new message prefix and structured diagnostics
- harden snapshot construction so missing-plugin refusal paths dispose allocated resources safely

## Testing
- `dotnet test LiteDB.Tests/LiteDB.Tests.csproj -c Release --filter "BehaviorMatrixIntegrationTests|PluginAbsentTests|VectorOptionalityTests"` *(fails: net462 testhost requires mono on this environment)*
- `dotnet test LiteDB.Tests/LiteDB.Tests.csproj -c Release -f net8.0 --filter "BehaviorMatrixIntegrationTests|PluginAbsentTests|VectorOptionalityTests"` *(fails: runtime missing Microsoft.NETCore.App 8.0.0 on host; only 10.0.0 available)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693715415944832dbc37b93c0cc2646c)