### PR TITLE
Align vector missing-plugin diagnostics

### DIFF
--- a/LiteDB.Vector/Extensions/LiteCollectionVectorExtensions.cs
+++ b/LiteDB.Vector/Extensions/LiteCollectionVectorExtensions.cs
@@ -162,7 +162,13 @@ namespace LiteDB.Vector
 
             if (descriptor == null || pluginContext == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                var diagnostics = VectorCompatibility.CreateMissingPluginDiagnostics(
+                    operation: "EnsureCustomIndex",
+                    collection: collection.Name,
+                    strategyKind: VectorCompatibility.DefaultStrategyKind,
+                    pluginContext: pluginContext);
+
+                throw VectorCompatibility.PluginRequired(diagnostics);
             }
 
             var metadataDescriptor = RequireMetadataDescriptor(pluginContext);

--- a/LiteDB.Vector/Utils/VectorCompatibility.cs
+++ b/LiteDB.Vector/Utils/VectorCompatibility.cs
@@ -16,7 +16,7 @@ namespace LiteDB.Vector.Utils
         internal const string DefaultStrategyKind = VectorPlugin.StrategyKind;
         internal const string DefaultIndexKind = VectorPlugin.IndexKind;
 
-        private const string PluginRequiredMessage = "Vector index support requires the VectorSearchPlugin. Add the LiteDB.Vector package and enable the plugin when constructing LiteDatabase (e.g., new LiteDatabase(connectionString, plugins: new[] { VectorSearchPlugin.Instance })).";
+        private const string PluginRequiredMessage = "Vector index support requires the LiteDB.Vector plugin. Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] { VectorSearchPlugin.Instance })).";
 
         public static CustomIndexStrategyDescriptor TryGetStrategy(ICustomIndexStrategyRegistry registry)
         {
@@ -51,6 +51,68 @@ namespace LiteDB.Vector.Utils
             return descriptor;
         }
 
-        public static LiteException PluginRequired() => new LiteException(LiteException.PLUGIN_REQUIRED, PluginRequiredMessage);
+        public static LiteException PluginRequired(BsonDocument diagnostics = null)
+        {
+            var exception = new LiteException(LiteException.PLUGIN_REQUIRED, PluginRequiredMessage);
+
+            if (diagnostics != null)
+            {
+                try
+                {
+                    exception.Data["VectorDiagnostics"] = diagnostics;
+                }
+                catch (ArgumentException)
+                {
+                    exception.Data["VectorDiagnostics"] = diagnostics.ToString();
+                }
+            }
+
+            return exception;
+        }
+
+        public static BsonDocument CreateMissingPluginDiagnostics(string operation, string collection, string strategyKind, ILitePluginContext pluginContext, BsonDocument options = null)
+        {
+            var diagnostics = new BsonDocument
+            {
+                ["event"] = "plugin.index_required",
+                ["operation"] = operation ?? string.Empty,
+                ["collection"] = collection ?? string.Empty,
+                ["index"] = string.Empty,
+                ["expression"] = string.Empty,
+                ["strategyKind"] = strategyKind ?? string.Empty,
+                ["pluginContextAvailable"] = pluginContext != null,
+                ["strategyRegistryAvailable"] = pluginContext?.CustomIndexes != null,
+                ["pluginId"] = VectorPlugin.PluginId,
+                ["registeredStrategies"] = GetRegisteredCustomStrategies(pluginContext)
+            };
+
+            if (options != null && options.Count > 0)
+            {
+                var copy = new BsonDocument();
+                options.CopyTo(copy);
+                diagnostics["options"] = copy;
+            }
+
+            return diagnostics;
+        }
+
+        private static BsonArray GetRegisteredCustomStrategies(ILitePluginContext pluginContext)
+        {
+            var array = new BsonArray();
+            var registered = pluginContext?.CustomIndexes?.Registered;
+
+            if (registered != null)
+            {
+                foreach (var descriptor in registered)
+                {
+                    if (descriptor?.StrategyId != null)
+                    {
+                        array.Add(descriptor.StrategyId);
+                    }
+                }
+            }
+
+            return array;
+        }
     }
 }

--- a/LiteDB.Vector/Utils/VectorPluginDiagnosticPolicy.cs
+++ b/LiteDB.Vector/Utils/VectorPluginDiagnosticPolicy.cs
@@ -16,7 +16,7 @@ namespace LiteDB.Vector.Utils
         public override LiteException CreateMissingPluginException(string pluginId, string operation, BsonDocument diagnostics)
         {
             var resolvedPluginId = string.IsNullOrWhiteSpace(pluginId) ? VectorPlugin.PluginId : pluginId;
-            var message = $"Vector search requires the LiteDB.Vector plugin. Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] {{ VectorSearchPlugin.Instance }})) before performing '{operation ?? "the requested operation"}'.";
+            var message = $"Vector index support requires the LiteDB.Vector plugin. Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] {{ VectorSearchPlugin.Instance }})) before performing '{operation ?? "the requested operation"}'.";
 
             var exception = new LiteException(LiteException.PLUGIN_REQUIRED, message);
 
@@ -26,10 +26,12 @@ namespace LiteDB.Vector.Utils
                 {
                     diagnostics["pluginId"] = resolvedPluginId;
                     exception.Data["PluginDiagnostics"] = diagnostics;
+                    exception.Data["VectorDiagnostics"] = diagnostics;
                 }
                 catch (System.ArgumentException)
                 {
                     exception.Data["PluginDiagnostics"] = diagnostics.ToString();
+                    exception.Data["VectorDiagnostics"] = diagnostics.ToString();
                 }
             }
 

--- a/LiteDB.Vector/VectorIndexStrategy.cs
+++ b/LiteDB.Vector/VectorIndexStrategy.cs
@@ -11,7 +11,7 @@ namespace LiteDB.Vector
 {
     internal sealed class VectorIndexStrategy : IIndexStrategy
     {
-        private const string PluginNotRegisteredMessage = "Plugin 'LiteDB.Vector' is required for this operation. Install the plugin package and register it via LiteDatabaseOptions.Plugins.";
+        private const string PluginNotRegisteredMessage = "Vector index support requires the LiteDB.Vector plugin. Install the LiteDB.Vector package and register VectorSearchPlugin.Instance via LiteDatabaseOptions.Plugins.";
 
         private readonly ILogger _logger;
         private readonly VectorDistanceMetric? _defaultMetric;

--- a/LiteDB/Engine/Engine/Index.cs
+++ b/LiteDB/Engine/Engine/Index.cs
@@ -213,9 +213,31 @@ namespace LiteDB.Engine
             var policy = _plugins?.DiagnosticPolicy ?? DefaultPluginDiagnosticPolicy.Instance;
             var exception = policy.CreateMissingPluginException(pluginId, operation ?? "PluginOperation", diagnostics);
 
+            if (exception != null && this.IsVectorStrategy(strategyKind, pluginId))
+            {
+                try
+                {
+                    exception.Data["VectorDiagnostics"] = diagnostics;
+                }
+                catch (ArgumentException)
+                {
+                    exception.Data["VectorDiagnostics"] = diagnostics.ToString();
+                }
+            }
+
             LOG($"custom index plugin missing: {diagnostics.ToString()}", "PLUGIN");
 
             return exception;
+        }
+
+        private bool IsVectorStrategy(string strategyKind, string pluginId)
+        {
+            if (!string.IsNullOrWhiteSpace(pluginId) && string.Equals(pluginId, "LiteDB.Vector", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return string.Equals(strategyKind, "vector", StringComparison.OrdinalIgnoreCase);
         }
 
         private static string TryGetPluginIdFromOptions(BsonDocument options)

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -94,7 +94,15 @@ namespace LiteDB.Engine
                 // local pages contains only data/index pages
                 _localPages.Remove(_collectionPage.PageID);
 
-                this.EvaluatePluginAssets();
+                try
+                {
+                    this.EvaluatePluginAssets();
+                }
+                catch
+                {
+                    this.Dispose();
+                    throw;
+                }
             }
         }
 

--- a/LiteDB/Plugins/PluginDiagnosticPolicy.cs
+++ b/LiteDB/Plugins/PluginDiagnosticPolicy.cs
@@ -54,8 +54,9 @@ namespace LiteDB.Plugins
         {
             var hasPluginId = !string.IsNullOrWhiteSpace(pluginId);
             var subject = hasPluginId ? $"Plugin '{pluginId}'" : "A plugin";
-            var message = $"{subject} is required to perform '{operation ?? "the requested operation"}'. " +
-                          "Install and register the plugin to continue.";
+            var message = hasPluginId && string.Equals(pluginId, "LiteDB.Vector", StringComparison.Ordinal)
+                ? $"Vector index support requires the LiteDB.Vector plugin. Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] {{ VectorSearchPlugin.Instance }})) before performing '{operation ?? "the requested operation"}'."
+                : $"{subject} is required to perform '{operation ?? "the requested operation"}'. Install and register the plugin to continue.";
 
             var exception = new LiteException(LiteException.PLUGIN_REQUIRED, message);
 
@@ -64,10 +65,20 @@ namespace LiteDB.Plugins
                 try
                 {
                     exception.Data["PluginDiagnostics"] = diagnostics;
+
+                    if (hasPluginId && string.Equals(pluginId, "LiteDB.Vector", StringComparison.Ordinal))
+                    {
+                        exception.Data["VectorDiagnostics"] = diagnostics;
+                    }
                 }
                 catch (ArgumentException)
                 {
                     exception.Data["PluginDiagnostics"] = diagnostics.ToString();
+
+                    if (hasPluginId && string.Equals(pluginId, "LiteDB.Vector", StringComparison.Ordinal))
+                    {
+                        exception.Data["VectorDiagnostics"] = diagnostics.ToString();
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- align vector missing-plugin messages with the expected LiteDB.Vector prefix and propagate vector diagnostics through default and plugin policies
- add structured diagnostics when vector index operations lack a plugin and ensure plugin context detection in collection extensions
- dispose snapshots when plugin validation fails during creation to avoid leaking locks/pages

## Testing
- `dotnet test LiteDB.Tests/LiteDB.Tests.csproj -c Release --filter "BehaviorMatrixIntegrationTests|PluginAbsentTests|VectorOptionalityTests"` *(fails: missing mono for net48 and missing Microsoft.NETCore.App 8.0 runtime in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693715448144832dbb83253e1f034581)