### PR TITLE
Strengthen vector missing-plugin handling

### DIFF
--- a/LiteDB.Vector/Extensions/LiteCollectionVectorExtensions.cs
+++ b/LiteDB.Vector/Extensions/LiteCollectionVectorExtensions.cs
@@ -159,13 +159,25 @@ namespace LiteDB.Vector
             var services = database?.Services;
             var descriptor = VectorCompatibility.TryGetStrategy(services?.CustomIndexes);
             var pluginContext = services?.Context;
+            var diagnosticOptions = new BsonDocument
+            {
+                ["dimensions"] = (int)options.Dimensions,
+                ["metric"] = (int)options.Metric
+            };
 
             if (descriptor == null || pluginContext == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                throw VectorCompatibility.PluginRequired(
+                    operation: "EnsureCustomIndex",
+                    collection: collection.Name,
+                    strategyKind: VectorCompatibility.DefaultStrategyKind,
+                    indexName: name,
+                    expression: expression.Source,
+                    options: diagnosticOptions,
+                    pluginContext: pluginContext);
             }
 
-            var metadataDescriptor = RequireMetadataDescriptor(pluginContext);
+            var metadataDescriptor = RequireMetadataDescriptor(pluginContext, collection.Name, name, expression.Source, diagnosticOptions);
             var materializedOptions = VectorExtensionHelpers.CreateOptionsDocument(options, metadataDescriptor);
 
             var ensureContext = new EnsureIndexContext(
@@ -185,11 +197,23 @@ namespace LiteDB.Vector
             return descriptor.EnsureIndex(vectorContext);
         }
 
-        private static PluginIndexMetadataDescriptor RequireMetadataDescriptor(ILitePluginContext pluginContext)
+        private static PluginIndexMetadataDescriptor RequireMetadataDescriptor(
+            ILitePluginContext pluginContext,
+            string collectionName,
+            string indexName,
+            string expression,
+            BsonDocument options)
         {
             if (pluginContext?.IndexMetadata == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                throw VectorCompatibility.PluginRequired(
+                    operation: "EnsureCustomIndex",
+                    collection: collectionName,
+                    strategyKind: VectorCompatibility.DefaultStrategyKind,
+                    indexName: indexName,
+                    expression: expression,
+                    options: options,
+                    pluginContext: pluginContext);
             }
 
             if (pluginContext.IndexMetadata.TryGet(VectorCompatibility.DefaultIndexKind, out var descriptor))
@@ -197,7 +221,14 @@ namespace LiteDB.Vector
                 return descriptor;
             }
 
-            throw VectorCompatibility.PluginRequired();
+            throw VectorCompatibility.PluginRequired(
+                operation: "EnsureCustomIndex",
+                collection: collectionName,
+                strategyKind: VectorCompatibility.DefaultStrategyKind,
+                indexName: indexName,
+                expression: expression,
+                options: options,
+                pluginContext: pluginContext);
         }
     }
 }

--- a/LiteDB.Vector/Extensions/QueryableExtensions.cs
+++ b/LiteDB.Vector/Extensions/QueryableExtensions.cs
@@ -137,7 +137,11 @@ namespace LiteDB.Vector.Extensions
 
             if (VectorCompatibility.TryGetStrategy(services?.CustomIndexes) == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                throw VectorCompatibility.PluginRequired(
+                    operation: "WhereNear",
+                    collection: source.CollectionName,
+                    strategyKind: VectorCompatibility.DefaultStrategyKind,
+                    pluginContext: services?.Context);
             }
         }
 

--- a/LiteDB.Vector/Utils/VectorCompatibility.cs
+++ b/LiteDB.Vector/Utils/VectorCompatibility.cs
@@ -16,7 +16,7 @@ namespace LiteDB.Vector.Utils
         internal const string DefaultStrategyKind = VectorPlugin.StrategyKind;
         internal const string DefaultIndexKind = VectorPlugin.IndexKind;
 
-        private const string PluginRequiredMessage = "Vector index support requires the VectorSearchPlugin. Add the LiteDB.Vector package and enable the plugin when constructing LiteDatabase (e.g., new LiteDatabase(connectionString, plugins: new[] { VectorSearchPlugin.Instance })).";
+        private const string PluginRequiredMessage = "Vector index support requires the LiteDB.Vector plugin. Add the LiteDB.Vector package and enable the plugin when constructing LiteDatabase (e.g., new LiteDatabase(connectionString, plugins: new[] { VectorSearchPlugin.Instance })).";
 
         public static CustomIndexStrategyDescriptor TryGetStrategy(ICustomIndexStrategyRegistry registry)
         {
@@ -45,12 +45,78 @@ namespace LiteDB.Vector.Utils
 
             if (descriptor == null)
             {
-                throw new LiteException(0, PluginRequiredMessage);
+                throw PluginRequired(operation: "EnsureCustomIndex", strategyKind: DefaultStrategyKind, pluginContext: null);
             }
 
             return descriptor;
         }
 
-        public static LiteException PluginRequired() => new LiteException(LiteException.PLUGIN_REQUIRED, PluginRequiredMessage);
+        public static LiteException PluginRequired(
+            string operation = null,
+            string collection = null,
+            string strategyKind = null,
+            string indexName = null,
+            string expression = null,
+            BsonDocument options = null,
+            ILitePluginContext pluginContext = null)
+        {
+            var diagnostics = new BsonDocument
+            {
+                ["event"] = "plugin.index_required",
+                ["operation"] = operation ?? string.Empty,
+                ["collection"] = collection ?? string.Empty,
+                ["index"] = indexName ?? string.Empty,
+                ["expression"] = expression ?? string.Empty,
+                ["strategyKind"] = strategyKind ?? string.Empty,
+                ["pluginContextAvailable"] = pluginContext != null,
+                ["strategyRegistryAvailable"] = pluginContext?.CustomIndexes != null,
+                ["pluginId"] = VectorPlugin.PluginId,
+                ["registeredStrategies"] = GetRegisteredCustomStrategies(pluginContext?.CustomIndexes)
+            };
+
+            if (options != null && options.Count > 0)
+            {
+                var optionCopy = new BsonDocument();
+                options.CopyTo(optionCopy);
+                diagnostics["options"] = optionCopy;
+            }
+
+            var policy = pluginContext?.DiagnosticPolicy;
+
+            if (policy == null || policy is DefaultPluginDiagnosticPolicy)
+            {
+                policy = VectorPluginDiagnosticPolicy.Instance;
+            }
+
+            return policy.CreateMissingPluginException(VectorPlugin.PluginId, operation ?? "VectorOperation", diagnostics);
+        }
+
+        private static BsonArray GetRegisteredCustomStrategies(ICustomIndexStrategyRegistry registry)
+        {
+            var registered = registry?.Registered;
+
+            if (registered == null || registered.Count == 0)
+            {
+                return new BsonArray();
+            }
+
+            var array = new BsonArray();
+
+            foreach (var descriptor in registered)
+            {
+                if (descriptor == null)
+                {
+                    continue;
+                }
+
+                array.Add(new BsonDocument
+                {
+                    ["pluginId"] = descriptor.PluginId ?? string.Empty,
+                    ["strategyId"] = descriptor.StrategyId ?? string.Empty
+                });
+            }
+
+            return array;
+        }
     }
 }

--- a/LiteDB.Vector/Utils/VectorPluginDiagnosticPolicy.cs
+++ b/LiteDB.Vector/Utils/VectorPluginDiagnosticPolicy.cs
@@ -16,7 +16,9 @@ namespace LiteDB.Vector.Utils
         public override LiteException CreateMissingPluginException(string pluginId, string operation, BsonDocument diagnostics)
         {
             var resolvedPluginId = string.IsNullOrWhiteSpace(pluginId) ? VectorPlugin.PluginId : pluginId;
-            var message = $"Vector search requires the LiteDB.Vector plugin. Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] {{ VectorSearchPlugin.Instance }})) before performing '{operation ?? "the requested operation"}'.";
+            var message =
+                "Vector index support requires the LiteDB.Vector plugin. " +
+                $"Install the LiteDB.Vector package and register VectorSearchPlugin.Instance (for example, new LiteDatabase(connectionString, plugins: new[] {{ VectorSearchPlugin.Instance }})) before performing '{operation ?? "the requested operation"}'.";
 
             var exception = new LiteException(LiteException.PLUGIN_REQUIRED, message);
 
@@ -25,10 +27,12 @@ namespace LiteDB.Vector.Utils
                 try
                 {
                     diagnostics["pluginId"] = resolvedPluginId;
+                    exception.Data["VectorDiagnostics"] = diagnostics;
                     exception.Data["PluginDiagnostics"] = diagnostics;
                 }
                 catch (System.ArgumentException)
                 {
+                    exception.Data["VectorDiagnostics"] = diagnostics.ToString();
                     exception.Data["PluginDiagnostics"] = diagnostics.ToString();
                 }
             }

--- a/LiteDB.Vector/VectorIndexStrategy.cs
+++ b/LiteDB.Vector/VectorIndexStrategy.cs
@@ -11,7 +11,7 @@ namespace LiteDB.Vector
 {
     internal sealed class VectorIndexStrategy : IIndexStrategy
     {
-        private const string PluginNotRegisteredMessage = "Plugin 'LiteDB.Vector' is required for this operation. Install the plugin package and register it via LiteDatabaseOptions.Plugins.";
+        private const string PluginNotRegisteredMessage = "Vector index support requires the LiteDB.Vector plugin. Install the plugin package and register it via LiteDatabaseOptions.Plugins.";
 
         private readonly ILogger _logger;
         private readonly VectorDistanceMetric? _defaultMetric;
@@ -65,7 +65,14 @@ namespace LiteDB.Vector
 
             _logger?.Write(LogLevel.Information, $"Creating vector index '{typedSnapshot.CollectionName}.{name}'.");
 
-            var pluginContext = typedSnapshot.Plugins ?? throw VectorCompatibility.PluginRequired();
+            var pluginContext = typedSnapshot.Plugins ?? throw VectorCompatibility.PluginRequired(
+                operation: "EnsureCustomIndex",
+                collection: typedSnapshot.CollectionName,
+                strategyKind: this.Kind,
+                indexName: name,
+                expression: expression.Source,
+                options: options,
+                pluginContext: typedSnapshot.Plugins);
             var registry = pluginContext.Expressions;
             var metadataEnvelope = this.ExtractMetadata(options);
             var descriptor = this.RequireMetadataDescriptor(pluginContext, metadataEnvelope);
@@ -253,7 +260,14 @@ namespace LiteDB.Vector
         {
             if (pluginContext?.IndexMetadata == null)
             {
-                throw VectorCompatibility.PluginRequired();
+                throw VectorCompatibility.PluginRequired(
+                    operation: "EnsureCustomIndex",
+                    collection: null,
+                    strategyKind: this.Kind,
+                    indexName: null,
+                    expression: envelope?.IndexKind,
+                    options: envelope?.Metadata,
+                    pluginContext: pluginContext);
             }
 
             if (!pluginContext.IndexMetadata.TryGet(envelope.IndexKind, out var descriptor))

--- a/LiteDB/Client/Database/LiteDatabase.cs
+++ b/LiteDB/Client/Database/LiteDatabase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using LiteDB.Engine;
 using LiteDB.Plugins;
@@ -62,6 +63,8 @@ namespace LiteDB
             this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(resolvedPlugins);
+
+            this.ValidateMissingPlugins();
         }
 
         /// <summary>
@@ -89,6 +92,8 @@ namespace LiteDB
             this.Services = new LiteDatabaseServices(_pluginContext);
 
             this.InitializePlugins(resolvedPlugins);
+
+            this.ValidateMissingPlugins();
         }
 
         /// <summary>
@@ -316,6 +321,71 @@ namespace LiteDB
             if (_engine is IPluginHost host)
             {
                 host.SetPluginContext(_pluginContext);
+            }
+        }
+
+        private void ValidateMissingPlugins()
+        {
+            if (_pluginContext?.DiagnosticPolicy?.MissingBehavior != PluginMissingBehavior.RefuseDatabase)
+            {
+                return;
+            }
+
+            try
+            {
+                var settingsField = typeof(LiteEngine).GetField("_settings", BindingFlags.NonPublic | BindingFlags.Instance);
+                var settings = settingsField?.GetValue(_engine) as EngineSettings;
+
+                if (settings == null || string.IsNullOrWhiteSpace(settings.Filename))
+                {
+                    return;
+                }
+
+                using var reader = new FileReaderV8(settings, new List<FileReaderError>(), _pluginContext);
+                reader.Open();
+
+                var registry = _pluginContext.CustomIndexes;
+
+                foreach (var collection in reader.GetCollections())
+                {
+                    foreach (var index in reader.GetIndexes(collection))
+                    {
+                        var hasPluginMetadata = index.PluginMetadata != null && index.PluginMetadata.Length > 0;
+                        var hasPluginId = !string.IsNullOrWhiteSpace(index.PluginId);
+                        var isPluginIndex = hasPluginMetadata || hasPluginId || index.IndexType != 0;
+
+                        if (!isPluginIndex)
+                        {
+                            continue;
+                        }
+
+                        var resolvedPluginId = hasPluginId ? index.PluginId : ReservedCodeRanges.VectorPluginId;
+                        var hasSupport = registry?.Registered?.Any(d => d?.PluginId == resolvedPluginId) == true;
+
+                        if (hasSupport)
+                        {
+                            continue;
+                        }
+
+                        var diagnostics = new BsonDocument
+                        {
+                            ["event"] = "plugin.asset_detected",
+                            ["pluginId"] = resolvedPluginId,
+                            ["collection"] = collection ?? string.Empty,
+                            ["asset"] = index.Name ?? string.Empty
+                        };
+
+                        var policy = _pluginContext.DiagnosticPolicy ?? DefaultPluginDiagnosticPolicy.Instance;
+                        throw policy.CreateMissingPluginException(resolvedPluginId, "OpenDatabase", diagnostics);
+                    }
+                }
+            }
+            catch (LiteException ex) when (ex.ErrorCode == LiteException.PLUGIN_REQUIRED)
+            {
+                throw;
+            }
+            catch
+            {
             }
         }
 

--- a/LiteDB/Engine/Services/SnapShot.cs
+++ b/LiteDB/Engine/Services/SnapShot.cs
@@ -94,7 +94,15 @@ namespace LiteDB.Engine
                 // local pages contains only data/index pages
                 _localPages.Remove(_collectionPage.PageID);
 
-                this.EvaluatePluginAssets();
+                try
+                {
+                    this.EvaluatePluginAssets();
+                }
+                catch
+                {
+                    this.Dispose();
+                    throw;
+                }
             }
         }
 
@@ -105,7 +113,9 @@ namespace LiteDB.Engine
                 return;
             }
 
-            foreach (var (index, pluginId, _) in _collectionPage.GetPluginIndexes())
+            var pluginIndexes = _collectionPage.GetPluginIndexes().ToArray();
+
+            foreach (var (index, pluginId, _) in pluginIndexes)
             {
                 if (string.IsNullOrWhiteSpace(pluginId))
                 {
@@ -118,6 +128,19 @@ namespace LiteDB.Engine
                 }
 
                 this.HandleMissingPluginAsset(pluginId, index?.Name);
+            }
+
+            if (pluginIndexes.Length == 0)
+            {
+                foreach (var index in _collectionPage.GetCollectionIndexes())
+                {
+                    if (index.IndexType == 0)
+                    {
+                        continue;
+                    }
+
+                    this.HandleMissingPluginAsset(ReservedCodeRanges.VectorPluginId, index.Name);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- update vector diagnostic policy and helpers to emit consistent LiteDB.Vector messaging and payloads
- tighten plugin detection during database opening and plugin index creation
- ensure snapshots and collection pages propagate plugin metadata and diagnostics for missing vector support

## Testing
- DOTNET_ROLL_FORWARD=Major dotnet test LiteDB.Tests/LiteDB.Tests.csproj -c Release -f net8.0 --filter "BehaviorMatrixIntegrationTests|PluginAbsentTests|VectorOptionalityTests" *(fails: BehaviorMatrixIntegrationTests still expect LiteException when plugin assets are present)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693715448144832dbb83253e1f034581)